### PR TITLE
Redo changes for object explorer arrow colors

### DIFF
--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -77,6 +77,16 @@
 	background-image: url('expanded.svg');
 }
 
+/* {{SQL CARBON EDIT}} -- Display a high-contrast arrow when an expandable item is selected and expanded */
+.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected.expanded > .content:before {
+	background-image: url('expanded-hc.svg');
+}
+
+/* {{SQL CARBON EDIT}} -- Display a high-contrast arrow when an expandable item is selected and collapsed */
+.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected > .content:before {
+	background-image: url('collapsed-hc.svg');
+}
+
 .monaco-tree .monaco-tree-rows > .monaco-tree-row.has-children.loading > .content:before {
 	background-image: url('loading.svg');
 }

--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -78,12 +78,12 @@
 }
 
 /* {{SQL CARBON EDIT}} -- Display a high-contrast arrow when an expandable item is selected and expanded */
-.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected.expanded > .content:before {
+.monaco-tree.focused .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected.expanded > .content:before {
 	background-image: url('expanded-hc.svg');
 }
 
 /* {{SQL CARBON EDIT}} -- Display a high-contrast arrow when an expandable item is selected and collapsed */
-.monaco-tree .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected > .content:before {
+.monaco-tree.focused .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected > .content:before {
 	background-image: url('collapsed-hc.svg');
 }
 


### PR DESCRIPTION
The changes that Aditya made in #425 and I made in a later PR to color the object explorer arrows correctly when in light theme disappeared during the VS Code merge, likely because we forgot to mark them with "carbon edit" comments. This PR puts back the rules we had added. 

This change also updates the rule to only show the light arrow when OE has focus
