### PR TITLE
Fix broken Run Current Query command

### DIFF
--- a/src/sql/parts/query/execution/queryActions.ts
+++ b/src/sql/parts/query/execution/queryActions.ts
@@ -13,9 +13,6 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IMessageService, Severity } from 'vs/platform/message/common/message';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
-import { IWorkspaceConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
-import { IReadOnlyModel } from 'vs/editor/common/editorCommon';
-import { IModel, ICommonCodeEditor } from 'vs/editor/common/editorCommon';
 
 import { ISelectionData } from 'data';
 import {
@@ -27,8 +24,6 @@ import {
 } from 'sql/parts/connection/common/connectionManagement';
 import { QueryEditor } from 'sql/parts/query/editor/queryEditor';
 import { IQueryModelService } from 'sql/parts/query/execution/queryModel';
-import * as WorkbenchUtils from 'sql/workbench/common/sqlWorkbenchUtils';
-import * as Constants from 'sql/parts/query/common/constants';
 
 /**
  * Action class that query-based Actions will extend. This base class automatically handles activating and
@@ -153,6 +148,7 @@ export class RunQueryAction extends QueryTaskbarAction {
 			// otherwise, either run the statement or the script depending on parameter
 			let selection: ISelectionData = editor.getSelection(false);
 			if (runCurrentStatement && selection && this.isCursorPosition(selection)) {
+				editor.currentQueryInput.runQueryStatement(selection);
 			} else {
 				// get the selection again this time with trimming
 				selection = editor.getSelection();

--- a/src/sql/parts/query/services/queryEditorService.ts
+++ b/src/sql/parts/query/services/queryEditorService.ts
@@ -6,13 +6,12 @@
 import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
 import { QueryInput } from 'sql/parts/query/common/queryInput';
 import { EditDataInput } from 'sql/parts/editData/common/editDataInput';
-import { IConnectableInput } from 'sql/parts/connection/common/connectionManagement';
+import { IConnectableInput, IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
 import { IQueryEditorService, IQueryEditorOptions } from 'sql/parts/query/common/queryEditorService';
 import { QueryPlanInput } from 'sql/parts/queryPlan/queryPlanInput';
 import { sqlModeId, untitledFilePrefix, getSupportedInputResource } from 'sql/parts/common/customInputConverter';
 import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
-import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
 
 import { IMode } from 'vs/editor/common/modes';
 import { IModel } from 'vs/editor/common/editorCommon';
@@ -23,7 +22,6 @@ import { IUntitledEditorService, UNTITLED_SCHEMA } from 'vs/workbench/services/u
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { FileEditorInput } from 'vs/workbench/parts/files/common/editors/fileEditorInput';
-import { indexOf } from 'vs/platform/files/common/files';
 import { IMessageService } from 'vs/platform/message/common/message';
 import Severity from 'vs/base/common/severity';
 import nls = require('vs/nls');


### PR DESCRIPTION
Fixes [419 Run Current Query no longer identifies the extents of the current statement](https://github.com/Microsoft/sqlopsstudio/issues/419) which was regressed by PR to 'Support query shortcuts'.

Also, cleans up a few linting issues with import statements.