### PR TITLE
bump versions to remove semver warnings

### DIFF
--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -390,11 +390,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@git://github.com/Microsoft/sqlops-dataprotocolclient.git#release":
-  version "1.0.0"
-  resolved "git://github.com/Microsoft/sqlops-dataprotocolclient.git#739fdf93140c3cb1bc882076bf11765b187bf8a3"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.0":
+  version "0.1.0"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/6bd33f43b23227eb01424418a8740e6c0b20578e"
   dependencies:
-    sqlops "git://github.com/anthonydresser/vscode-extension-vscode"
+    sqlops "github:anthonydresser/vscode-extension-vscode#1.1.11"
     vscode "1.1.5"
     vscode-languageclient "3.5.0"
 
@@ -587,7 +587,7 @@ extend@~1.2.1:
 "extensions-modules@file:../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "git://github.com/Microsoft/sqlops-dataprotocolclient.git#release"
+    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#0.1.0"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"
@@ -1905,9 +1905,9 @@ split@0.3:
   dependencies:
     through "2"
 
-"sqlops@git://github.com/anthonydresser/vscode-extension-vscode":
-  version "1.1.10"
-  resolved "git://github.com/anthonydresser/vscode-extension-vscode#96cc0758d2528a33a12d73894a6d40c8bfb15ca1"
+"sqlops@github:anthonydresser/vscode-extension-vscode#1.1.11":
+  version "1.1.11"
+  resolved "https://codeload.github.com/anthonydresser/vscode-extension-vscode/tar.gz/06c604d7f6ab9642a678d86a1b93412da37b01cc"
   dependencies:
     glob "^7.1.2"
     gulp-chmod "^2.0.0"

--- a/extensions-modules/package.json
+++ b/extensions-modules/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Shared modules for Carbon extensions",
   "dependencies": {
-    "dataprotocol-client": "git://github.com/Microsoft/sqlops-dataprotocolclient.git#0.1.0",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.1.0",
     "decompress": "^4.2.0",
     "fs-extra-promise": "^1.0.1",
     "http-proxy-agent": "^2.0.0",

--- a/extensions-modules/package.json
+++ b/extensions-modules/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Shared modules for Carbon extensions",
   "dependencies": {
-    "dataprotocol-client": "git://github.com/Microsoft/sqlops-dataprotocolclient.git#release",
+    "dataprotocol-client": "git://github.com/Microsoft/sqlops-dataprotocolclient.git#0.1.0",
     "decompress": "^4.2.0",
     "fs-extra-promise": "^1.0.1",
     "http-proxy-agent": "^2.0.0",

--- a/extensions-modules/yarn.lock
+++ b/extensions-modules/yarn.lock
@@ -382,11 +382,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@git://github.com/Microsoft/sqlops-dataprotocolclient.git#0.1.0":
-  version "1.0.0"
-  resolved "git://github.com/Microsoft/sqlops-dataprotocolclient.git#ace880978ea414dc2a1f012855b9a2e1cf6136af"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.0":
+  version "0.1.0"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/6bd33f43b23227eb01424418a8740e6c0b20578e"
   dependencies:
-    sqlops "git://github.com/anthonydresser/vscode-extension-vscode#1.1.11"
+    sqlops "github:anthonydresser/vscode-extension-vscode#1.1.11"
     vscode "1.1.5"
     vscode-languageclient "3.5.0"
 
@@ -2204,9 +2204,9 @@ split@0.3:
   dependencies:
     through "2"
 
-"sqlops@git://github.com/anthonydresser/vscode-extension-vscode#1.1.11":
-  version "1.1.10"
-  resolved "git://github.com/anthonydresser/vscode-extension-vscode#bccac9662f2d9723dc6a9ca7d9372e13f62627b0"
+"sqlops@github:anthonydresser/vscode-extension-vscode#1.1.11":
+  version "1.1.11"
+  resolved "https://codeload.github.com/anthonydresser/vscode-extension-vscode/tar.gz/06c604d7f6ab9642a678d86a1b93412da37b01cc"
   dependencies:
     glob "^7.1.2"
     gulp-chmod "^2.0.0"

--- a/extensions-modules/yarn.lock
+++ b/extensions-modules/yarn.lock
@@ -382,11 +382,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@git://github.com/Microsoft/sqlops-dataprotocolclient.git#release":
+"dataprotocol-client@git://github.com/Microsoft/sqlops-dataprotocolclient.git#0.1.0":
   version "1.0.0"
-  resolved "git://github.com/Microsoft/sqlops-dataprotocolclient.git#739fdf93140c3cb1bc882076bf11765b187bf8a3"
+  resolved "git://github.com/Microsoft/sqlops-dataprotocolclient.git#ace880978ea414dc2a1f012855b9a2e1cf6136af"
   dependencies:
-    sqlops "git://github.com/anthonydresser/vscode-extension-vscode"
+    sqlops "git://github.com/anthonydresser/vscode-extension-vscode#1.1.11"
     vscode "1.1.5"
     vscode-languageclient "3.5.0"
 
@@ -2204,9 +2204,9 @@ split@0.3:
   dependencies:
     through "2"
 
-"sqlops@git://github.com/anthonydresser/vscode-extension-vscode":
+"sqlops@git://github.com/anthonydresser/vscode-extension-vscode#1.1.11":
   version "1.1.10"
-  resolved "git://github.com/anthonydresser/vscode-extension-vscode#96cc0758d2528a33a12d73894a6d40c8bfb15ca1"
+  resolved "git://github.com/anthonydresser/vscode-extension-vscode#bccac9662f2d9723dc6a9ca7d9372e13f62627b0"
   dependencies:
     glob "^7.1.2"
     gulp-chmod "^2.0.0"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -323,11 +323,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@git://github.com/Microsoft/sqlops-dataprotocolclient.git#release":
-  version "1.0.0"
-  resolved "git://github.com/Microsoft/sqlops-dataprotocolclient.git#739fdf93140c3cb1bc882076bf11765b187bf8a3"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.0":
+  version "0.1.0"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/6bd33f43b23227eb01424418a8740e6c0b20578e"
   dependencies:
-    sqlops "git://github.com/anthonydresser/vscode-extension-vscode"
+    sqlops "github:anthonydresser/vscode-extension-vscode#1.1.11"
     vscode "1.1.5"
     vscode-languageclient "3.5.0"
 
@@ -507,7 +507,7 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
 "extensions-modules@file:../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "git://github.com/Microsoft/sqlops-dataprotocolclient.git#release"
+    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#0.1.0"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"
@@ -1749,9 +1749,9 @@ split@0.3:
   dependencies:
     through "2"
 
-"sqlops@git://github.com/anthonydresser/vscode-extension-vscode":
-  version "1.1.10"
-  resolved "git://github.com/anthonydresser/vscode-extension-vscode#96cc0758d2528a33a12d73894a6d40c8bfb15ca1"
+"sqlops@github:anthonydresser/vscode-extension-vscode#1.1.11":
+  version "1.1.11"
+  resolved "https://codeload.github.com/anthonydresser/vscode-extension-vscode/tar.gz/06c604d7f6ab9642a678d86a1b93412da37b01cc"
   dependencies:
     glob "^7.1.2"
     gulp-chmod "^2.0.0"


### PR DESCRIPTION
semver was complaining cause it didn't have any numbers to work with. so made initial version numbers for the affected repos. There are no functional changes, just added release numbers to what we were already pulling.

EDIT: unfortunately this won't remove the warnings. It won't be fixable until we convert the sqlops extension and the dataprotocol node repos into npm packages.