### PR TITLE
initial check in for adding controls to a dialog from extension

### DIFF
--- a/src/sql/base/browser/ui/button/button.ts
+++ b/src/sql/base/browser/ui/button/button.ts
@@ -1,4 +1,4 @@
-/*---------------------------------------------------------------------------------------------
+	/*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
@@ -14,6 +14,7 @@ export interface IButtonStyles extends vsIButtonStyles {
 
 export class Button extends vsButton {
 	private buttonFocusOutline: Color;
+	private _id: number;
 
 	constructor(container: any, options?: IButtonOptions) {
 		super(container, options);
@@ -32,5 +33,13 @@ export class Button extends vsButton {
 
 	public set title(value: string) {
 		this.$el.title(value);
+	}
+
+	public set id(value: number) {
+		this._id = value;
+	}
+
+	public get id(): number {
+		return this._id;
 	}
 }

--- a/src/sql/base/browser/ui/modal/webViewDialog.ts
+++ b/src/sql/base/browser/ui/modal/webViewDialog.ts
@@ -38,6 +38,8 @@ export class WebViewDialog extends Modal {
 	public onOk: Event<void> = this._onOk.event;
 	private _onClosed = new Emitter<void>();
 	public onClosed: Event<void> = this._onClosed.event;
+	private _onLoaded = new Emitter<void>();
+	public onLoaded: Event<void> = this._onLoaded.event;
 	private contentDisposables: IDisposable[] = [];
 	private _onMessage = new Emitter<any>();
 
@@ -97,14 +99,20 @@ export class WebViewDialog extends Modal {
 				{
 					allowScripts: true,
 					enableWrappedPostMessage: true,
-					hideFind: true
+					hideFind: true,
+					loadModules: true,
+					appRoot: `${this._environmentService.appRoot}/out`
 				}
 			);
 
 			this._webview.style(this._themeService.getTheme());
 
 			this._webview.onMessage(message => {
-				this._onMessage.fire(message);
+				if (message === 'modulesReady') {
+					this._onLoaded.fire();
+				} else {
+					this._onMessage.fire(message);
+				}
 			}, null, this.contentDisposables);
 
 			this._themeService.onThemeChange(theme => this._webview.style(theme), null, this.contentDisposables);

--- a/src/sql/base/browser/ui/uiControlBuilder.ts
+++ b/src/sql/base/browser/ui/uiControlBuilder.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Button } from 'sql/base/browser/ui/button/button';
+import views = require('views');
+
+export enum ControlTypes {
+	button = 0
+}
+
+export function addButton(info: views.UIControl, container: any): void {
+	let button = new Button(container);
+	button.id = info.id;
+	let buttonInfo = <views.Button>info.control;
+	button.label = buttonInfo.label;
+	button.onDidClick (() => {
+		let args: views.ControlEventArgs = {
+			type: info.type,
+			id: button.id,
+			event: 'onclick'
+		};
+		parent.postMessage(args, '*');
+	});
+}
+
+export function addControl(info: views.UIControl, container: any) {
+	if (info.type === ControlTypes.button) {
+		addButton(info, container);
+	}
+}

--- a/src/sql/base/browser/ui/uiControlLoader.js
+++ b/src/sql/base/browser/ui/uiControlLoader.js
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+let ControlBuilder;
+
+require(['sql/base/browser/ui/uiControlBuilder',
+	], function(value) {
+        ControlBuilder = value;
+        parent.postMessage('modulesReady', '*');
+    });
+
+    window.addEventListener('message', (args) => {
+        if (args && args.data && args.data.control && args.data.container) {
+            ControlBuilder.addControl(args.data, getContainer(args.data.container));
+        }
+});
+
+function getContainer(id) {
+    return document.getElementById(id);
+}

--- a/src/sql/data.d.ts
+++ b/src/sql/data.d.ts
@@ -1361,6 +1361,10 @@ declare module 'data' {
 		ipAddress: string;
 	}
 
+	export enum ControlTypes {
+		button = 0
+	}
+
 	export interface ModalDialog {
 		/**
 		 * Title of the webview.
@@ -1408,6 +1412,11 @@ declare module 'data' {
 		 * @param message Body of the message.
 		 */
 		postMessage(message: any): Thenable<any>;
