### PR TITLE
Set tab color default off and add config for fill/border

### DIFF
--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -29,6 +29,7 @@ import * as TelemetryUtils from 'sql/common/telemetryUtilities';
 import { warn } from 'sql/base/common/log';
 import { IResourceProviderService } from 'sql/parts/accountManagement/common/interfaces';
 import { IAngularEventingService, AngularEventType } from 'sql/services/angularEventing/angularEventingService';
+import * as QueryConstants from 'sql/parts/query/common/constants';
 
 import * as data from 'data';
 
@@ -1331,7 +1332,7 @@ export class ConnectionManagementService implements IConnectionManagementService
 	}
 
 	public getTabColorForUri(uri: string): string {
-		if (!WorkbenchUtils.getSqlConfigValue<string>(this._workspaceConfigurationService, 'enableTabColors')) {
+		if (WorkbenchUtils.getSqlConfigValue<string>(this._workspaceConfigurationService, 'tabColorMode') === QueryConstants.tabColorModeOff) {
 			return undefined;
 		}
 		let connectionProfile = this.getConnectionProfile(uri);

--- a/src/sql/parts/query/common/constants.ts
+++ b/src/sql/parts/query/common/constants.ts
@@ -10,3 +10,6 @@ export const configShowBatchTime = 'showBatchTime';
 export const querySection = 'query';
 export const shortcutStart = 'shortcut';
 
+export const tabColorModeOff = 'off';
+export const tabColorModeBorder = 'border';
+export const tabColorModeFill = 'fill';

--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -31,6 +31,7 @@ import * as gridActions from 'sql/parts/grid/views/gridActions';
 import * as gridCommands from 'sql/parts/grid/views/gridCommands';
 import { QueryPlanEditor } from 'sql/parts/queryPlan/queryPlanEditor';
 import { QueryPlanInput } from 'sql/parts/queryPlan/queryPlanInput';
+import * as Constants from 'sql/parts/query/common/constants';
 import { localize } from 'vs/nls';
 
 const gridCommandsWeightBonus = 100; // give our commands a little bit more weight over other default list/tree commands
@@ -240,10 +241,16 @@ let registryProperties = {
 		'description': localize('sql.showBatchTime', '[Optional] Should execution time be shown for individual batches'),
 		'default': false
 	},
-	'sql.enableTabColors': {
-		'type': 'boolean',
-		'description': localize('sql.enableTabColors', 'True to color tabs based on the server group of their active connection, false otherwise'),
-		'default': true
+	'sql.tabColorMode': {
+		'type': 'string',
+		'enum': [Constants.tabColorModeOff, Constants.tabColorModeBorder, Constants.tabColorModeFill],
+		'enumDescriptions': [
+			localize('tabColorMode.off', "Tab coloring will be disabled"),
+			localize('tabColorMode.border', "The top border of each editor tab will be colored to match the relevant server group"),
+			localize('tabColorMode.fill', "Each editor tab's background color will match the relevant server group"),
+		],
+		'default': Constants.tabColorModeOff,
+		'description': localize('tabColorMode', "Controls how to color tabs based on the server group of their active connection")
 	},
 	'mssql.intelliSense.enableIntelliSense': {
 		'type': 'boolean',

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -774,7 +774,7 @@ suite('SQL ConnectionManagementService tests', () => {
 
 	test('getTabColorForUri returns the group color corresponding to the connection for a URI', done => {
 		// Set up the connection store to give back a group for the expected connection profile
-		configResult['enableTabColors'] = true;
+		configResult['tabColorMode'] = 'border';
 		let expectedColor = 'red';
 		connectionStore.setup(x => x.getGroupFromId(connectionProfile.groupId)).returns(() => <IConnectionProfileGroup> {
 			color: expectedColor


### PR DESCRIPTION
This PR makes a few minor changes to tab coloring, per our design discussion earlier:
- Disables it by default
- Allows it to be toggled between off/border/fill to let users configure whether to fill the tab or just set the border color
- Makes the colored border 1px thicker so that it is more visible
- Makes the colored background less transparent when the tab is active to make it more visible

Border:
![screen shot 2018-01-08 at 2 10 49 pm](https://user-images.githubusercontent.com/3758704/34694990-0fb59c38-f497-11e7-811e-517f7f33e85d.png)
![screen shot 2018-01-08 at 2 11 35 pm](https://user-images.githubusercontent.com/3758704/34694982-0be143a0-f497-11e7-80b7-fa4e37a05063.png)

Fill:
![screen shot 2018-01-08 at 2 11 07 pm](https://user-images.githubusercontent.com/3758704/34695001-1763d71a-f497-11e7-84bb-8bcc71559613.png)
![screen shot 2018-01-08 at 2 11 19 pm](https://user-images.githubusercontent.com/3758704/34695004-19730436-f497-11e7-965b-7d1008139c88.png)
