### PR TITLE
Fix #58: Default sort order for DB size widget

### DIFF
--- a/extensions/insights-default/sql/db_size.sql
+++ b/extensions/insights-default/sql/db_size.sql
@@ -10,4 +10,4 @@ select top 10
     (select sum(size) from fs where type = 1 and fs.database_id = db.database_id) LogFileSizeMB
 from sys.databases db
 where database_id > 4
-order by DataFileSizeMB
+order by DataFileSizeMB desc


### PR DESCRIPTION
Change default sort order for the DB size widget to descending