### PR TITLE
Fix issue where loading unsave sql file open as untitiledEditorInput

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -136,6 +136,7 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 		return JSON.stringify(serialized);
 	}
 
+	// {{SQL CARBON EDIT}}
 	public deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): EditorInput {
 		return instantiationService.invokeFunction<EditorInput>(accessor => {
 			const deserialized: ISerializedUntitledEditorInput = JSON.parse(serializedEditorInput);
@@ -144,6 +145,7 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 			const language = deserialized.modeId;
 			const encoding = deserialized.encoding;
 
+			// {{SQL CARBON EDIT}}
 			let input = accessor.get(IWorkbenchEditorService).createInput({ resource, filePath, language, encoding }) as UntitledEditorInput;
 			if (deserialized.modeId === QueryInput.SCHEMA) {
 				const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, resource.toString());

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -42,6 +42,10 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { isMacintosh } from 'vs/base/common/platform';
 import { GroupOnePicker, GroupTwoPicker, GroupThreePicker, AllEditorsPicker } from 'vs/workbench/browser/parts/editor/editorPicker';
 
+// {{SQL CARBON EDIT}}
+import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
+import { QueryInput } from 'sql/parts/query/common/queryInput';
+
 // Register String Editor
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
@@ -132,15 +136,21 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 		return JSON.stringify(serialized);
 	}
 
-	public deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): UntitledEditorInput {
-		return instantiationService.invokeFunction<UntitledEditorInput>(accessor => {
+	public deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): EditorInput {
+		return instantiationService.invokeFunction<EditorInput>(accessor => {
 			const deserialized: ISerializedUntitledEditorInput = JSON.parse(serializedEditorInput);
 			const resource = !!deserialized.resourceJSON ? URI.revive(deserialized.resourceJSON) : URI.parse(deserialized.resource);
 			const filePath = resource.scheme === 'file' ? resource.fsPath : void 0;
 			const language = deserialized.modeId;
 			const encoding = deserialized.encoding;
 
-			return accessor.get(IWorkbenchEditorService).createInput({ resource, filePath, language, encoding }) as UntitledEditorInput;
+			let input = accessor.get(IWorkbenchEditorService).createInput({ resource, filePath, language, encoding }) as UntitledEditorInput;
+			if (deserialized.modeId === QueryInput.SCHEMA) {
+				const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, resource.toString());
+				return instantiationService.createInstance(QueryInput, input.getName(), '', input, queryResultsInput, undefined);
+			} else {
+				return input;
+			}
 		});
 	}
 }

--- a/src/vs/workbench/services/textfile/common/textFileService.ts
+++ b/src/vs/workbench/services/textfile/common/textFileService.ts
@@ -366,9 +366,7 @@ export abstract class TextFileService implements ITextFileService {
 		}
 
 		// Hot exit
-		// {{SQL CARBON EDIT}}
-		// const hotExitMode = configuration && configuration.files ? configuration.files.hotExit : HotExitConfiguration.ON_EXIT;
-		const hotExitMode = HotExitConfiguration.OFF;
+		const hotExitMode = configuration && configuration.files ? configuration.files.hotExit : HotExitConfiguration.ON_EXIT;
 		if (hotExitMode === HotExitConfiguration.OFF || hotExitMode === HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE) {
 			this.configuredHotExit = hotExitMode;
 		} else {


### PR DESCRIPTION
Fix #356, After hot exit, editors display connection/query results incorrectly when switching tabs