+
+		/**
+		 * Adds a control to the dialog
+		 */
+		addControl(controlType: ControlTypes, containerId: string): any;
 	}
 
 	export namespace window {

--- a/src/sql/views.d.ts
+++ b/src/sql/views.d.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'views' {
+	import * as vscode from 'vscode';
+	import * as data from 'data';
+
+	export interface Button {
+		label: string;
+		readonly onClicked: vscode.Event<any>;
+	}
+
+	export interface UIControl {
+		type: data.ControlTypes,
+		control: any,
+		container: string,
+		id: number
+	}
+
+	export interface ControlEventArgs {
+		type: data.ControlTypes,
+		id: number,
+		event: string
+	}
+}

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -73,3 +73,7 @@ export enum ScriptOperation {
 	Execute = 5,
 	Alter = 6
 }
+
+export enum ControlTypes {
+	button = 0
+}

--- a/src/sql/workbench/api/electron-browser/mainThreadModalDialog.ts
+++ b/src/sql/workbench/api/electron-browser/mainThreadModalDialog.ts
@@ -40,6 +40,10 @@ export class MainThreadModalDialog implements MainThreadModalDialogShape {
 		dialog.onClosed(args => {
 			this._proxy.$onClosed(handle);
 		});
+
+		dialog.onLoaded(args => {
+			this._proxy.$onLoaded(handle);
+		});
 	}
 
 	$disposeDialog(handle: number): void {

--- a/src/sql/workbench/api/node/extHostModalDialog.ts
+++ b/src/sql/workbench/api/node/extHostModalDialog.ts
@@ -8,7 +8,42 @@ import { SqlMainContext, MainThreadModalDialogShape, ExtHostModalDialogsShape } 
 import { IMainContext } from 'vs/workbench/api/node/extHost.protocol';
 import * as vscode from 'vscode';
 import * as data from 'data';
+import * as views from 'views';
 import { Emitter } from 'vs/base/common/event';
+
+export enum ControlTypes {
+	button = 0
+}
+
+export class ExtButton implements views.Button {
+	public label: string;
+	private _containerId: string;
+	private _onClickedEmitter = new Emitter<any>();
+	private _events: {[name: string]: Emitter<any>} = {}
+
+	constructor() {
+		this._events["onclick"] = this._onClickedEmitter;
+	}
+
+	public set containerId(value: string) {
+		this._containerId = value;
+	}
+
+	public get containerId(): string {
+		return this._containerId;
+	}
+
+	public get onClicked(): vscode.Event<any> {
+		return this._onClickedEmitter.event;
+	}
+
+	public fireEvent(eventName: string) {
+		let event = this._events[eventName];
+		if (event) {
+			event.fire();
+		}
+	}
+}
 
 class ExtHostDialog implements data.ModalDialog {
 	private _title: string;
@@ -17,6 +52,7 @@ class ExtHostDialog implements data.ModalDialog {
 	private _closeTitle: string;
 	public onMessageEmitter = new Emitter<any>();
 	public onClosedEmitter = new Emitter<any>();
+	private _buttons : ExtButton[] = [];
 
 	constructor(
 		private readonly _proxy: MainThreadModalDialogShape,
@@ -80,6 +116,48 @@ class ExtHostDialog implements data.ModalDialog {
 	public get onClosed(): vscode.Event<any> {
 		return this.onClosedEmitter.event;
 	}
+
+	public addControl(controlType: ControlTypes, containerId: string): any {
+		switch (controlType) {
+			case ControlTypes.button:
+				return this.addButton(containerId);
+			default:
+				return undefined;
+		}
+	}
+
+	private loadButtons() {
+		let index = 0;
+		this._buttons.forEach(control => {
+			let uiControl: views.UIControl = {
+				type: ControlTypes.button,
+				control: control,
+				container: control.containerId,
+				id: index
+			};
+			this.postMessage(uiControl);
+			index = index + 1;
+		});
+	}
+
+	private addButton(containerId: string): views.Button {
+		let button = new ExtButton();
+		button.containerId = containerId;
+		this._buttons.push(button);
+		return button;
+	}
+
+	public onLoaded() {
+		this.loadButtons();
+	}
+
+	public onControlEvent(args: views.ControlEventArgs) {
+		let id: number = args.id;
+		let button = this._buttons[id];
+		if (button) {
+			button.fireEvent(args.event);
+		}
+	}
 }
 
 export class ExtHostModalDialogs implements ExtHostModalDialogsShape {
@@ -98,25 +176,30 @@ export class ExtHostModalDialogs implements ExtHostModalDialogsShape {
 	createDialog(
 		title: string
 	): data.ModalDialog {
-		console.log(title);
 		const handle = ExtHostModalDialogs._handlePool++;
 		this._proxy.$createDialog(handle);
 
 		const webview = new ExtHostDialog(this._proxy, handle);
 		this._webviews.set(handle, webview);
 		webview.title = title;
-		//webview.options = options;
-		//this._proxy.$show(handle);
 		return webview;
 	}
 
 	$onMessage(handle: number, message: any): void {
 		const webview = this._webviews.get(handle);
+		if (message && message.event) {
+			webview.onControlEvent(message);
+		}
 		webview.onMessageEmitter.fire(message);
 	}
 
 	$onClosed(handle: number): void {
 		const webview = this._webviews.get(handle);
 		webview.onClosedEmitter.fire();
+	}
+
+	$onLoaded(handle: number): void {
+		const webview = this._webviews.get(handle);
+		webview.onLoaded();
 	}
 }

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -257,6 +257,7 @@ export function createApiFactory(
 				TaskStatus: sqlExtHostTypes.TaskStatus,
 				TaskExecutionMode: sqlExtHostTypes.TaskExecutionMode,
 				ScriptOperation: sqlExtHostTypes.ScriptOperation,
+				ControlTypes: sqlExtHostTypes.ControlTypes,
 				window
 			};
 		}

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -433,4 +433,5 @@ export interface MainThreadModalDialogShape extends IDisposable {
 export interface ExtHostModalDialogsShape {
 	$onMessage(handle: number, message: any): void;
 	$onClosed(handle: number): void;
+	$onLoaded(handle: number): void;
 }

--- a/src/vs/workbench/parts/html/browser/webview.ts
+++ b/src/vs/workbench/parts/html/browser/webview.ts
@@ -40,6 +40,8 @@ export interface WebviewOptions {
 	// {{SQL CARBON EDIT}}
 	enableWrappedPostMessage?: boolean;
 	hideFind?: boolean;
+	loadModules?: boolean;
+	appRoot?: string;
 }
 
 export default class Webview {


### PR DESCRIPTION
- Loading the amd modules inside the webview
- Added API to add controls to a dialog (for now only button is supported)

API call example in extension:

```
	          let dialog = data.window.createDialog('test dialog');
	          dialog.html = `
			<html>
				<body>
					<div id="testPanel"></div>
				</body>
			</html>
			`;

		  dialog.onMessage(args => {
			dialog.postMessage('message from extension');

		  });

		  let button: views.Button = dialog.addControl(data.ControlTypes.button, "testPanel");
		  button.label = 'test button';
		  button.onClicked(() =>{
			console.info('Button clicked event!');
			dialog.close();
		  });
```

TODO: 

- add comments for public method and API
- add tests
- test in mac and linux
- test in production