### PR TITLE
Bump SQL Tools Service version for OE default db fix

### DIFF
--- a/extensions/mssql/client/src/config.json
+++ b/extensions/mssql/client/src/config.json
@@ -1,7 +1,7 @@
 {
 	"service": {
 		"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-		"version": "1.4.0-alpha.9",
+		"version": "1.4.0-alpha.10",
 			"downloadFileNames": {
 			"Windows_86": "win-x86-netcoreapp2.0.zip",
 			"Windows_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
This is the SQL Tools Service update for the fix to #649 

The SQL Tools Service changes were covered in this PR: https://github.com/Microsoft/sqltoolsservice/pull/583