### PR TITLE
Fix theming issue for manage account status bar icon

### DIFF
--- a/src/sql/parts/accountManagement/accountListStatusbar/accountListStatusbarItem.ts
+++ b/src/sql/parts/accountManagement/accountListStatusbar/accountListStatusbarItem.ts
@@ -7,25 +7,35 @@
 
 import 'vs/css!./media/accountListStatusbarItem';
 import { Action, IAction } from 'vs/base/common/actions';
-import { combinedDisposable, IDisposable } from 'vs/base/common/lifecycle';
+import { IDisposable } from 'vs/base/common/lifecycle';
 import { $, append } from 'vs/base/browser/dom';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { localize } from 'vs/nls';
 import { IStatusbarItem } from 'vs/workbench/browser/parts/statusbar/statusbar';
+import { Themable, STATUS_BAR_FOREGROUND } from 'vs/workbench/common/theme';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 import { IAccountManagementService } from 'sql/services/accountManagement/interfaces';
 
-export class AccountListStatusbarItem implements IStatusbarItem {
-	private _toDispose: IDisposable[];
+export class AccountListStatusbarItem extends Themable implements IStatusbarItem {
 	private _manageLinkedAccountAction: IAction;
+	private _icon: HTMLElement;
 
 	constructor(
 		@IInstantiationService private _instantiationService: IInstantiationService,
-		@IAccountManagementService private _accountManagementService: IAccountManagementService
+		@IAccountManagementService private _accountManagementService: IAccountManagementService,
+		@IThemeService themeService: IThemeService
 	) {
-		this._toDispose = [];
+		super(themeService);
+	}
+
+	protected updateStyles(): void {
+		super.updateStyles();
+		if (this._icon) {
+			this._icon.style.backgroundColor = this.getColor(STATUS_BAR_FOREGROUND);
+		}
 	}
 
 	public render(container: HTMLElement): IDisposable {
@@ -34,9 +44,11 @@ export class AccountListStatusbarItem implements IStatusbarItem {
 		const accountElement = append(rootElement, $('a.linked-account-status-selection'));
 		accountElement.title = ManageLinkedAccountAction.LABEL;
 		accountElement.onclick = () => this._onClick();
-		append(accountElement, $('.linked-account-icon'));
+		this._icon = append(accountElement, $('.linked-account-icon'));
 
-		return combinedDisposable(this._toDispose);
+		this.updateStyles();
+
+		return this;
 	}
 
 	private _onClick() {

--- a/src/sql/parts/accountManagement/accountListStatusbar/media/accountListStatusbarItem.css
+++ b/src/sql/parts/accountManagement/accountListStatusbar/media/accountListStatusbarItem.css
@@ -6,7 +6,6 @@
 .statusbar-item .linked-account-staus a.linked-account-status-selection .linked-account-icon {
 	-webkit-mask: url('accounts_statusbar_inverse.svg') no-repeat 50% 50%;
 	-webkit-mask-size: 12px;
-	background-color: rgb(255, 255, 255);
 	width: 12px;
 	height: 22px;
 }


### PR DESCRIPTION
Fix #384: Manage linked account status bar icon should change the color based on the theming 

![image](https://user-images.githubusercontent.com/25463959/34325012-4ee5a24a-e83a-11e7-8638-80e2167c672a.png)
