### PR TITLE
Show current connection info in the status bar

### DIFF
--- a/src/sql/parts/connection/common/connectionStatus.ts
+++ b/src/sql/parts/connection/common/connectionStatus.ts
@@ -13,7 +13,7 @@ import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { IObjectExplorerService } from 'sql/parts/registeredServer/common/objectExplorerService';
 import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
 
-// Connection status bar for editor
+// Connection status bar showing the current global connection
 export class ConnectionStatusbarItem implements IStatusbarItem {
 
 	private _element: HTMLElement;
@@ -47,7 +47,7 @@ export class ConnectionStatusbarItem implements IStatusbarItem {
 		return combinedDisposable(this._toDispose);
 	}
 
-	// Show/hide query status for active editor
+	// Update the connection status shown in the bar
 	private _updateStatus(): void {
 		let activeConnection = TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService);
 		if (activeConnection) {

--- a/src/sql/parts/connection/common/connectionStatus.ts
+++ b/src/sql/parts/connection/common/connectionStatus.ts
@@ -4,44 +4,21 @@
  *--------------------------------------------------------------------------------------------*/
 import { $, append, show, hide } from 'vs/base/browser/dom';
 import { IDisposable, combinedDisposable } from 'vs/base/common/lifecycle';
-import URI from 'vs/base/common/uri';
-import { IEditorInput } from 'vs/platform/editor/common/editor';
 import { IStatusbarItem } from 'vs/workbench/browser/parts/statusbar/statusbar';
-import { IEditorCloseEvent } from 'vs/workbench/common/editor';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IEditorGroupService } from 'vs/workbench/services/group/common/groupService';
-import { IConnectionManagementService, IConnectionParams } from 'sql/parts/connection/common/connectionManagement';
-import { ConnectionStatusManager } from 'sql/parts/connection/common/connectionStatusManager';
+import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
 import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
-import { QueryInput } from 'sql/parts/query/common/queryInput';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
-import * as WorkbenchUtils from 'sql/workbench/common/sqlWorkbenchUtils';
 import { IObjectExplorerService } from 'sql/parts/registeredServer/common/objectExplorerService';
 import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
-
-enum ConnectionActivityStatus {
-	Connected,
-	Disconnected
-}
-
-// Contains connection status for each editor
-class ConnectionStatusEditor {
-	public connectionActivityStatus: ConnectionActivityStatus;
-	public connectionProfile: IConnectionProfile;
-
-	constructor() {
-		this.connectionActivityStatus = ConnectionActivityStatus.Disconnected;
-	}
-}
 
 // Connection status bar for editor
 export class ConnectionStatusbarItem implements IStatusbarItem {
 
 	private _element: HTMLElement;
 	private _connectionElement: HTMLElement;
-	private _connectionStatusEditors: { [connectionUri: string]: ConnectionStatusEditor };
 	private _toDispose: IDisposable[];
-	private _connectionStatusManager: ConnectionStatusManager;
 
 	constructor(
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
@@ -50,8 +27,6 @@ export class ConnectionStatusbarItem implements IStatusbarItem {
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService,
 		@IObjectExplorerService private _objectExplorerService: IObjectExplorerService,
 	) {
-		this._connectionStatusEditors = {};
-		this._connectionStatusManager = new ConnectionStatusManager(this._capabilitiesService);
 	}
 
 	public render(container: HTMLElement): IDisposable {
@@ -61,88 +36,26 @@ export class ConnectionStatusbarItem implements IStatusbarItem {
 
 		this._toDispose = [];
 		this._toDispose.push(
-			this._connectionManagementService.onConnect((connectionUri: IConnectionParams) => this._onConnect(connectionUri)),
-			this._connectionManagementService.onConnectionChanged((connectionUri: IConnectionParams) => this._onConnect(connectionUri)),
-			this._connectionManagementService.onDisconnect((connectionUri: IConnectionParams) => this._onDisconnect(connectionUri)),
-			this._editorGroupService.onEditorsChanged(() => this._onEditorsChanged()),
-			this._editorGroupService.getStacksModel().onEditorClosed(event => this._onEditorClosed(event)),
-			this._objectExplorerService.onSelectionOrFocusChange(() => this._onEditorsChanged())
+			this._connectionManagementService.onConnect(() => this._updateStatus()),
+			this._connectionManagementService.onConnectionChanged(() => this._updateStatus()),
+			this._connectionManagementService.onDisconnect(() => this._updateStatus()),
+			this._editorGroupService.onEditorsChanged(() => this._updateStatus()),
+			this._editorGroupService.getStacksModel().onEditorClosed(() => this._updateStatus()),
+			this._objectExplorerService.onSelectionOrFocusChange(() => this._updateStatus())
 		);
 
 		return combinedDisposable(this._toDispose);
 	}
 
-	private _onEditorClosed(event: IEditorCloseEvent): void {
-		let uri = WorkbenchUtils.getEditorUri(event.editor);
-		if (uri && uri in this._connectionStatusEditors) {
-			this._updateStatus(uri, ConnectionActivityStatus.Disconnected, undefined);
-			delete this._connectionStatusEditors[uri];
-		}
-	}
-
-	private _onEditorsChanged(): void {
+	// Show/hide query status for active editor
+	private _updateStatus(): void {
 		let activeConnection = TaskUtilities.getCurrentGlobalConnection(this._objectExplorerService, this._connectionManagementService, this._editorService);
 		if (activeConnection) {
-			this._updateStatus(activeConnection.id, ConnectionActivityStatus.Connected, activeConnection);
+			this._setConnectionText(activeConnection);
+			show(this._connectionElement);
 		} else {
 			hide(this._connectionElement);
 		}
-		// let activeEditor = this._editorService.getActiveEditor();
-		// if (activeEditor) {
-		// 	let uri = WorkbenchUtils.getEditorUri(activeEditor.input);
-
-		// 	// Show active editor's query status
-		// 	if (uri && uri in this._connectionStatusEditors) {
-		// 		this._showStatus(uri);
-		// 	} else {
-		// 		hide(this._connectionElement);
-		// 	}
-		// } else {
-		// 	hide(this._connectionElement);
-		// }
-	}
-
-	private _onConnect(connectionParams: IConnectionParams): void {
-		if (!this._connectionStatusManager.isDefaultTypeUri(connectionParams.connectionUri)) {
-			this._updateStatus(connectionParams.connectionUri, ConnectionActivityStatus.Connected, connectionParams.connectionProfile);
-		}
-	}
-
-	private _onDisconnect(connectionUri: IConnectionParams): void {
-		if (!this._connectionStatusManager.isDefaultTypeUri(connectionUri.connectionUri)) {
-			this._updateStatus(connectionUri.connectionUri, ConnectionActivityStatus.Disconnected, undefined);
-		}
-	}
-
-	// Update connection status for the editor
-	private _updateStatus(uri: string, newStatus: ConnectionActivityStatus, connectionProfile: IConnectionProfile) {
-		if (uri) {
-			if (!(uri in this._connectionStatusEditors)) {
-				this._connectionStatusEditors[uri] = new ConnectionStatusEditor();
-			}
-			this._connectionStatusEditors[uri].connectionActivityStatus = newStatus;
-			this._connectionStatusEditors[uri].connectionProfile = connectionProfile;
-			this._showStatus(uri);
-		}
-	}
-
-	// Show/hide query status for active editor
-	private _showStatus(uri: string): void {
-		// let activeEditor = this._editorService.getActiveEditor();
-		// if (activeEditor) {
-		// 	let currentUri = WorkbenchUtils.getEditorUri(activeEditor.input);
-		// 	if (uri === currentUri) {
-				switch (this._connectionStatusEditors[uri].connectionActivityStatus) {
-					case ConnectionActivityStatus.Connected:
-						this._setConnectionText(this._connectionStatusEditors[uri].connectionProfile);
-						show(this._connectionElement);
-						break;
-					case ConnectionActivityStatus.Disconnected:
-						hide(this._connectionElement);
-						break;
-				}
-		// 	}
-		// }
 	}
 
 	// Set connection info to connection status bar

--- a/src/sql/parts/registeredServer/common/objectExplorerService.ts
+++ b/src/sql/parts/registeredServer/common/objectExplorerService.ts
@@ -61,6 +61,8 @@ export interface IObjectExplorerService {
 	getSelectedProfileAndDatabase(): { profile: ConnectionProfile, databaseName: string };
 
 	isFocused(): boolean;
+
+	onSelectionOrFocusChange: Event<void>;
 }
 
 interface SessionStatus {
@@ -94,6 +96,8 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 	private _serverTreeView: ServerTreeView;
 
+	private _onSelectionOrFocusChange: Emitter<void>;
+
 	constructor(
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
 		@ITelemetryService private _telemetryService: ITelemetryService
@@ -102,10 +106,15 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		this._activeObjectExplorerNodes = {};
 		this._sessions = {};
 		this._providers = {};
+		this._onSelectionOrFocusChange = new Emitter<void>();
 	}
 
 	public get onUpdateObjectExplorerNodes(): Event<ObjectExplorerNodeEventArgs> {
 		return this._onUpdateObjectExplorerNodes.event;
+	}
+
+	public get onSelectionOrFocusChange(): Event<void> {
+		return this._onSelectionOrFocusChange.event;
 	}
 
 	public updateObjectExplorerNodes(connection: IConnectionProfile): Promise<void> {
@@ -370,6 +379,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 			throw new Error('The object explorer server tree view is already registered');
 		}
 		this._serverTreeView = view;
+		this._serverTreeView.onSelectionOrFocusChange(() => this._onSelectionOrFocusChange.fire());
 	}
 
 	/**

--- a/src/sql/parts/registeredServer/common/objectExplorerService.ts
+++ b/src/sql/parts/registeredServer/common/objectExplorerService.ts
@@ -113,6 +113,9 @@ export class ObjectExplorerService implements IObjectExplorerService {
 		return this._onUpdateObjectExplorerNodes.event;
 	}
 
+	/**
+	 * Event fired when the selection or focus of Object Explorer changes
+	 */
 	public get onSelectionOrFocusChange(): Event<void> {
 		return this._onSelectionOrFocusChange.event;
 	}

--- a/src/sql/parts/registeredServer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/registeredServer/viewlet/serverTreeView.ts
@@ -61,16 +61,20 @@ export class ServerTreeView {
 		this._onSelectionOrFocusChange = new Emitter();
 	}
 
-	public get onSelectionOrFocusChange(): Event<void> {
-		return this._onSelectionOrFocusChange.event;
-	}
-
 	/**
 	 * Get active connections filter action
 	 */
 	public get activeConnectionsFilterAction(): ActiveConnectionsFilterAction {
 		return this._activeConnectionsFilterAction;
 	}
+
+	/**
+	 * Event fired when the tree's selection or focus changes
+	 */
+	public get onSelectionOrFocusChange(): Event<void> {
+		return this._onSelectionOrFocusChange.event;
+	}
+
 	/**
 	 * Render the view body
 	 */
@@ -394,7 +398,7 @@ export class ServerTreeView {
 	}
 
 	private onSelected(event: any): void {
-		this._treeSelectionHandler.onTreeSelect(event, this._tree, this._connectionManagementService, this._objectExplorerService, this._onSelectionOrFocusChange);
+		this._treeSelectionHandler.onTreeSelect(event, this._tree, this._connectionManagementService, this._objectExplorerService, () => this._onSelectionOrFocusChange.fire());
 		this._onSelectionOrFocusChange.fire();
 	}
 

--- a/src/sql/parts/registeredServer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/registeredServer/viewlet/serverTreeView.ts
@@ -437,8 +437,4 @@ export class ServerTreeView {
 		this._tree.dispose();
 		this._toDispose = dispose(this._toDispose);
 	}
-
-	public get tree(): ITree {
-		return this._tree;
-	}
 }

--- a/src/sql/parts/registeredServer/viewlet/treeSelectionHandler.ts
+++ b/src/sql/parts/registeredServer/viewlet/treeSelectionHandler.ts
@@ -11,6 +11,7 @@ import { IObjectExplorerService } from 'sql/parts/registeredServer/common/object
 import { IProgressService, IProgressRunner } from 'vs/platform/progress/common/progress';
 import { TreeNode } from 'sql/parts/registeredServer/common/treeNode';
 import { TreeUpdateUtils } from 'sql/parts/registeredServer/viewlet/treeUpdateUtils';
+import { Emitter } from 'vs/base/common/event';
 
 export class TreeSelectionHandler {
 	progressRunner: IProgressRunner;
@@ -41,7 +42,7 @@ export class TreeSelectionHandler {
 	/**
 	 * Handle selection of tree element
 	 */
-	public onTreeSelect(event: any, tree: ITree, connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService) {
+	public onTreeSelect(event: any, tree: ITree, connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, connectionCompleteEmitter: Emitter<void>) {
 		if (this.isMouseEvent(event)) {
 			this._clicks++;
 		}
@@ -60,7 +61,7 @@ export class TreeSelectionHandler {
 			// don't send tree update events while dragging
 			if (!TreeUpdateUtils.isInDragAndDrop) {
 				let isDoubleClick = this._clicks > 1;
-				this.handleTreeItemSelected(connectionManagementService, objectExplorerService, isDoubleClick, isKeyboard, selection, tree);
+				this.handleTreeItemSelected(connectionManagementService, objectExplorerService, isDoubleClick, isKeyboard, selection, tree, connectionCompleteEmitter);
 			}
 			this._clicks = 0;
 			this._doubleClickTimeoutId = -1;
@@ -75,7 +76,7 @@ export class TreeSelectionHandler {
 	 * @param isKeyboard
 	 * @param selection
 	 */
-	private handleTreeItemSelected(connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, isDoubleClick: boolean, isKeyboard: boolean, selection: any[], tree: ITree): void {
+	private handleTreeItemSelected(connectionManagementService: IConnectionManagementService, objectExplorerService: IObjectExplorerService, isDoubleClick: boolean, isKeyboard: boolean, selection: any[], tree: ITree, connectionCompleteEmitter: Emitter<void>): void {
 		let connectionProfile: ConnectionProfile = undefined;
 		let options: IConnectionCompletionOptions = {
 			params: undefined,
@@ -94,6 +95,7 @@ export class TreeSelectionHandler {
 					if (!sessionCreated) {
 						this.onTreeActionStateChange(false);
 					}
+					connectionCompleteEmitter.fire();
 				}, error => {
 					this.onTreeActionStateChange(false);
 				});

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -18,6 +18,7 @@ import * as TypeMoq from 'typemoq';
 import * as assert from 'assert';
 import { ServerTreeView } from 'sql/parts/registeredServer/viewlet/serverTreeView';
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
+import Event from 'vs/base/common/event';
 
 suite('SQL Object Explorer Service tests', () => {
 	var sqlOEProvider: TypeMoq.Mock<ObjectExplorerProviderTestService>;
@@ -451,7 +452,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile if it is selected', () => {
-		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined } as ServerTreeView);
+		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as ServerTreeView);
 		serverTreeView.setup(x => x.getSelection()).returns(() => [connection]);
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
@@ -461,7 +462,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile but no database if children of a server are selected', () => {
-		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined } as ServerTreeView);
+		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as ServerTreeView);
 		let databaseNode = new TreeNode(NodeType.Folder, 'Folder1', false, 'testServerName\\Folder1', '', '', undefined, undefined);
 		databaseNode.connection = connection;
 		serverTreeView.setup(x => x.getSelection()).returns(() => [databaseNode]);
@@ -473,7 +474,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns the profile and database if children of a database node are selected', () => {
-		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined } as ServerTreeView);
+		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as ServerTreeView);
 		let databaseMetadata = {
 			metadataType: 0,
 			metadataTypeName: 'Database',
@@ -495,7 +496,7 @@ suite('SQL Object Explorer Service tests', () => {
 	});
 
 	test('getSelectedProfileAndDatabase returns undefined when there is no selection', () => {
-		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined } as ServerTreeView);
+		let serverTreeView = TypeMoq.Mock.ofInstance({ getSelection: () => undefined, onSelectionOrFocusChange: Event.None } as ServerTreeView);
 		serverTreeView.setup(x => x.getSelection()).returns(() => []);
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 


### PR DESCRIPTION
This PR closes #540 by updating the status bar's connection status to always show the current global connection. This simplifies the code in `connectionStatus.ts` for determining what to show in the status bar significantly, since now it just has to get the global connection whenever it needs it.