### PR TITLE
Enable hot exit for saved files

### DIFF
--- a/src/sql/parts/dashboard/dashboardInput.ts
+++ b/src/sql/parts/dashboard/dashboardInput.ts
@@ -5,7 +5,6 @@
 
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorInput, EditorModel } from 'vs/workbench/common/editor';
-import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import URI from 'vs/base/common/uri';
 import { IModelService } from 'vs/editor/common/services/modelService';
@@ -70,7 +69,7 @@ export class DashboardInput extends EditorInput {
 	}
 
 	public getTypeId(): string {
-		return UntitledEditorInput.ID;
+		return DashboardInput.ID;
 	}
 
 	public getResource(): URI {

--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -116,7 +116,7 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 	public getQueryResultsInputResource(): string { return this._results.uri; }
 	public showQueryResultsEditor(): void { this._showQueryResultsEditor.fire(); }
 	public updateSelection(selection: ISelectionData): void { this._updateSelection.fire(selection); }
-	public getTypeId(): string { return UntitledEditorInput.ID; }
+	public getTypeId(): string { return QueryInput.ID; }
 	public getDescription(): string { return this._description; }
 	public supportsSplitEditor(): boolean { return false; }
 	public getModeId(): string { return QueryInput.SCHEMA; }

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -132,9 +132,8 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 		return JSON.stringify(serialized);
 	}
 
