### PR TITLE
bump slickgrid to take a hot fix

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -134,9 +134,9 @@
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
     },
     "caniuse-db": {
-      "version": "1.0.30000793",
+      "version": "1.0.30000795",
       "from": "caniuse-db@>=1.0.30000161 <2.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000793.tgz"
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000795.tgz"
     },
     "chart.js": {
       "version": "2.7.1",
@@ -692,7 +692,7 @@
     "slickgrid": {
       "version": "2.3.12",
       "from": "anthonydresser/SlickGrid#2.3.12",
-      "resolved": "git://github.com/anthonydresser/SlickGrid.git#5610e05166cd7068dcf196498ae20054382b1684"
+      "resolved": "git://github.com/anthonydresser/SlickGrid.git#e7783f6a26b0ab0c34997a94caf2cefc186e1b77"
     },
     "string_decoder": {
       "version": "1.0.3",


### PR DESCRIPTION
Bump slickgrid to take https://github.com/anthonydresser/SlickGrid/commit/e7783f6a26b0ab0c34997a94caf2cefc186e1b77 which patches a bug that was introduced with the slickgrid downward merge. It would arise when restore was opened before a edit/result window was opened.