### PR TITLE
Disable custom title bar rendering on macOS

### DIFF
--- a/src/vs/code/electron-main/window.ts
+++ b/src/vs/code/electron-main/window.ts
@@ -169,12 +169,16 @@ export class CodeWindow implements ICodeWindow {
 		}
 
 		let useCustomTitleStyle = false;
-		if (isMacintosh && (!windowConfig || !windowConfig.titleBarStyle || windowConfig.titleBarStyle === 'custom')) {
-			const isDev = !this.environmentService.isBuilt || !!config.extensionDevelopmentPath;
-			if (!isDev) {
-				useCustomTitleStyle = true; // not enabled when developing due to https://github.com/electron/electron/issues/3647
-			}
-		}
+
+		// {{SQL CARBON EDIT}}
+		// turn-off custom menus to avoid bug calculating size of SQL editor
+		//
+		// if (isMacintosh && (!windowConfig || !windowConfig.titleBarStyle || windowConfig.titleBarStyle === 'custom')) {
+		// 	const isDev = !this.environmentService.isBuilt || !!config.extensionDevelopmentPath;
+		// 	if (!isDev) {
+		// 		useCustomTitleStyle = true; // not enabled when developing due to https://github.com/electron/electron/issues/3647
+		// 	}
+		// }
 
 		if (useNativeTabs) {
 			useCustomTitleStyle = false; // native tabs on sierra do not work with custom title style

--- a/src/vs/workbench/electron-browser/workbench.ts
+++ b/src/vs/workbench/electron-browser/workbench.ts
@@ -833,6 +833,8 @@ export class Workbench implements IPartService {
 	}
 
 	private getCustomTitleBarStyle(): 'custom' {
+		// {{SQL CARBON EDIT}}
+		/*
 		if (!isMacintosh) {
 			return null; // custom title bar is only supported on Mac currently
 		}
@@ -854,6 +856,7 @@ export class Workbench implements IPartService {
 				return style;
 			}
 		}
+		*/
 
 		return null;
 	}


### PR DESCRIPTION
This ports over a fix that was in Nov. release, but got lost during merge.  This fixes some sizing issues in query editor.