### PR TITLE
Fix bug where collapsed OE icon never appeared for selected element

### DIFF
--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -77,8 +77,12 @@
 	background-image: url('expanded.svg');
 }
 
-.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.selected > .content:before {
+.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected.expanded > .content:before {
 	background-image: url('expanded-hc.svg');
+}
+
+.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected > .content:before {
+	background-image: url('collapsed-hc.svg');
 }
 
 .monaco-tree .monaco-tree-rows > .monaco-tree-row.has-children.loading > .content:before {


### PR DESCRIPTION
I came across a small new bug where the collapsed icon never shows up in OE for collapsed objects when they are selected (see screenshot).

This PR fixes that bug by adding a new rule to match selected but non-expanded objects.

![screen shot 2018-01-08 at 5 01 59 pm](https://user-images.githubusercontent.com/3758704/34700078-f5680254-f4ae-11e7-9f89-f864adae8504.png)
