### PR TITLE
Fixed bug where drag and drop would break scripting

### DIFF
--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -953,7 +953,6 @@ export class ConnectionManagementService implements IConnectionManagementService
 		return this._connectionStore.changeGroupIdForConnection(source, targetGroupId).then(result => {
 			if (id && targetGroupId) {
 				source.groupId = targetGroupId;
-				this._connectionStatusManager.updateConnectionProfile(source, id);
 			}
 		});
 	}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/sqlopsstudio/issues/366

The issue was that after the drag and drop, we were changing the group ID as well as the connection ID, which was incorrect.