### PR TITLE
Add tab coloring by server group

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,7 +63,7 @@
 			"outFiles": [
 				"${workspaceFolder}/out/**/*.js"
 			]
-		},	
+		},
 		{
 			"type": "chrome",
 			"request": "attach",
@@ -95,7 +95,7 @@
 			"name": "Unit Tests",
 			"protocol": "inspector",
 			"program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-			"runtimeExecutable": "${workspaceFolder}/.build/electron/sqlops.app/Contents/MacOS/Electron",
+			"runtimeExecutable": "${workspaceFolder}/.build/electron/SQL Operations Studio.app/Contents/MacOS/Electron",
 			"windows": {
 				"runtimeExecutable": "${workspaceFolder}/.build/electron/sqlops.exe"
 			},

--- a/src/sql/parts/connection/common/connectionManagement.ts
+++ b/src/sql/parts/connection/common/connectionManagement.ts
@@ -220,7 +220,7 @@ export interface IConnectionManagementService {
 
 	canChangeConnectionConfig(profile: ConnectionProfile, newGroupID: string): boolean;
 
-	getGroupColorForUri(uri: string): string;
+	getTabColorForUri(uri: string): string;
 
 	/**
 	 * Sends a notification that the language flavor for a given URI has changed.

--- a/src/sql/parts/connection/common/connectionManagement.ts
+++ b/src/sql/parts/connection/common/connectionManagement.ts
@@ -220,6 +220,8 @@ export interface IConnectionManagementService {
 
 	canChangeConnectionConfig(profile: ConnectionProfile, newGroupID: string): boolean;
 
+	getGroupColorForUri(uri: string): string;
+
 	/**
 	 * Sends a notification that the language flavor for a given URI has changed.
 	 * For SQL, this would be the specific SQL implementation being used.

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -148,6 +148,16 @@ export class ConnectionManagementService implements IConnectionManagementService
 
 		this.disposables.push(this._onAddConnectionProfile);
 		this.disposables.push(this._onDeleteConnectionProfile);
+
+		// Refresh editor titles when connections start/end/change to ensure tabs are colored correctly
+		let refreshEditorTitlesFunction = () => {
+			if (this._editorGroupService instanceof EditorPart) {
+				this._editorGroupService.refreshEditorTitles();
+			}
+		};
+		this._onConnectionChanged.event(refreshEditorTitlesFunction);
+		this._onConnect.event(refreshEditorTitlesFunction);
+		this._onDisconnect.event(refreshEditorTitlesFunction);
 	}
 
 	// Event Emitters
@@ -1325,7 +1335,10 @@ export class ConnectionManagementService implements IConnectionManagementService
 		return Promise.reject('The given URI is not currently connected');
 	}
 
-	public getGroupColorForUri(uri: string): string {
+	public getTabColorForUri(uri: string): string {
+		if (!WorkbenchUtils.getSqlConfigValue<string>(this._workspaceConfigurationService, 'enableTabColors')) {
+			return undefined;
+		}
 		let connectionProfile = this.getConnectionProfile(uri);
 		if (!connectionProfile) {
 			return undefined;

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -1324,4 +1324,16 @@ export class ConnectionManagementService implements IConnectionManagementService
 		}
 		return Promise.reject('The given URI is not currently connected');
 	}
+
+	public getGroupColorForUri(uri: string): string {
+		let connectionProfile = this.getConnectionProfile(uri);
+		if (!connectionProfile) {
+			return undefined;
+		}
+		let matchingGroup = this._connectionStore.getGroupFromId(connectionProfile.groupId);
+		if (!matchingGroup) {
+			return undefined;
+		}
+		return matchingGroup.color;
+	}
 }

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -155,9 +155,9 @@ export class ConnectionManagementService implements IConnectionManagementService
 				this._editorGroupService.refreshEditorTitles();
 			}
 		};
-		this._onConnectionChanged.event(refreshEditorTitlesFunction);
-		this._onConnect.event(refreshEditorTitlesFunction);
-		this._onDisconnect.event(refreshEditorTitlesFunction);
+		this.onConnectionChanged(refreshEditorTitlesFunction);
+		this.onConnect(refreshEditorTitlesFunction);
+		this.onDisconnect(refreshEditorTitlesFunction);
 	}
 
 	// Event Emitters

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -150,14 +150,9 @@ export class ConnectionManagementService implements IConnectionManagementService
 		this.disposables.push(this._onDeleteConnectionProfile);
 
 		// Refresh editor titles when connections start/end/change to ensure tabs are colored correctly
-		let refreshEditorTitlesFunction = () => {
-			if (this._editorGroupService instanceof EditorPart) {
-				this._editorGroupService.refreshEditorTitles();
-			}
-		};
-		this.onConnectionChanged(refreshEditorTitlesFunction);
-		this.onConnect(refreshEditorTitlesFunction);
-		this.onDisconnect(refreshEditorTitlesFunction);
+		this.onConnectionChanged(() => this.refreshEditorTitles());
+		this.onConnect(() => this.refreshEditorTitles());
+		this.onDisconnect(() => this.refreshEditorTitles());
 	}
 
 	// Event Emitters
@@ -1230,6 +1225,7 @@ export class ConnectionManagementService implements IConnectionManagementService
 	public editGroup(group: ConnectionProfileGroup): Promise<any> {
 		return new Promise<string>((resolve, reject) => {
 			this._connectionStore.editGroup(group).then(groupId => {
+				this.refreshEditorTitles();
 				this._onAddConnectionProfile.fire();
 				resolve(null);
 			}).catch(err => {
@@ -1348,5 +1344,11 @@ export class ConnectionManagementService implements IConnectionManagementService
 			return undefined;
 		}
 		return matchingGroup.color;
+	}
+
+	private refreshEditorTitles(): void {
+		if (this._editorGroupService instanceof EditorPart) {
+			this._editorGroupService.refreshEditorTitles();
+		}
 	}
 }

--- a/src/sql/parts/connection/common/connectionStore.ts
+++ b/src/sql/parts/connection/common/connectionStore.ts
@@ -462,6 +462,20 @@ export class ConnectionStore {
 		return connectionProfileGroups;
 	}
 
+	public getGroupFromId(groupId: string): ConnectionProfileGroup {
+		let groups = new Set<ConnectionProfileGroup>();
+		this.getConnectionProfileGroups().forEach(group => groups.add(group));
+		while (groups.size > 0) {
+			let currentGroup = groups.values().next().value;
+			if (currentGroup.id === groupId) {
+				return currentGroup;
+			}
+			currentGroup.children.forEach(group => groups.add(group));
+			groups.delete(currentGroup);
+		}
+		return undefined;
+	}
+
 	private convertToConnectionGroup(groups: IConnectionProfileGroup[], connections: ConnectionProfile[], parent: ConnectionProfileGroup = undefined): ConnectionProfileGroup[] {
 		let result: ConnectionProfileGroup[] = [];
 		let children = groups.filter(g => g.parentId === (parent ? parent.id : undefined));

--- a/src/sql/parts/dashboard/dashboardInput.ts
+++ b/src/sql/parts/dashboard/dashboardInput.ts
@@ -167,4 +167,8 @@ export class DashboardInput extends EditorInput {
 			&& profile1.authenticationType === profile2.authenticationType
 			&& profile1.groupFullName === profile2.groupFullName;
 	}
+
+	public get tabColor(): string {
+		return this._connectionService.getGroupColorForUri(this.uri);
+	}
 }

--- a/src/sql/parts/dashboard/dashboardInput.ts
+++ b/src/sql/parts/dashboard/dashboardInput.ts
@@ -169,6 +169,6 @@ export class DashboardInput extends EditorInput {
 	}
 
 	public get tabColor(): string {
-		return this._connectionService.getGroupColorForUri(this.uri);
+		return this._connectionService.getTabColorForUri(this.uri);
 	}
 }

--- a/src/sql/parts/editData/common/editDataInput.ts
+++ b/src/sql/parts/editData/common/editDataInput.ts
@@ -182,6 +182,6 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 	}
 
 	public get tabColor(): string {
-		return this._connectionManagementService.getGroupColorForUri(this.uri);
+		return this._connectionManagementService.getTabColorForUri(this.uri);
 	}
 }

--- a/src/sql/parts/editData/common/editDataInput.ts
+++ b/src/sql/parts/editData/common/editDataInput.ts
@@ -180,4 +180,8 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 			super.close();
 		});
 	}
+
+	public get tabColor(): string {
+		return this._connectionManagementService.getGroupColorForUri(this.uri);
+	}
 }

--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -240,6 +240,11 @@ let registryProperties = {
 		'description': localize('sql.showBatchTime', '[Optional] Should execution time be shown for individual batches'),
 		'default': false
 	},
+	'sql.enableTabColors': {
+		'type': 'boolean',
+		'description': localize('sql.enableTabColors', 'True to color tabs based on the server group of their active connection, false otherwise'),
+		'default': true
+	},
 	'mssql.intelliSense.enableIntelliSense': {
 		'type': 'boolean',
 		'default': true,

--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -253,7 +253,10 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		this._currentEventCallbacks = callbacks;
 	}
 
+	/**
+	 * Get the color that should be displayed
+	 */
 	public get tabColor(): string {
-		return this._connectionManagementService.getGroupColorForUri(this.uri);
+		return this._connectionManagementService.getTabColorForUri(this.uri);
 	}
 }

--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -252,4 +252,8 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 		this._currentEventCallbacks = dispose(this._currentEventCallbacks);
 		this._currentEventCallbacks = callbacks;
 	}
