### PR TITLE
Set tab background color when dragged

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -245,6 +245,17 @@ export class TabsTitleControl extends TitleControl {
 			element.style.outlineColor = activeContrastBorderColor;
 			element.style.outlineOffset = null;
 		}
+
+		// {{SQL CARBON EDIT}} -- Display the editor's tab color
+		if (isTab) {
+			const tabContainer = this.tabsContainer.children[index];
+			if (tabContainer instanceof HTMLElement) {
+				let editor = this.context.getEditor(index);
+				if (editor) {
+					this.setEditorTabColor(editor, tabContainer, isActiveTab);
+				}
+			}
+		}
 	}
 
 	public allowDragging(element: HTMLElement): boolean {
@@ -335,18 +346,7 @@ export class TabsTitleControl extends TitleControl {
 				}
 
 				// {{SQL CARBON EDIT}} -- Display the editor's tab color
-				let sqlEditor = editor as any;
-				if (sqlEditor.tabColor && this.themeService.getTheme().type !== HIGH_CONTRAST) {
-					tabContainer.style.borderTopColor = sqlEditor.tabColor;
-					tabContainer.style.borderTopWidth = isTabActive ? '2px' : '1px';
-					let backgroundColor = Color.Format.CSS.parseHex(sqlEditor.tabColor);
-					if (backgroundColor) {
-						tabContainer.style.backgroundColor = backgroundColor.transparent(isTabActive ? 0.3 : 0.2).toString();
-					}
-				} else {
-					tabContainer.style.borderTopColor = '';
-					tabContainer.style.borderTopWidth = '';
-				}
+				this.setEditorTabColor(editor, tabContainer, isTabActive);
 			}
 		});
 
@@ -861,6 +861,22 @@ export class TabsTitleControl extends TitleControl {
 		const isCopy = (e.ctrlKey && !isMacintosh) || (e.altKey && isMacintosh);
 
 		return !isCopy || source.id === target.id;
+	}
+
+	// {{SQL CARBON EDIT}} -- Display the editor's tab color
+	private setEditorTabColor(editor: IEditorInput, tabContainer: HTMLElement, isTabActive: boolean) {
+		let sqlEditor = editor as any;
+		if (sqlEditor.tabColor && this.themeService.getTheme().type !== HIGH_CONTRAST) {
+			tabContainer.style.borderTopColor = sqlEditor.tabColor;
+			tabContainer.style.borderTopWidth = isTabActive ? '2px' : '1px';
+			let backgroundColor = Color.Format.CSS.parseHex(sqlEditor.tabColor);
+			if (backgroundColor) {
+				tabContainer.style.backgroundColor = backgroundColor.transparent(isTabActive ? 0.3 : 0.2).toString();
+			}
+		} else {
+			tabContainer.style.borderTopColor = '';
+			tabContainer.style.borderTopWidth = '';
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #439 by setting the tab background color when a tab is dragged in addition to when the tab bar is refreshed.