### PR TITLE
Remove unneeded npm package references from mssql

### DIFF
--- a/extensions/mssql/npm-shrinkwrap.json
+++ b/extensions/mssql/npm-shrinkwrap.json
@@ -2,20 +2,5 @@
   "name": "mssql",
   "version": "0.1.0",
   "dependencies": {
-    "dataprotocol-client": {
-      "version": "2.6.3",
-      "from": "..\\..\\dataprotocol-node\\client",
-      "resolved": "file:..\\..\\dataprotocol-node\\client"
-    },
-    "dataprotocol-jsonrpc": {
-      "version": "2.4.0",
-      "from": "..\\..\\dataprotocol-node\\jsonrpc",
-      "resolved": "file:..\\..\\dataprotocol-node\\jsonrpc"
-    },
-    "dataprotocol-languageserver-types": {
-      "version": "1.0.4",
-      "from": "..\\..\\dataprotocol-node\\types",
-      "resolved": "file:..\\..\\dataprotocol-node\\types"
-    }
   }
 }


### PR DESCRIPTION
These references to dataprotocol in the mssql npm shrinkwrap don't appear necessary since the extension is loading these from under extensions\node_modules.