### PR TITLE
Fixes the 'undefined' in connection tree when capabilities not loaded

### DIFF
--- a/src/sql/parts/connection/common/connectionConfig.ts
+++ b/src/sql/parts/connection/common/connectionConfig.ts
@@ -41,6 +41,11 @@ export class ConnectionConfig implements IConnectionConfig {
 	) {
 		this._providerCapabilitiesMap = {};
 		this.setCachedMetadata(cachedMetadata);
+		if (this._capabilitiesService && this._capabilitiesService.onCapabilitiesReady()) {
+			this._capabilitiesService.onCapabilitiesReady().then(() => {
+				this.setCachedMetadata(this._capabilitiesService.getCapabilities());
+			});
+		}
 	}
 
 	public setCachedMetadata(cachedMetadata: data.DataProtocolServerCapabilities[]): void {
@@ -102,8 +107,10 @@ export class ConnectionConfig implements IConnectionConfig {
 		} else {
 			let capabilities = this._capabilitiesService.getCapabilities();
 			if (capabilities) {
+				console.info('capabilities ' + capabilities.length);
 				let providerCapabilities = capabilities.find(c => c.providerName === providerName);
 				if (providerCapabilities) {
+					console.info('capabilities 2 ' + providerCapabilities);
 					this.updateCapabilitiesCache(providerName, providerCapabilities);
 					return providerCapabilities;
 				} else {

--- a/src/sql/parts/connection/common/connectionConfig.ts
+++ b/src/sql/parts/connection/common/connectionConfig.ts
@@ -107,10 +107,8 @@ export class ConnectionConfig implements IConnectionConfig {
 		} else {
 			let capabilities = this._capabilitiesService.getCapabilities();
 			if (capabilities) {
-				console.info('capabilities ' + capabilities.length);
 				let providerCapabilities = capabilities.find(c => c.providerName === providerName);
 				if (providerCapabilities) {
-					console.info('capabilities 2 ' + providerCapabilities);
 					this.updateCapabilitiesCache(providerName, providerCapabilities);
 					return providerCapabilities;
 				} else {

--- a/src/sql/parts/connection/common/connectionProfileGroup.ts
+++ b/src/sql/parts/connection/common/connectionProfileGroup.ts
@@ -79,9 +79,12 @@ export class ConnectionProfileGroup implements IConnectionProfileGroup {
 		return false;
 	}
 
+	/**
+	 * Returns true if all connections in the tree have valid options using the correct capabilities
+	 */
 	public get hasValidConnections(): boolean {
 		if (this.connections) {
-			let invalidConnections = this.connections.find(c => c.serverCapabilities === undefined);
+			let invalidConnections = this.connections.find(c => !c.isConnectionOptionsValid);
 			if (invalidConnections !== undefined) {
 				return false;
 			} else {

--- a/src/sql/parts/connection/common/providerConnectionInfo.ts
+++ b/src/sql/parts/connection/common/providerConnectionInfo.ts
@@ -104,6 +104,23 @@ export class ProviderConnectionInfo implements data.ConnectionInfo {
 		this.options[name] = value;
 	}
 
+	/**
+	 * Returns the title of the connection
+	 */
+	public get title(): string {
+		let databaseName = this.databaseName ? this.databaseName : '<default>';
+		let userName = this.userName ? this.userName : 'Windows Authentication';
+		let label = this.serverName + ', ' + databaseName + ' (' + userName + ')';
+		return label;
+	}
+
+	/**
+	 * Returns true if the capabilities and options are loaded correctly
+	 */
+	public get isConnectionOptionsValid(): boolean {
+		return this.serverCapabilities && this.title.indexOf('undefined') < 0;
+	}
+
 	public isPasswordRequired(): boolean {
 		let optionMetadata = this._serverCapabilities.connectionProvider.options.find(
 			option => option.specialValueType === ConnectionOptionSpecialType.password);

--- a/src/sql/parts/registeredServer/viewlet/serverTreeRenderer.ts
+++ b/src/sql/parts/registeredServer/viewlet/serverTreeRenderer.ts
@@ -8,6 +8,7 @@ import 'vs/css!sql/media/objectTypes/objecttypes';
 import 'vs/css!sql/media/icons/common-icons';
 
 import * as dom from 'vs/base/browser/dom';
+import { localize } from 'vs/nls';
 import { ConnectionProfileGroup } from 'sql/parts/connection/common/connectionProfileGroup';
 import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -146,9 +147,10 @@ export class ServerTreeRenderer implements IRenderer {
 			}
 		}
 
-		let databaseName = connection.databaseName ? connection.databaseName : '<default>';
-		let userName = connection.userName ? connection.userName : "Windows Authentication";
-		let label = connection.serverName + ', ' + databaseName + ' (' + userName + ')';
+		let label = connection.title;
+		if (!connection.isConnectionOptionsValid) {
+			label = localize('loading', 'Loading ...');
+		}
 
 		templateData.label.textContent = label;
 		templateData.root.title = label;

--- a/src/sql/parts/registeredServer/viewlet/serverTreeRenderer.ts
+++ b/src/sql/parts/registeredServer/viewlet/serverTreeRenderer.ts
@@ -149,7 +149,7 @@ export class ServerTreeRenderer implements IRenderer {
 
 		let label = connection.title;
 		if (!connection.isConnectionOptionsValid) {
-			label = localize('loading', 'Loading ...');
+			label = localize('loading', 'Loading...');
 		}
 
 		templateData.label.textContent = label;

--- a/src/sql/parts/registeredServer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/registeredServer/viewlet/serverTreeView.ts
@@ -59,6 +59,12 @@ export class ServerTreeView {
 			this);
 		this._treeSelectionHandler = this._instantiationService.createInstance(TreeSelectionHandler);
 		this._onSelectionOrFocusChange = new Emitter();
+		if (this._capabilitiesService) {
+			this._capabilitiesService.onCapabilitiesReady().then(() => {
+				this.refreshTree();
+				this._treeSelectionHandler.onTreeActionStateChange(false);
+			});
+		}
 	}
 
 	/**
@@ -134,23 +140,9 @@ export class ServerTreeView {
 			self.refreshTree();
 			let root = <ConnectionProfileGroup>this._tree.getInput();
 			if (root && !root.hasValidConnections) {
-
 				this._treeSelectionHandler.onTreeActionStateChange(true);
-				if (this._capabilitiesService) {
-					this._capabilitiesService.onCapabilitiesReady().then(() => {
-						self.refreshTree();
-						this._treeSelectionHandler.onTreeActionStateChange(false);
-						resolve();
-
-					}, error => {
-						reject(error);
-					});
-				} else {
-					self.refreshTree();
-					resolve();
-				}
+				resolve();
 			} else {
-
 				resolve();
 			}
 		});


### PR DESCRIPTION
fixes #554

These are the things I fixed this PR:

1. If any of the connections in the tree has invalid title ('undefined' in the label), the label is changed to 'Loading ...'  
2. Updating the cached capabilities when the capabilities service is loaded.  
3. Refreshing the tree when capabilities service has the metadata ready so the tree node with "loading ..." in the label will change to the connection label

When capabilities cache is empty or metadata is different, the tree would look like this:
![image](https://user-images.githubusercontent.com/17187348/35875369-e3d84a0e-0b23-11e8-96c8-3eac7324ea5d.png)

And after the capabilities service is ready and has the updated metadata, the tree would refresh to display the correct labels 
