### PR TITLE
Fix service downloader in lab build scripts

### DIFF
--- a/extensions-modules/src/languageservice/serviceDownloadProvider.ts
+++ b/extensions-modules/src/languageservice/serviceDownloadProvider.ts
@@ -99,7 +99,7 @@ export default class ServiceDownloadProvider {
 		if (path.isAbsolute(installDirFromConfig)) {
 			basePath = installDirFromConfig;
 		} else if (this._fromBuild) {
-			basePath = path.join(__dirname, '../../../../../extensions/' + extensionConfigSectionName + '/' + installDirFromConfig);
+			basePath = path.join(__dirname, '../../../extensions/' + extensionConfigSectionName + '/' + installDirFromConfig);
 		} else {
 			// The path from config is relative to the out folder
 			basePath = path.join(__dirname, '../../../../' + extensionConfigSectionName + '/' +  installDirFromConfig);


### PR DESCRIPTION
Fixes this error in lab builds `failed to delete the install folder error: Error: Cannot delete files/folders outside the current working directory.`