### PR TITLE
Fix script as alter/execute capitalization

### DIFF
--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -103,7 +103,7 @@ export class ScriptSelectAction extends Action {
 
 export class ScriptExecuteAction extends Action {
 	public static ID = 'scriptExecute';
-	public static LABEL = nls.localize('scriptExecute', 'Script As Execute');
+	public static LABEL = nls.localize('scriptExecute', 'Script as Execute');
 
 	constructor(
 		id: string, label: string,
@@ -139,7 +139,7 @@ export class ScriptExecuteAction extends Action {
 
 export class ScriptAlterAction extends Action {
 	public static ID = 'scriptAlter';
-	public static LABEL = nls.localize('scriptAlter', 'Script As Alter');
+	public static LABEL = nls.localize('scriptAlter', 'Script as Alter');
 
 	constructor(
 		id: string, label: string,


### PR DESCRIPTION
This PR fixes an inconsistency in the menu text for script as alter and script as execute where the word "as" was capitalized differently than for the existing other script options.

![screen shot 2017-12-18 at 1 46 37 pm](https://user-images.githubusercontent.com/3758704/34129895-bbc680a8-e3fa-11e7-96c4-8b1aa0778764.png)
