### PR TITLE
Install SQL Tools Service relative to extension directory

### DIFF
--- a/extensions-modules/src/languageservice/serviceDownloadProvider.ts
+++ b/extensions-modules/src/languageservice/serviceDownloadProvider.ts
@@ -100,10 +100,9 @@ export default class ServiceDownloadProvider {
 			basePath = installDirFromConfig;
 		} else if (this._fromBuild) {
 			basePath = path.join(__dirname, '../../../../../extensions/' + extensionConfigSectionName + '/' + installDirFromConfig);
-		}
-		else {
+		} else {
 			// The path from config is relative to the out folder
-			basePath = path.join(__dirname, '../../../../' + installDirFromConfig);
+			basePath = path.join(__dirname, '../../../../' + extensionConfigSectionName + '/' +  installDirFromConfig);
 		}
 		return basePath;
 	}


### PR DESCRIPTION
Fixes this regression [#434 SQL Ops fails to load tools service when installed by setup EXE](https://github.com/Microsoft/sqlopsstudio/issues/434) from this PR https://github.com/Microsoft/sqlopsstudio/pull/359.