+
+	public get tabColor(): string {
+		return this._connectionManagementService.getGroupColorForUri(this.uri);
+	}
 }

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -291,7 +291,7 @@ suite('SQL ConnectionManagementService tests', () => {
 			}).catch(err => {
 				done(err);
 			});
-		});
+		}, err => done(err));
 	});
 
 	test('connect should save profile given options with saveProfile set to true', done => {

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -32,6 +32,7 @@ import { WorkspaceConfigurationTestService } from 'sqltest/stubs/workspaceConfig
 
 import * as assert from 'assert';
 import * as TypeMoq from 'typemoq';
+import { IConnectionProfileGroup } from 'sql/parts/connection/common/connectionProfileGroup';
 
 suite('SQL ConnectionManagementService tests', () => {
 
@@ -210,7 +211,7 @@ suite('SQL ConnectionManagementService tests', () => {
 		let connectionToUse = connection ? connection : connectionProfile;
 		return new Promise<IConnectionResult>((resolve, reject) => {
 			let id = connectionToUse.getOptionsKey();
-			let defaultUri = 'connection://' + (id ? id : connection.serverName + ':' + connection.databaseName);
+			let defaultUri = 'connection://' + (id ? id : connectionToUse.serverName + ':' + connectionToUse.databaseName);
 			connectionManagementService.onConnectionRequestSent(() => {
 				let info: data.ConnectionInfoSummary = {
 					connectionId: error ? undefined : 'id',
@@ -761,6 +762,31 @@ suite('SQL ConnectionManagementService tests', () => {
 				done();
 			} catch (err) {
 				done(err);
+			}
+		}, err => done(err));
+	});
+
+	test('getTabColorForUri returns undefined when there is no connection for the given URI', () => {
+		let connectionManagementService = createConnectionManagementService();
+		let color = connectionManagementService.getTabColorForUri('invalidUri');
+		assert.equal(color, undefined);
+	});
+
+	test('getTabColorForUri returns the group color corresponding to the connection for a URI', done => {
+		// Set up the connection store to give back a group for the expected connection profile
+		configResult['enableTabColors'] = true;
+		let expectedColor = 'red';
+		connectionStore.setup(x => x.getGroupFromId(connectionProfile.groupId)).returns(() => <IConnectionProfileGroup> {
+			color: expectedColor
+		});
+		let uri = 'testUri';
+		connect(uri).then(() => {
+			try {
+				let tabColor = connectionManagementService.getTabColorForUri(uri);
+				assert.equal(tabColor, expectedColor);
+				done();
+			} catch (e) {
+				done(e);
 			}
 		}, err => done(err));
 	});

--- a/src/sqltest/stubs/connectionManagementService.test.ts
+++ b/src/sqltest/stubs/connectionManagementService.test.ts
@@ -237,4 +237,8 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 	rebuildIntelliSenseCache(uri: string): Thenable<void> {
 		return undefined;
 	}
+
+	getGroupColorForUri(uri: string): string {
+		return undefined;
+	}
 }

--- a/src/sqltest/stubs/connectionManagementService.test.ts
+++ b/src/sqltest/stubs/connectionManagementService.test.ts
@@ -238,7 +238,7 @@ export class TestConnectionManagementService implements IConnectionManagementSer
 		return undefined;
 	}
 
-	getGroupColorForUri(uri: string): string {
+	getTabColorForUri(uri: string): string {
 		return undefined;
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -87,10 +87,10 @@ export interface IEditorGroupsControl {
 
 	getRatio(): number[];
 
+	// {{SQL CARBON EDIT}} -- Allow editor titles to be refreshed to support tab coloring
+	refreshTitles(): void;
 
 	dispose(): void;
-
-	refreshTitles(): void;
 }
 
 /**
@@ -2128,6 +2128,7 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 		}
 	}
 
+	// {{SQL CARBON EDIT}} -- Allow editor titles to be refreshed to support tab coloring
 	public refreshTitles(): void {
 		POSITIONS.forEach(position => {
 			let titleControl = this.getTitleAreaControl(position);

--- a/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupsControl.ts
@@ -89,6 +89,8 @@ export interface IEditorGroupsControl {
 
 
 	dispose(): void;
+
+	refreshTitles(): void;
 }
 
 /**
@@ -2124,6 +2126,13 @@ export class EditorGroupsControl extends Themable implements IEditorGroupsContro
 				progressbar.stop().getContainer().hide();
 				break;
 		}
+	}
+
+	public refreshTitles(): void {
+		POSITIONS.forEach(position => {
+			let titleControl = this.getTitleAreaControl(position);
+			titleControl.refresh();
+		});
 	}
 
 	public dispose(): void {

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -1359,6 +1359,11 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupService
 		return sizes;
 	}
 
+	// {{SQL CARBON EDIT}} -- Allow editor titles to be refreshed to support tab coloring
+	public refreshEditorTitles(): void {
+		this.editorGroupsControl.refreshTitles();
+	}
+
 	public shutdown(): void {
 
 		// Persist UI State

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -45,6 +45,9 @@ import { activeContrastBorder, contrastBorder } from 'vs/platform/theme/common/c
 import { IFileService } from 'vs/platform/files/common/files';
 import { IWorkspacesService } from 'vs/platform/workspaces/common/workspaces';
 
+// {{SQL CARBON EDIT}} -- Display the editor's tab color
+import { Color } from 'vs/base/common/color';
+
 interface IEditorInputLabel {
 	name: string;
 	description?: string;
@@ -336,6 +339,10 @@ export class TabsTitleControl extends TitleControl {
 				if (sqlEditor.tabColor && this.themeService.getTheme().type !== HIGH_CONTRAST) {
 					tabContainer.style.borderTopColor = sqlEditor.tabColor;
 					tabContainer.style.borderTopWidth = isTabActive ? '2px' : '1px';
+					let backgroundColor = Color.Format.CSS.parseHex(sqlEditor.tabColor);
+					if (backgroundColor) {
+						tabContainer.style.backgroundColor = backgroundColor.transparent(isTabActive ? 0.3 : 0.2).toString();
+					}
 				} else {
 					tabContainer.style.borderTopColor = '';
 					tabContainer.style.borderTopWidth = '';

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -39,7 +39,7 @@ import { ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { extractResources } from 'vs/base/browser/dnd';
 import { getOrSet } from 'vs/base/common/map';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector } from 'vs/platform/theme/common/themeService';
+import { IThemeService, registerThemingParticipant, ITheme, ICssStyleCollector, HIGH_CONTRAST } from 'vs/platform/theme/common/themeService';
 import { TAB_INACTIVE_BACKGROUND, TAB_ACTIVE_BACKGROUND, TAB_ACTIVE_FOREGROUND, TAB_INACTIVE_FOREGROUND, TAB_BORDER, EDITOR_DRAG_AND_DROP_BACKGROUND, TAB_UNFOCUSED_ACTIVE_FOREGROUND, TAB_UNFOCUSED_INACTIVE_FOREGROUND, TAB_UNFOCUSED_ACTIVE_BORDER, TAB_ACTIVE_BORDER } from 'vs/workbench/common/theme';
 import { activeContrastBorder, contrastBorder } from 'vs/platform/theme/common/colorRegistry';
 import { IFileService } from 'vs/platform/files/common/files';
@@ -331,9 +331,10 @@ export class TabsTitleControl extends TitleControl {
 					DOM.removeClass(tabContainer, 'dirty');
 				}
 
-				let anyEditor = editor as any;
-				if (anyEditor.tabColor) {
-					tabContainer.style.borderTopColor = anyEditor.tabColor;
+				// {{SQL CARBON EDIT}} -- Display the editor's tab color
+				let sqlEditor = editor as any;
+				if (sqlEditor.tabColor && this.themeService.getTheme().type !== HIGH_CONTRAST) {
+					tabContainer.style.borderTopColor = sqlEditor.tabColor;
 					tabContainer.style.borderTopWidth = isTabActive ? '2px' : '1px';
 				} else {
 					tabContainer.style.borderTopColor = '';

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -330,6 +330,15 @@ export class TabsTitleControl extends TitleControl {
 				} else {
 					DOM.removeClass(tabContainer, 'dirty');
 				}
+
+				let anyEditor = editor as any;
+				if (anyEditor.tabColor) {
+					tabContainer.style.borderTopColor = anyEditor.tabColor;
+					tabContainer.style.borderTopWidth = isTabActive ? '2px' : '1px';
+				} else {
+					tabContainer.style.borderTopColor = '';
+					tabContainer.style.borderTopWidth = '';
+				}
 			}
 		});
 


### PR DESCRIPTION
This PR addresses issues #327 and #63 by adding a colored line at the top of tabs when they are connected to a database, and that database is part of a server group. The color of the line is determined by the server group's color, and is 1px when the tab is inactive and 2px when the tab is active. The line does not display in high-contrast themes. It can be disabled with the setting `sql.enableTabColors`

![screen shot 2017-12-20 at 1 53 33 pm](https://user-images.githubusercontent.com/3758704/34230515-3de3730a-e58d-11e7-9867-c3b58d95d9e8.png)
