### PR TITLE
Connection dialog: dropdown for databases

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionController.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionController.ts
@@ -15,8 +15,6 @@ import * as Constants from 'sql/parts/connection/common/constants';
 import data = require('data');
 import * as Utils from 'sql/parts/connection/common/utils';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { TPromise } from 'vs/base/common/winjs.base';
-import { resolve } from 'path';
 
 export class ConnectionController implements IConnectionComponentController {
 	private _container: HTMLElement;
@@ -77,7 +75,7 @@ export class ConnectionController implements IConnectionComponentController {
 				} else {
 					reject(connResult.errorMessage);
 				}
-			})
+			});
 		});
 	}
 

--- a/src/sql/parts/connection/connectionDialog/connectionController.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionController.ts
@@ -76,6 +76,7 @@ export class ConnectionController implements IConnectionComponentController {
 					reject(connResult.errorMessage);
 				}
 			});
+
 		});
 	}
 

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -43,6 +43,7 @@ export interface IConnectionComponentCallbacks {
 	onCreateNewServerGroup?: () => void;
 	onAdvancedProperties?: () => void;
 	onSetAzureTimeOut?: () => void;
+	onUpdateDatabaseNames?: () => Promise<string[]>;
 }
 
 export interface IConnectionComponentController {

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -27,9 +27,7 @@ import data = require('data');
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { localize } from 'vs/nls';
 import { OS, OperatingSystem } from 'vs/base/common/platform';
-import * as Utils from 'sql/parts/connection/common/utils';
-import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile';
-import { IMessageService, Severity } from 'vs/platform/message/common/message';
+import { Severity } from 'vs/platform/message/common/message';
 
 export class ConnectionWidget {
 	private _builder: Builder;
@@ -75,8 +73,7 @@ export class ConnectionWidget {
 		parentId: undefined,
 		color: undefined,
 		description: undefined
-	}
-
+	};
 	private _addNewServerGroup = {
 		id: '',
 		name: localize('addNewServerGroup', 'Add new group...'),
@@ -200,7 +197,7 @@ export class ConnectionWidget {
 			this._databaseNameInputBox.disable();
 
 			// connect to server and fetch database names
-			if (this.authenticationType == Constants.integrated) {
+			if (this.authenticationType === Constants.integrated) {
 				this._callbacks.onUpdateDatabaseNames().then(result => {
 					if (result) {
 						this._databaseNameOptions = [this.DefaultDatabaseGroup];
@@ -221,7 +218,7 @@ export class ConnectionWidget {
 				}).catch(err => {
 					this._errorMessageService.showDialog(Severity.Error, '', err);
 					this._databaseNameInputBox.setOptions([this.DefaultDatabaseGroup].map(d => d.name));
-				})
+				});
 			}
 
 			this._databaseNameInputBox.enable();
@@ -295,7 +292,7 @@ export class ConnectionWidget {
 		}));
 		this._toDispose.push(this._databaseNameInputBox.onDidSelect(selectedDatabase => {
 			this._databaseNameInputBox.selectWithOptionName(selectedDatabase.selected);
-		}))
+		}));
 	}
 
 	private onGroupSelected(selectedGroup: string) {

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -171,9 +171,6 @@ export class ConnectionWidget {
 		let databaseNameBuilder = DialogHelper.appendRow(this._tableContainer, databaseOption.displayName, 'connection-label', 'connection-input');
 		this._databaseNameOptions = [this.DefaultDatabaseGroup, this.LoadingDatabaseGroup];
 		this._databaseNameInputBox = new SelectBox(this._databaseNameOptions.map(d => d.name), this._defaultDatabaseName, databaseNameBuilder.getHTMLElement());
-		let disabledBackground : ISelectBoxStyles = {
-			disabledSelectBackground : Color.fromHex('#444444')
-		}
 		DialogHelper.appendInputSelectBox(databaseNameBuilder, this._databaseNameInputBox);
 
 		let serverGroupLabel = localize('serverGroup', 'Server group');
@@ -220,7 +217,7 @@ export class ConnectionWidget {
 					this.showErrorPromise(err).then(() => {
 						this._serverNameInputBox.enable();
 						this._databaseNameInputBox.setOptions([this.DefaultDatabaseGroup].map(d => d.name), 0);
-					})
+					});
 				});
 			}
 		}

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -9,7 +9,7 @@ import 'vs/css!./media/sqlConnection';
 import { Builder, $ } from 'vs/base/browser/builder';
 import { Button } from 'sql/base/browser/ui/button/button';
 import { MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
-import { SelectBox, ISelectBoxStyles } from 'sql/base/browser/ui/selectBox/selectBox';
+import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import * as DialogHelper from 'sql/base/browser/ui/modal/dialogHelper';
@@ -28,7 +28,6 @@ import { IContextViewService } from 'vs/platform/contextview/browser/contextView
 import { localize } from 'vs/nls';
 import { OS, OperatingSystem } from 'vs/base/common/platform';
 import { Severity } from 'vs/platform/message/common/message';
-import { Color } from 'vs/base/common/color';
 
 export class ConnectionWidget {
 	private _builder: Builder;

--- a/src/sql/parts/connection/connectionDialog/recentConnectionTreeController.ts
+++ b/src/sql/parts/connection/connectionDialog/recentConnectionTreeController.ts
@@ -16,7 +16,6 @@ import { IConnectionManagementService } from 'sql/parts/connection/common/connec
 import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile';
 import { IAction } from 'vs/base/common/actions';
 import Event, { Emitter } from 'vs/base/common/event';
-import { IMessageService } from 'vs/platform/message/common/message';
 import mouse = require('vs/base/browser/mouseEvent');
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 
@@ -26,8 +25,7 @@ export class RecentConnectionActionsProvider extends ContributableActionProvider
 
 	constructor(
 		@IInstantiationService private _instantiationService: IInstantiationService,
-		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
-		@IMessageService private _messageService: IMessageService,
+		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService
 	) {
 		super();
 	}


### PR DESCRIPTION
Fixes https://github.com/Microsoft/sqlopsstudio/issues/22

Functionality is similar to SSDT's functionality. I've attached some screenshots -

1. Dropdown when a supported server name is populated
<img width="498" alt="screen shot 2018-01-16 at 6 19 49 pm" src="https://user-images.githubusercontent.com/6411451/34989879-29000328-faea-11e7-90e3-bcf80b684c98.png">

2. UI when a connection is made to a server  (Loading in database input)
<img width="500" alt="screen shot 2018-01-16 at 6 20 11 pm" src="https://user-images.githubusercontent.com/6411451/34989880-2ad5f522-faea-11e7-8ebf-9dc1e9d71e4d.png">

3. Error thrown when trying to fetch databases from a server that doesn't exist
<img width="1439" alt="screen shot 2018-01-16 at 6 20 27 pm" src="https://user-images.githubusercontent.com/6411451/34989886-2e3ebdca-faea-11e7-92d1-4153115581e4.png">

4. Dropdown populated when a connection is picked from the recent list
<img width="500" alt="screen shot 2018-01-16 at 6 21 09 pm" src="https://user-images.githubusercontent.com/6411451/34989895-31c2d6b6-faea-11e7-8a07-da51d05dc505.png">


