### PR TITLE
removed hygiene from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,12 +51,10 @@ install:
   - yarn
 
 script:
-  - node_modules/.bin/gulp hygiene
   - node_modules/.bin/gulp electron --silent
   - node_modules/.bin/gulp compile --silent --max_old_space_size=4096
   - node_modules/.bin/gulp optimize-vscode --silent --max_old_space_size=4096
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./scripts/test.sh --coverage --reporter dot; else ./scripts/test.sh --reporter dot; fi
-  - ./scripts/test-integration.sh
 
 after_success:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then node_modules/.bin/coveralls < .build/coverage/lcov.info; fi

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -390,7 +390,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@file:./../dataprotocol-client":
+"dataprotocol-client@file:../dataprotocol-client":
   version "1.0.0"
   dependencies:
     vscode "1.1.5"
@@ -585,7 +585,7 @@ extend@~1.2.1:
 "extensions-modules@file:../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "file:./../../../../../Users/karlb/AppData/Local/Yarn/cache/v1/dataprotocol-client"
+    dataprotocol-client "file:../../../../Library/Caches/Yarn/v1/dataprotocol-client"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"

--- a/extensions-modules/yarn.lock
+++ b/extensions-modules/yarn.lock
@@ -374,7 +374,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@file:./../dataprotocol-client":
+"dataprotocol-client@file:../dataprotocol-client":
   version "1.0.0"
   dependencies:
     vscode "1.1.5"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -315,7 +315,7 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@file:./../dataprotocol-client":
+"dataprotocol-client@file:../dataprotocol-client":
   version "1.0.0"
   dependencies:
     vscode "1.1.5"
@@ -493,7 +493,7 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
 "extensions-modules@file:../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "file:./../../../../../Users/karlb/AppData/Local/Yarn/cache/v1/dataprotocol-client"
+    dataprotocol-client "file:../../../../Library/Caches/Yarn/v1/dataprotocol-client"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -29,9 +29,9 @@ export ELECTRON_ENABLE_LOGGING=1
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	cd $ROOT ; ulimit -n 4096 ; \
 		"$CODE" \
-		test/electron/index.js "$@"
+		node_modules/mocha/bin/_mocha "$@"
 else
 	cd $ROOT ; \
 		"$CODE" \
-		test/electron/index.js "$@"
+		node_modules/mocha/bin/_mocha "$@"
 fi

--- a/test/electron/renderer.js
+++ b/test/electron/renderer.js
@@ -14,12 +14,14 @@ const istanbul = require('istanbul');
 const i_remap = require('remap-istanbul/lib/remap');
 const util = require('util');
 
+require('reflect-metadata');
+
 // Disabled custom inspect. See #38847
 if (util.inspect && util.inspect['defaultOptions']) {
 	util.inspect['defaultOptions'].customInspect = false;
 }
 
-let _tests_glob = '**/test/**/*.test.js';
+let _tests_glob = '**/+(test|sqltest)/**/*.test.js';
 let loader;
 let _out;
 
@@ -36,9 +38,23 @@ function initLoader(opts) {
 		baseUrl: path.join(__dirname, '../../src'),
 		paths: {
 			'vs': `../${outdir}/vs`,
+			'sql': `../${outdir}/sql`,
 			'lib': `../${outdir}/lib`,
 			'bootstrap': `../${outdir}/bootstrap`
-		}
+		},
+		nodeModules: [
+			'@angular/common',
+			'@angular/core',
+			'@angular/forms',
+			'@angular/platform-browser',
+			'@angular/platform-browser-dynamic',
+			'@angular/router',
+			'angular2-grid',
+			'rxjs/add/observable/of',
+			'rxjs/Observable',
+			'rxjs/Subject',
+			'rxjs/Observer'
+		]
 	};
 
 	// nodeInstrumenter when coverage is requested

--- a/test/electron/renderer.js
+++ b/test/electron/renderer.js
@@ -14,14 +14,12 @@ const istanbul = require('istanbul');
 const i_remap = require('remap-istanbul/lib/remap');
 const util = require('util');
 
-require('reflect-metadata');
-
 // Disabled custom inspect. See #38847
 if (util.inspect && util.inspect['defaultOptions']) {
 	util.inspect['defaultOptions'].customInspect = false;
 }
 
-let _tests_glob = '**/+(test|sqltest)/**/*.test.js';
+let _tests_glob = '**/test/**/*.test.js';
 let loader;
 let _out;
 
@@ -38,23 +36,9 @@ function initLoader(opts) {
 		baseUrl: path.join(__dirname, '../../src'),
 		paths: {
 			'vs': `../${outdir}/vs`,
-			'sql': `../${outdir}/sql`,
 			'lib': `../${outdir}/lib`,
 			'bootstrap': `../${outdir}/bootstrap`
-		},
-		nodeModules: [
-			'@angular/common',
-			'@angular/core',
-			'@angular/forms',
-			'@angular/platform-browser',
-			'@angular/platform-browser-dynamic',
-			'@angular/router',
-			'angular2-grid',
-			'rxjs/add/observable/of',
-			'rxjs/Observable',
-			'rxjs/Subject',
-			'rxjs/Observer'
-		]
+		}
 	};
 
 	// nodeInstrumenter when coverage is requested


### PR DESCRIPTION
we aren't enforcing hygiene currently, so until we plan to do so there is no reason to have it in our travis builds. I also believe it is overloading the builds and making them all fail. We also don't have any integration tests so running the integration tests is currently only running vscode tests.

Additionally, we aren't running the correct tests currently because the testing mechanism vscode uses vs what we use is different now. We should revert back and invest time into doing the conversion.