### PR TITLE
Fix rendering tab issue

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.component.ts
+++ b/src/sql/base/browser/ui/panel/panel.component.ts
@@ -126,7 +126,8 @@ export class PanelComponent implements AfterContentInit, OnInit, OnChanges, OnDe
 				}
 			});
 
-			if (this._activeTab && tab.identifier === this._activeTab.identifier) {
+			if (this._activeTab && tab === this._activeTab) {
+				this.onTabChange.emit(tab);
 				return;
 			}
 


### PR DESCRIPTION
When you switch between database dashboards and server dashboard, the home tab is empty. This is because the tab id is the same but the content of the tab is different. 