-	// {{SQL CARBON EDIT}}
-	public deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): EditorInput {
-		return instantiationService.invokeFunction<EditorInput>(accessor => {
+	public deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): UntitledEditorInput {
+		return instantiationService.invokeFunction<UntitledEditorInput>(accessor => {
 			const deserialized: ISerializedUntitledEditorInput = JSON.parse(serializedEditorInput);
 			const resource = !!deserialized.resourceJSON ? URI.revive(deserialized.resourceJSON) : URI.parse(deserialized.resource);
 			const filePath = resource.scheme === 'file' ? resource.fsPath : void 0;

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -42,10 +42,6 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { isMacintosh } from 'vs/base/common/platform';
 import { GroupOnePicker, GroupTwoPicker, GroupThreePicker, AllEditorsPicker } from 'vs/workbench/browser/parts/editor/editorPicker';
 
-// {{SQL CARBON EDIT}}
-import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
-import { QueryInput } from 'sql/parts/query/common/queryInput';
-
 // Register String Editor
 Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
 	new EditorDescriptor(
@@ -114,7 +110,7 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 			return null; // never restore untitled unless hot exit is enabled
 		}
 
-		const untitledEditorInput = <UntitledEditorInput>editorInput;
+		let untitledEditorInput = <UntitledEditorInput>editorInput;
 
 		// {{SQL CARBON EDIT}}
 		if (!untitledEditorInput.getResource()) {
@@ -145,14 +141,7 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 			const language = deserialized.modeId;
 			const encoding = deserialized.encoding;
 
-			// {{SQL CARBON EDIT}}
-			let input = accessor.get(IWorkbenchEditorService).createInput({ resource, filePath, language, encoding }) as UntitledEditorInput;
-			if (deserialized.modeId === QueryInput.SCHEMA) {
-				const queryResultsInput: QueryResultsInput = instantiationService.createInstance(QueryResultsInput, resource.toString());
-				return instantiationService.createInstance(QueryInput, input.getName(), '', input, queryResultsInput, undefined);
-			} else {
-				return input;
-			}
+			return accessor.get(IWorkbenchEditorService).createInput({ resource, filePath, language, encoding }) as UntitledEditorInput;
 		});
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -110,7 +110,7 @@ class UntitledEditorInputFactory implements IEditorInputFactory {
 			return null; // never restore untitled unless hot exit is enabled
 		}
 
-		let untitledEditorInput = <UntitledEditorInput>editorInput;
+		const untitledEditorInput = <UntitledEditorInput>editorInput;
 
 		// {{SQL CARBON EDIT}}
 		if (!untitledEditorInput.getResource()) {

--- a/src/vs/workbench/parts/files/browser/files.contribution.ts
+++ b/src/vs/workbench/parts/files/browser/files.contribution.ts
@@ -267,7 +267,7 @@ configurationRegistry.registerConfiguration({
 		'files.hotExit': {
 			'type': 'string',
 			'enum': [HotExitConfiguration.OFF, HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE],
-			'default': HotExitConfiguration.ON_EXIT,
+			'default': HotExitConfiguration.OFF,
 			'enumDescriptions': [
 				nls.localize('hotExit.off', 'Disable hot exit.'),
 				nls.localize('hotExit.onExit', 'Hot exit will be triggered when the application is closed, that is when the last window is closed on Windows/Linux or when the workbench.action.quit command is triggered (command palette, keybinding, menu). All windows with backups will be restored upon next launch.'),

--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -32,6 +32,10 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ResourceGlobMatcher } from 'vs/workbench/common/resources';
 import { IEditorRegistry, Extensions } from 'vs/workbench/browser/editor';
 
+// {{SQL CARBON EDIT}}
+import { QueryInput } from 'sql/parts/query/common/queryInput';
+import * as CustomInputConverter from 'sql/parts/common/customInputConverter';
+
 /**
  * Stores the selection & view state of an editor and allows to compare it to other selection states.
  */
@@ -716,7 +720,16 @@ export class HistoryService extends BaseHistoryService implements IHistoryServic
 
 		const registry = Registry.as<IEditorInputFactoryRegistry>(EditorExtensions.EditorInputFactories);
 
-		const entries: ISerializedEditorHistoryEntry[] = this.history.map(input => {
+		// {{SQL CARBON EDIT}}
+		let history = this.history.map(input => {
+			if (input instanceof QueryInput) {
+				return input.sql;
+			} else {
+				return input;
+			}
+		});
+
+		const entries: ISerializedEditorHistoryEntry[] = history.map(input => {
 
 			// Editor input: try via factory
 			if (input instanceof EditorInput) {
@@ -768,7 +781,8 @@ export class HistoryService extends BaseHistoryService implements IHistoryServic
 						once(input.onDispose)(() => this.removeFromHistory(input)); // remove from history once disposed
 					}
 
-					return input;
+					// {{SQL CARBON EDIT}}
+					return CustomInputConverter.convertEditorInput(input, undefined, this.instantiationService);
 				}
 			}
 

--- a/src/vs/workbench/services/history/browser/history.ts
+++ b/src/vs/workbench/services/history/browser/history.ts
@@ -32,10 +32,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ResourceGlobMatcher } from 'vs/workbench/common/resources';
 import { IEditorRegistry, Extensions } from 'vs/workbench/browser/editor';
 
-// {{SQL CARBON EDIT}}
-import { QueryInput } from 'sql/parts/query/common/queryInput';
-import * as CustomInputConverter from 'sql/parts/common/customInputConverter';
-
 /**
  * Stores the selection & view state of an editor and allows to compare it to other selection states.
  */
@@ -720,16 +716,7 @@ export class HistoryService extends BaseHistoryService implements IHistoryServic
 
 		const registry = Registry.as<IEditorInputFactoryRegistry>(EditorExtensions.EditorInputFactories);
 
-		// {{SQL CARBON EDIT}}
-		let history = this.history.map(input => {
-			if (input instanceof QueryInput) {
-				return input.sql;
-			} else {
-				return input;
-			}
-		});
-
-		const entries: ISerializedEditorHistoryEntry[] = history.map(input => {
+		const entries: ISerializedEditorHistoryEntry[] = this.history.map(input => {
 
 			// Editor input: try via factory
 			if (input instanceof EditorInput) {
@@ -781,8 +768,7 @@ export class HistoryService extends BaseHistoryService implements IHistoryServic
 						once(input.onDispose)(() => this.removeFromHistory(input)); // remove from history once disposed
 					}
 
-					// {{SQL CARBON EDIT}}
-					return CustomInputConverter.convertEditorInput(input, undefined, this.instantiationService);
+					return input;
 				}
 			}
 

--- a/src/vs/workbench/services/textfile/common/textFileService.ts
+++ b/src/vs/workbench/services/textfile/common/textFileService.ts
@@ -366,10 +366,7 @@ export abstract class TextFileService implements ITextFileService {
 		}
 
 		// Hot exit
-		// {{SQL CARBON EDIT}}
-
-		// const hotExitMode = configuration && configuration.files ? configuration.files.hotExit : HotExitConfiguration.ON_EXIT;
-		const hotExitMode = HotExitConfiguration.OFF;
+		const hotExitMode = configuration && configuration.files ? configuration.files.hotExit : HotExitConfiguration.ON_EXIT;
 		if (hotExitMode === HotExitConfiguration.OFF || hotExitMode === HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE) {
 			this.configuredHotExit = hotExitMode;
 		} else {


### PR DESCRIPTION
This will fix #463 by changing how we serialize and deserialize editor windows to always serialize VS Code's version of the editor, then convert it to a `SqlInput` editor upon deserialization if needed.

This is still a work in progress and needs some testing, but opening the PR now in case others are interested in looking at the code change.