### PR TITLE
Connection Dialog: Dropdown for database name

### DIFF
--- a/src/sql/base/browser/ui/editableDropdown/dropdownTree.ts
+++ b/src/sql/base/browser/ui/editableDropdown/dropdownTree.ts
@@ -36,7 +36,7 @@ export class DropdownRenderer implements tree.IRenderer {
 	public renderTemplate(tree: tree.ITree, templateId: string, container: HTMLElement) {
 		const row = $('div.list-row').style('height', '22px').style('padding-left', '5px').getHTMLElement();
 		DOM.append(container, row);
-		const label = $('span.label').style('margin', 'auto').getHTMLElement();
+		const label = $('span.label').style('margin', 'auto').style('vertical-align', 'middle').getHTMLElement();
 		DOM.append(row, label);
 
 		return { label };
@@ -91,7 +91,7 @@ export class DropdownFilter extends TreeDefaults.DefaultFilter {
 	public filterString: string;
 
 	public isVisible(tree: tree.ITree, element: Resource): boolean {
-		return element.value.includes(this.filterString);
+		return element.value.toLowerCase().includes(this.filterString.toLowerCase());
 	}
 }
 

--- a/src/sql/parts/connection/connectionDialog/connectionController.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionController.ts
@@ -44,17 +44,24 @@ export class ConnectionController implements IConnectionComponentController {
 			onCreateNewServerGroup: () => this.onCreateNewServerGroup(),
 			onAdvancedProperties: () => this.handleOnAdvancedProperties(),
 			onSetAzureTimeOut: () => this.handleonSetAzureTimeOut(),
-			onFetchDatabases: () => this.onFetchDatabases(this._connectionWidget.serverName).then(result => {
+			onFetchDatabases: (serverName: string, authenticationType: string, userName?: string, password?: string) => this.onFetchDatabases(
+				serverName, authenticationType, userName, password).then(result => {
 				return result;
 			})
 		}, providerName);
 		this._providerName = providerName;
 	}
 
-	private onFetchDatabases(serverName: string): Promise<string[]> {
+	private onFetchDatabases(serverName: string, authenticationType: string, userName?: string, password?: string): Promise<string[]> {
 		let tempProfile = this._model;
 		tempProfile.serverName = serverName;
-		tempProfile.authenticationType = Constants.integrated;
+		if (authenticationType === Constants.integrated) {
+			tempProfile.authenticationType = Constants.integrated;
+		} else {
+			tempProfile.authenticationType = Constants.sqlLogin;
+			tempProfile.userName = userName;
+			tempProfile.password = password;
+		}
 		let uri = this._connectionManagementService.getConnectionId(tempProfile);
 		return new Promise<string[]>((resolve, reject) => {
 			this._connectionManagementService.connect(tempProfile, uri).then(connResult => {

--- a/src/sql/parts/connection/connectionDialog/connectionController.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionController.ts
@@ -55,13 +55,9 @@ export class ConnectionController implements IConnectionComponentController {
 	private onFetchDatabases(serverName: string, authenticationType: string, userName?: string, password?: string): Promise<string[]> {
 		let tempProfile = this._model;
 		tempProfile.serverName = serverName;
-		if (authenticationType === Constants.integrated) {
-			tempProfile.authenticationType = Constants.integrated;
-		} else {
-			tempProfile.authenticationType = Constants.sqlLogin;
-			tempProfile.userName = userName;
-			tempProfile.password = password;
-		}
+		tempProfile.authenticationType = authenticationType;
+		tempProfile.userName = userName;
+		tempProfile.password = password;
 		let uri = this._connectionManagementService.getConnectionId(tempProfile);
 		return new Promise<string[]>((resolve, reject) => {
 			this._connectionManagementService.connect(tempProfile, uri).then(connResult => {

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -43,6 +43,7 @@ export interface IConnectionComponentCallbacks {
 	onCreateNewServerGroup?: () => void;
 	onAdvancedProperties?: () => void;
 	onSetAzureTimeOut?: () => void;
+	onFetchDatabases?: (serverName: string) => Promise<string[]>;
 }
 
 export interface IConnectionComponentController {

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -43,7 +43,7 @@ export interface IConnectionComponentCallbacks {
 	onCreateNewServerGroup?: () => void;
 	onAdvancedProperties?: () => void;
 	onSetAzureTimeOut?: () => void;
-	onFetchDatabases?: (serverName: string) => Promise<string[]>;
+	onFetchDatabases?: (serverName: string, authenticationType: string, userName?: string, password?: string) => Promise<string[]>;
 }
 
 export interface IConnectionComponentController {

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -158,7 +158,8 @@ export class ConnectionWidget {
 		this._databaseNameInputBox = new Dropdown(databaseNameBuilder.getHTMLElement(), this._contextViewService, this._themeService, {
 			values: [this._defaultDatabaseName, this._loadingDatabaseName],
 			strictSelection : false,
-			placeholder: this._defaultDatabaseName
+			placeholder: this._defaultDatabaseName,
+			maxHeight: 125
 		});
 
 		let serverGroupLabel = localize('serverGroup', 'Server group');

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -159,23 +159,6 @@ export class ConnectionWidget {
 			placeholder: '<Default>'
 		});
 
-		this._databaseNameInputBox.onFocus(() => {
-			if (this.serverName) {
-				this._databaseNameInputBox.values = ['Loading...'];
-				this._callbacks.onFetchDatabases(this.serverName).then(databases => {
-					if (databases) {
-						this._databaseNameInputBox.values = databases;
-					} else {
-						this._databaseNameInputBox.values = ['<Default>'];
-					}
-				}).catch(() => {
-					this._databaseNameInputBox.values = ['<Default>'];
-				});
-			} else {
-				this._databaseNameInputBox.values = ['<Default>'];
-			}
-		});
-
 		let serverGroupLabel = localize('serverGroup', 'Server group');
 		let serverGroupBuilder = DialogHelper.appendRow(this._tableContainer, serverGroupLabel, 'connection-label', 'connection-input');
 		DialogHelper.appendInputSelectBox(serverGroupBuilder, this._serverGroupSelectBox);
@@ -255,6 +238,31 @@ export class ConnectionWidget {
 
 		this._toDispose.push(this._passwordInputBox.onDidChange(passwordInput => {
 			this._password = passwordInput;
+		}));
+
+		this._toDispose.push(this._databaseNameInputBox.onFocus(() => {
+			if (this.serverName) {
+				this._databaseNameInputBox.values = ['Loading...'];
+				this._callbacks.onFetchDatabases(this.serverName, this.authenticationType, this.userName, this._password).then(databases => {
+					if (databases) {
+						this._databaseNameInputBox.values = databases;
+					} else {
+						this._databaseNameInputBox.values = ['<Default>'];
+					}
+				}).catch(() => {
+					this._databaseNameInputBox.values = ['<Default>'];
+				});
+			} else {
+				this._databaseNameInputBox.values = ['<Default>'];
+			}
+		}));
+
+		this._toDispose.push(this._databaseNameInputBox.onValueChange(s => {
+			if (s === '<Default>' || s === 'Loading...') {
+				this._databaseNameInputBox.value = '';
+			} else {
+				this._databaseNameInputBox.value = s;
+			}
 		}));
 	}
 


### PR DESCRIPTION
Instead of iterating on my previous PR here - https://github.com/Microsoft/sqlopsstudio/pull/489, I decided to make a new pull request altogether.

Changes from previous iteration/existing Connection Dialog -

1. Now uses an editable dropdown. 

![dropdown2-1](https://user-images.githubusercontent.com/6411451/35543167-861b1452-0518-11e8-8553-cd791079f0b5.PNG)

2. The UI is **not** frozen any more when a connection is made. The dropdown just shows "Loading..." until the dropdown options are populated by the list database task.

![dropdown2-2](https://user-images.githubusercontent.com/6411451/35543224-c99c89c2-0518-11e8-9024-8cc3e2ada893.PNG)

3. When a connection is selected from "Recent History", the database dropdown is still functional and doesn't have the database name set.

![dropdown2-3](https://user-images.githubusercontent.com/6411451/35543312-4f203012-0519-11e8-9241-584e52e29a5a.PNG)

4. Supports SQL Login in addition to Windows Integrated Auth.

![dropdown2-4](https://user-images.githubusercontent.com/6411451/35543388-b08202cc-0519-11e8-9942-cef25c01790f.PNG)
