### PR TITLE
 Refactor tab contribution to support content type

### DIFF
--- a/src/sql/parts/dashboard/common/dashboardPage.component.html
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.html
@@ -12,9 +12,9 @@
 		</div>
 		<panel style="flex: 1 1 auto; position: relative" class="dashboard-panel" (onTabChange)="handleTabChange($event)" (onTabClose)="handleTabClose($event)" [actions]="panelActions">
 			<tab *ngFor="let tab of tabs" [title]="tab.title" class="fullsize" [identifier]="tab.id" [canClose]="tab.canClose" [actions]="tab.actions">
-				<dashboard-webview-tab *ngIf="tab.isWebview" [tab]="tab">
+				<dashboard-webview-tab *ngIf="isWebviewContentType(tab)" [tab]="tab">
 				</dashboard-webview-tab>
-				<dashboard-widget-tab *ngIf="!tab.isWebview" [tab]="tab">
+				<dashboard-widget-tab *ngIf="isWidgetsContentType(tab)" [tab]="tab">
 				</dashboard-widget-tab>
 			</tab>
 		</panel>

--- a/src/sql/parts/dashboard/common/dashboardPage.component.html
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.html
@@ -12,9 +12,9 @@
 		</div>
 		<panel style="flex: 1 1 auto; position: relative" class="dashboard-panel" (onTabChange)="handleTabChange($event)" (onTabClose)="handleTabClose($event)" [actions]="panelActions">
 			<tab *ngFor="let tab of tabs" [title]="tab.title" class="fullsize" [identifier]="tab.id" [canClose]="tab.canClose" [actions]="tab.actions">
-				<dashboard-webview-tab *ngIf="isWebviewContentType(tab)" [tab]="tab">
+				<dashboard-webview-tab *ngIf="getContentType(tab) === 'webview-tab'" [tab]="tab">
 				</dashboard-webview-tab>
-				<dashboard-widget-tab *ngIf="isWidgetsContentType(tab)" [tab]="tab">
+				<dashboard-widget-tab *ngIf="getContentType(tab) === 'widgets-tab'" [tab]="tab">
 				</dashboard-widget-tab>
 			</tab>
 		</panel>

--- a/src/sql/parts/dashboard/common/dashboardPage.component.ts
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.ts
@@ -290,12 +290,8 @@ export abstract class DashboardPage extends Disposable implements OnDestroy {
 	}
 
 
