### PR TITLE
Fix #494 Connection error when connecting to an Azure SQL Server with no firewall rule

### DIFF
--- a/src/sql/parts/accountManagement/firewallRuleDialog/firewallRuleDialog.ts
+++ b/src/sql/parts/accountManagement/firewallRuleDialog/firewallRuleDialog.ts
@@ -19,6 +19,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IWindowsService } from 'vs/platform/windows/common/windows';
 
 import * as data from 'data';
 import { Button } from 'sql/base/browser/ui/button/button';
@@ -28,6 +29,10 @@ import { attachModalDialogStyler, attachButtonStyler } from 'sql/common/theme/st
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
 import { IAccountPickerService } from 'sql/parts/accountManagement/common/interfaces';
 import * as TelemetryKeys from 'sql/common/telemetryKeys';
+
+// TODO: Make the help link 1) extensible (01/08/2018, https://github.com/Microsoft/sqlopsstudio/issues/450)
+// in case that other non-Azure sign in is to be used
+const firewallHelpUri = 'https://aka.ms/sqlopsfirewallhelp';
 
 export class FirewallRuleDialog extends Modal {
 	public viewModel: FirewallRuleViewModel;
@@ -58,7 +63,8 @@ export class FirewallRuleDialog extends Modal {
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IContextViewService private _contextViewService: IContextViewService,
 		@ITelemetryService telemetryService: ITelemetryService,
-		@IContextKeyService contextKeyService: IContextKeyService
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IWindowsService private _windowsService: IWindowsService,
 	) {
 		super(
 			localize('createNewFirewallRule', 'Create new firewall rule'),
@@ -102,10 +108,12 @@ export class FirewallRuleDialog extends Modal {
 				'Your client IP address does not have access to the server. Sign in to an Azure account and create a new firewall rule to enable access.');
 			this.createLabelElement(new Builder(textDescriptionContainer), dialogDescription, false);
 
-			// TODO: Make this 1) extensible and 2) open the info via an action (01/08/2018, https://github.com/Microsoft/sqlopsstudio/issues/450)
-			// this._helpLink = DOM.append(textDescriptionContainer, DOM.$('a.help-link'));
-			// this._helpLink.setAttribute('href', 'https://docs.microsoft.com/en-us/azure/sql-database/sql-database-firewall-configure');
-			// this._helpLink.innerHTML += localize('firewallRuleHelpDescription', 'Learn more about firewall settings');
+			this._helpLink = DOM.append(textDescriptionContainer, DOM.$('a.help-link'));
+			this._helpLink.setAttribute('href', firewallHelpUri);
+			this._helpLink.innerHTML += localize('firewallRuleHelpDescription', 'Learn more about firewall settings');
+			this._helpLink.onclick = () => {
+				this._windowsService.openExternal(firewallHelpUri);
+			};
 		});
 
 		// Create account picker with event handling
@@ -225,7 +233,6 @@ export class FirewallRuleDialog extends Modal {
 	private updateTheme(theme: IColorTheme): void {
 		let linkColor = theme.getColor(buttonBackground);
 		let link = linkColor ? linkColor.toString() : null;
-		this._helpLink.style.color = link;
 		if (this._helpLink) {
 			this._helpLink.style.color = link;
 		}

--- a/src/sqltest/parts/accountManagement/firewallRuleDialogController.test.ts
+++ b/src/sqltest/parts/accountManagement/firewallRuleDialogController.test.ts
@@ -59,7 +59,7 @@ suite('Firewall rule dialog controller tests', () => {
 			.returns(() => mockFirewallRuleViewModel.object);
 
 		// Create a mock account picker
-		let firewallRuleDialog = new FirewallRuleDialog(null, null, null, instantiationService.object, null, null, new ContextKeyServiceStub());
+		let firewallRuleDialog = new FirewallRuleDialog(null, null, null, instantiationService.object, null, null, new ContextKeyServiceStub(), null);
 		mockFirewallRuleDialog = TypeMoq.Mock.ofInstance(firewallRuleDialog);
 
 		let mockEvent = new Emitter<any>();


### PR DESCRIPTION
- Reenabled the link and added a click handler that actually opens up the help
- Changed to using an aka.ms link so that if the docs page changes in the future we can update the link and not need to re-ship the code