### PR TITLE
Don't cut off dashboard icons when they expand

### DIFF
--- a/src/sql/parts/dashboard/dashboard.css
+++ b/src/sql/parts/dashboard/dashboard.css
@@ -10,3 +10,7 @@
 .dashboardEditor .header .monaco-action-bar .action-item {
 	margin-right: 5px;
 }
+
+.dashboardEditor .monaco-action-bar {
+	overflow: visible;
+}


### PR DESCRIPTION
Fixes #354 

Before:
![Dashboard icons are expanded and get cut off](https://user-images.githubusercontent.com/3758704/34131620-3551cb2a-e401-11e7-8c95-43a7942264ba.png)

After:
![Dashboard icons are expanded and do not get cut off](https://user-images.githubusercontent.com/3758704/35756248-708b64e8-081f-11e8-9c47-05bac76642ee.png)
