### PR TITLE
Add shortcut for toggle results pane

### DIFF
--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -132,15 +132,18 @@ actionRegistry.registerWorkbenchAction(
 		RefreshIntellisenseKeyboardAction.LABEL
 	);
 
-actionRegistry.registerWorkbenchAction(
-		new SyncActionDescriptor(
-			ToggleQueryResultsKeyboardAction,
-			ToggleQueryResultsKeyboardAction.ID,
-			ToggleQueryResultsKeyboardAction.LABEL
-		),
-		ToggleQueryResultsKeyboardAction.LABEL
-	);
 // Grid actions
+
+actionRegistry.registerWorkbenchAction(
+	new SyncActionDescriptor(
+		ToggleQueryResultsKeyboardAction,
+		ToggleQueryResultsKeyboardAction.ID,
+		ToggleQueryResultsKeyboardAction.LABEL,
+		{ primary:KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KEY_R },
+		QueryEditorVisibleCondition
+	),
+	ToggleQueryResultsKeyboardAction.LABEL
+);
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: gridActions.GRID_COPY_ID,

--- a/src/sql/parts/taskHistory/common/taskHistory.contribution.ts
+++ b/src/sql/parts/taskHistory/common/taskHistory.contribution.ts
@@ -107,7 +107,7 @@ registry.registerWorkbenchAction(
 		TaskHistoryViewletAction.ID,
 		TaskHistoryViewletAction.LABEL,
 		{ primary: KeyMod.CtrlCmd | KeyCode.KEY_T }),
-	'View: Show Task Histry',
+	'View: Show Task History',
 	localize('view', "View")
 );
 


### PR DESCRIPTION
This is commonly requested - we should have a keyboard shortcut for this by default. Using `Ctrl+Shift+R` since `Ctrl+R` is already bound.

On a separate note we should consider an "SSMS Keybindings" extension with the SSMS-native bindings (and the keys they hijack bound to a new value instead). This seems like an easy candidate as we work towards extensibility.