-	private isWebviewContentType(tab: TabConfig): boolean {
-		return tab.content && Object.keys(tab.content)[0] === WEBVIEW_TABS;
-	}
-
-	private isWidgetsContentType(tab: TabConfig): boolean {
-		return tab.content && Object.keys(tab.content)[0] === WIDGETS_TABS;
+	private getContentType(tab: TabConfig): string {
+		return tab.content ? Object.keys(tab.content)[0] : '';
 	}
 
 	private addNewTab(tab: TabConfig): void {

--- a/src/sql/parts/dashboard/common/dashboardPage.component.ts
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.ts
@@ -22,6 +22,9 @@ import { TabComponent } from 'sql/base/browser/ui/panel/tab.component';
 import { IBootstrapService, BOOTSTRAP_SERVICE_ID } from 'sql/services/bootstrap/bootstrapService';
 import { AngularEventType, IAngularEvent } from 'sql/services/angularEventing/angularEventingService';
 import { DashboardTab } from 'sql/parts/dashboard/common/interfaces';
+import { error } from 'sql/base/common/log';
+import { WIDGETS_TABS } from 'sql/parts/dashboard/tabs/dashboardWidgetTab.contribution';
+import { WEBVIEW_TABS } from 'sql/parts/dashboard/tabs/dashboardWebviewTab.contribution';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 import * as types from 'vs/base/common/types';
@@ -184,7 +187,7 @@ export abstract class DashboardPage extends Disposable implements OnDestroy {
 			id: 'homeTab',
 			publisher: undefined,
 			title: this.homeTabTitle,
-			widgets: homeWidgets,
+			content: { 'widgets-tab': homeWidgets },
 			context: this.context,
 			originalConfig: this._originalConfig,
 			editable: true,
@@ -246,15 +249,21 @@ export abstract class DashboardPage extends Disposable implements OnDestroy {
 	private loadNewTabs(dashboardTabs: IDashboardTab[]) {
 		if (dashboardTabs && dashboardTabs.length > 0) {
 			let selectedTabs = dashboardTabs.map(v => {
-				if (v.widgets) {
-					let configs = v.widgets;
+
+				if (Object.keys(v.content).length !== 1) {
+					error('Exactly 1 widget must be defined per space');
+				}
+
+				let key = Object.keys(v.content)[0];
+				if (key === WIDGETS_TABS) {
+					let configs = <WidgetConfig[]>Object.values(v.content)[0];
 					this._configModifiers.forEach(cb => {
 						configs = cb.apply(this, [configs]);
 					});
 					this._gridModifiers.forEach(cb => {
 						configs = cb.apply(this, [configs]);
 					});
-					return { id: v.id, title: v.title, widgets: configs, alwaysShow: v.alwaysShow };
+					return { id: v.id, title: v.title, content: { 'widgets-tab': configs }, alwaysShow: v.alwaysShow };
 				}
 				return v;
 			}).map(v => {
@@ -278,6 +287,15 @@ export abstract class DashboardPage extends Disposable implements OnDestroy {
 				this._panel.selectTab(selectedTabs.pop().id);
 			});
 		}
+	}
+
+
+	private isWebviewContentType(tab: TabConfig): boolean {
+		return tab.content && Object.keys(tab.content)[0]===WEBVIEW_TABS;
+	}
+
+	private isWidgetsContentType(tab: TabConfig): boolean {
+		return tab.content && Object.keys(tab.content)[0]===WIDGETS_TABS;
 	}
 
 	private addNewTab(tab: TabConfig): void {

--- a/src/sql/parts/dashboard/common/dashboardPage.component.ts
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.ts
@@ -291,11 +291,11 @@ export abstract class DashboardPage extends Disposable implements OnDestroy {
 
 
 	private isWebviewContentType(tab: TabConfig): boolean {
-		return tab.content && Object.keys(tab.content)[0]===WEBVIEW_TABS;
+		return tab.content && Object.keys(tab.content)[0] === WEBVIEW_TABS;
 	}
 
 	private isWidgetsContentType(tab: TabConfig): boolean {
-		return tab.content && Object.keys(tab.content)[0]===WIDGETS_TABS;
+		return tab.content && Object.keys(tab.content)[0] === WIDGETS_TABS;
 	}
 
 	private addNewTab(tab: TabConfig): void {

--- a/src/sql/parts/dashboard/tabs/dashboardWebviewTab.contribution.ts
+++ b/src/sql/parts/dashboard/tabs/dashboardWebviewTab.contribution.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { IJSONSchema } from 'vs/base/common/jsonSchema';
+import * as nls from 'vs/nls';
+
+import { registerTabContent } from 'sql/platform/dashboard/common/dashboardRegistry';
+
+export const WEBVIEW_TABS = 'webview-tab';
+
+let webviewSchema: IJSONSchema = {
+	type: 'null',
+	description: nls.localize('dashboard.tab.widgets', "The list of widgets that will be displayed in this tab."),
+	default: null
+};
+
+registerTabContent(WEBVIEW_TABS, webviewSchema);

--- a/src/sql/parts/dashboard/tabs/dashboardWidgetTab.component.html
+++ b/src/sql/parts/dashboard/tabs/dashboardWidgetTab.component.html
@@ -4,7 +4,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 -->
-<div [ngGrid]="gridConfig">
-	<dashboard-widget-wrapper *ngFor="let widget of tab.widgets" [(ngGridItem)]="widget.gridItemConfig" [_config]="widget">
+<div [ngGrid]="gridConfig" *ngIf="widgets" >
+	<dashboard-widget-wrapper *ngFor="let widget of widgets" [(ngGridItem)]="widget.gridItemConfig" [_config]="widget">
 	</dashboard-widget-wrapper>
 </div>

--- a/src/sql/parts/dashboard/tabs/dashboardWidgetTab.contribution.ts
+++ b/src/sql/parts/dashboard/tabs/dashboardWidgetTab.contribution.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { IJSONSchema } from 'vs/base/common/jsonSchema';
+import * as nls from 'vs/nls';
+
+import { generateDashboardWidgetSchema } from 'sql/parts/dashboard/pages/dashboardPageContribution';
+import { registerTabContent } from 'sql/platform/dashboard/common/dashboardRegistry';
+
+export const WIDGETS_TABS = 'widgets-tab';
+
+let widgetsSchema: IJSONSchema = {
+	type: 'array',
+	description: nls.localize('dashboard.tab.content.widgets', "The list of widgets that will be displayed in this tab."),
+	items: generateDashboardWidgetSchema(undefined, true)
+};
+
+registerTabContent(WIDGETS_TABS, widgetsSchema);

--- a/src/sql/platform/dashboard/common/dashboardRegistry.ts
+++ b/src/sql/platform/dashboard/common/dashboardRegistry.ts
@@ -82,7 +82,7 @@ class DashboardRegistry implements IDashboardRegistry {
 	 * @param id id of the widget
 	 * @param schema config schema of the widget
 	 */
-	public registerTabContent(id: string, schema: IJSONSchema ): void {
+	public registerTabContent(id: string, schema: IJSONSchema): void {
 		this._dashboardTabContentSchemaProperties[id] = schema;
 	}
 

--- a/src/vs/workbench/workbench.main.ts
+++ b/src/vs/workbench/workbench.main.ts
@@ -159,6 +159,9 @@ import 'sql/parts/dashboard/widgets/explorer/explorerWidget.contribution';
 import 'sql/parts/dashboard/widgets/tasks/tasksWidget.contribution';
 import 'sql/parts/dashboard/widgets/webview/webviewWidget.contribution';
 import 'sql/parts/dashboard/dashboardConfig.contribution';
+/* Tabs */
+import 'sql/parts/dashboard/tabs/dashboardWebviewTab.contribution';
+import 'sql/parts/dashboard/tabs/dashboardWidgetTab.contribution';
 import 'sql/parts/dashboard/common/dashboardTab.contribution';
 /* Tasks */
 import 'sql/workbench/common/actions.contribution';


### PR DESCRIPTION
Refactor tab contribution to support different tab content types:

Example for widgets tab

```

 "dashboard.tabs": {
      "id": "test-tab2",
      "title": "test-tab2",
      "provider": "MSSQL",
      "description": "The test-tab2 uses the ESLint library.",
      "edition": 4,
      "content": {
        "widgets-tab": [
          {
            "widget": {
              "query-data-store-db-insight": {
              }
            }
          },
          {
            "widget": {
              "explorer-widget": {
              }
            }
          }
        ]
      },
      "alwaysShow": true
    }

```

Example for webview tab
```

"dashboard.tabs": {
      "id": "test-tab2",
      "title": "test-tab2",
      "provider": "MSSQL",
      "description": "The test-tab2 uses the ESLint library.",
      "edition": 4,
      "content": {
        "webview-tab": null
      },
      "alwaysShow": true
    }

```


