### PR TITLE
Fix some minor connection db dropdown bugs

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionController.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionController.ts
@@ -60,6 +60,8 @@ export class ConnectionController implements IConnectionComponentController {
 		tempProfile.authenticationType = authenticationType;
 		tempProfile.userName = userName;
 		tempProfile.password = password;
+		tempProfile.groupFullName = '';
+		tempProfile.saveProfile = false;
 		let uri = this._connectionManagementService.getConnectionId(tempProfile);
 		return new Promise<string[]>((resolve, reject) => {
 			if (this._databaseCache.has(uri)) {
@@ -77,10 +79,9 @@ export class ConnectionController implements IConnectionComponentController {
 								this._databaseCache.set(uri, result.databaseNames);
 								resolve(result.databaseNames);
 							} else {
-								this._databaseCache.set(uri, null);
 								reject();
 							}
-						})
+						});
 					} else {
 						reject(connResult.errorMessage);
 					}
@@ -114,6 +115,7 @@ export class ConnectionController implements IConnectionComponentController {
 	}
 
 	public showUiComponent(container: HTMLElement): void {
+		this._databaseCache = new Map<string, string[]>();
 		this._connectionWidget.createConnectionWidget(container);
 	}
 

--- a/src/sql/parts/connection/connectionDialog/connectionController.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionController.ts
@@ -79,6 +79,7 @@ export class ConnectionController implements IConnectionComponentController {
 								this._databaseCache.set(uri, result.databaseNames);
 								resolve(result.databaseNames);
 							} else {
+								this._databaseCache.set(uri, null);
 								reject();
 							}
 						});


### PR DESCRIPTION
In testing I came across a few bugs with the database selection dropdown:
- The cache was not cleared when the connection dialog was closed and reopened
- The result was cached in the else branch for `if (result && result.databaseName)`, which is an error condition and shouldn't cause a cache (Edit: Discussed this with Aditya and it's not a bug - useful if the list database request takes a long time but ultimately always fails, for example)
- Because `saveProfile` defaults to true and `groupFullName` defaults to undefined, the connectionStore would attempt to compare the profile to other saved profiles and throw an error if one matched (because the group name was undefined, which it doesn't expect when saving a profile), causing the connection to fail