### PR TITLE
Tab contribution support both inline container and registered container

### DIFF
--- a/src/sql/parts/dashboard/common/dashboardHelper.ts
+++ b/src/sql/parts/dashboard/common/dashboardHelper.ts
@@ -195,7 +195,7 @@ export function filterConfigs<T extends { provider?: string | string[], edition?
  */
 export function getDashboardContainer(container: object): object {
 	if (Object.keys(container).length !== 1) {
-		error(nls.localize('moreThanOneDashboardContainersError','Exactly 1 dashboard container must be defined per space'));
+		error(nls.localize('moreThanOneDashboardContainersError', 'Exactly 1 dashboard container must be defined per space'));
 	}
 
 	let key = Object.keys(container)[0];
@@ -203,7 +203,7 @@ export function getDashboardContainer(container: object): object {
 	if (!containerTypeFound) {
 		let dashboardContainer = dashboardcontainerRegistry.getRegisteredContainer(key);
 		if (!dashboardContainer) {
-			error(nls.localize('unknownDashboardContainerError','The specified dashboard container is unknown.'));
+			error(nls.localize('unknownDashboardContainerError', 'The specified dashboard container is unknown.'));
 		} else {
 			container = dashboardContainer.container;
 		}

--- a/src/sql/parts/dashboard/common/dashboardHelper.ts
+++ b/src/sql/parts/dashboard/common/dashboardHelper.ts
@@ -193,9 +193,9 @@ export function filterConfigs<T extends { provider?: string | string[], edition?
  * Get registered container if it is specified as the key
  * @param container dashboard container
  */
-export function getOrSetContainer(container: object): object {
+export function getDashboardContainer(container: object): object {
 	if (Object.keys(container).length !== 1) {
-		error('Exactly 1 dashboard container must be defined per space');
+		error(nls.localize('moreThanOneDashboardContainersError','Exactly 1 dashboard container must be defined per space'));
 	}
 
 	let key = Object.keys(container)[0];
@@ -203,7 +203,7 @@ export function getOrSetContainer(container: object): object {
 	if (!containerTypeFound) {
 		let dashboardContainer = dashboardcontainerRegistry.getRegisteredContainer(key);
 		if (!dashboardContainer) {
-			error('The specified dashboard container is unknown.');
+			error(nls.localize('unknownDashboardContainerError','The specified dashboard container is unknown.'));
 		} else {
 			container = dashboardContainer.container;
 		}

--- a/src/sql/parts/dashboard/common/dashboardPage.component.ts
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.ts
@@ -241,7 +241,7 @@ export abstract class DashboardPage extends Disposable implements OnDestroy {
 	private loadNewTabs(dashboardTabs: IDashboardTab[]) {
 		if (dashboardTabs && dashboardTabs.length > 0) {
 			let selectedTabs = dashboardTabs.map(v => {
-				let container = dashboardHelper.getOrSetContainer(v.container);
+				let container = dashboardHelper.getDashboardContainer(v.container);
 				let key = Object.keys(container)[0];
 
 				if (key === WIDGETS_CONTAINER || key === GRID_CONTAINER) {

--- a/src/sql/parts/dashboard/common/dashboardTab.contribution.ts
+++ b/src/sql/parts/dashboard/common/dashboardTab.contribution.ts
@@ -6,7 +6,8 @@ import { IExtensionPointUser, ExtensionsRegistry } from 'vs/platform/extensions/
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';
 
-import { registerTab, generateTabContentSchemaProperties } from 'sql/platform/dashboard/common/dashboardRegistry';
+import { registerTab } from 'sql/platform/dashboard/common/dashboardRegistry';
+import { generateContainerTypeSchemaProperties } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 
 export interface IDashboardTabContrib {
 	id: string;
@@ -64,7 +65,7 @@ const tabSchema: IJSONSchema = {
 		container: {
 			description: localize('sqlops.extension.contributes.dashboard.tab.container', "The container that will be displayed in this tab."),
 			type: 'object',
-			properties: generateTabContentSchemaProperties()
+			properties: generateContainerTypeSchemaProperties()
 		},
 		alwaysShow: {
 			description: localize('sqlops.extension.contributes.dashboard.tab.alwaysShow', "Whether or not this tab should always be shown or only when the user adds it."),

--- a/src/sql/parts/dashboard/common/dashboardWidget.ts
+++ b/src/sql/parts/dashboard/common/dashboardWidget.ts
@@ -41,6 +41,15 @@ export interface TabConfig extends IDashboardTab {
 	actions?: Array<Action>;
 }
 
+export type IUserFriendlyIcon = string | { light: string; dark: string; };
+
+export interface NavSectionConfig {
+	id: string;
+	title: string;
+	icon?: IUserFriendlyIcon;
+	container: object;
+}
+
 export interface PinConfig {
 	tabId: string;
 	isPinned?: boolean;

--- a/src/sql/parts/dashboard/containers/dashboardContainer.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardContainer.contribution.ts
@@ -15,8 +15,6 @@ export type IUserFriendlyIcon = string | { light: string; dark: string; };
 
 export interface IDashboardContainerContrib {
 	id: string;
-	title: string;
-	icon?: IUserFriendlyIcon;
 	container: object;
 }
 
@@ -26,29 +24,6 @@ const containerSchema: IJSONSchema = {
 		id: {
 			type: 'string',
 			description: localize('sqlops.extension.contributes.dashboard.container.id', "Unique identifier for this inner tab. Will be passed to the extension for any requests.")
-		},
-		icon: {
-			description: localize('sqlops.extension.contributes.dashboard.container.icon', '(Optional) Icon which is used to represent this inner tab in the UI. Either a file path or a themable configuration'),
-			anyOf: [{
-				type: 'string'
-			},
-			{
-				type: 'object',
-				properties: {
-					light: {
-						description: localize('carbon.extension.contributes.account.icon.light', 'Icon path when a light theme is used'),
-						type: 'string'
-					},
-					dark: {
-						description: localize('carbon.extension.contributes.account.icon.dark', 'Icon path when a dark theme is used'),
-						type: 'string'
-					}
-				}
-			}]
-		},
-		title: {
-			type: 'string',
-			description: localize('sqlops.extension.contributes.dashboard.container.title', "Title of the inner tab to show the user.")
 		},
 		container: {
 			description: localize('sqlops.extension.contributes.dashboard.container.container', "The container that will be displayed in this inner tab."),
@@ -72,30 +47,11 @@ const containerContributionSchema: IJSONSchema = {
 ExtensionsRegistry.registerExtensionPoint<IDashboardContainerContrib | IDashboardContainerContrib[]>('dashboard.containers', [], containerContributionSchema).setHandler(extensions => {
 
 	function handleCommand(dashboardContainer: IDashboardContainerContrib, extension: IExtensionPointUser<any>) {
-		let { title, id, container, icon } = dashboardContainer;
-		if (!title) {
-			extension.collector.error('No title specified for extension.');
-			return;
-		}
+		let { id, container } = dashboardContainer;
 		if (!container) {
 			extension.collector.warn('No container specified to show.');
 		}
-
-		let iconClass: string;
-		if (icon) {
-			iconClass = id;
-			if (typeof icon === 'string') {
-				const path = join(extension.description.extensionFolderPath, icon);
-				createCSSRule(`.icon.${iconClass}`, `background-image: url("${URI.file(path).toString()}")`);
-			} else {
-				const light = join(extension.description.extensionFolderPath, icon.light);
-				const dark = join(extension.description.extensionFolderPath, icon.dark);
-				createCSSRule(`.icon.${iconClass}`, `background-image: url("${URI.file(light).toString()}")`);
-				createCSSRule(`.vs-dark .icon.${iconClass}, .hc-black .icon.${iconClass}`, `background-image: url("${URI.file(dark).toString()}")`);
-			}
-		}
-
-		registerContainer({ title, id, container, hasIcon: !!icon });
+		registerContainer({ id, container });
 	}
 
 	for (let extension of extensions) {

--- a/src/sql/parts/dashboard/containers/dashboardContainer.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardContainer.contribution.ts
@@ -23,10 +23,10 @@ const containerSchema: IJSONSchema = {
 	properties: {
 		id: {
 			type: 'string',
-			description: localize('sqlops.extension.contributes.dashboard.container.id', "Unique identifier for this inner tab. Will be passed to the extension for any requests.")
+			description: localize('sqlops.extension.contributes.dashboard.container.id', "Unique identifier for this container.")
 		},
 		container: {
-			description: localize('sqlops.extension.contributes.dashboard.container.container', "The container that will be displayed in this inner tab."),
+			description: localize('sqlops.extension.contributes.dashboard.container.container', "The container that will be displayed in the tab."),
 			type: 'object',
 			properties: generateContainerTypeSchemaProperties()
 		}
@@ -34,7 +34,7 @@ const containerSchema: IJSONSchema = {
 };
 
 const containerContributionSchema: IJSONSchema = {
-	description: localize('sqlops.extension.contributes.containers', "Contributes a single or multiple inner tabs for users to add to their dashboard."),
+	description: localize('sqlops.extension.contributes.containers', "Contributes a single or multiple dashboard containers for users to add to their dashboard."),
 	oneOf: [
 		containerSchema,
 		{

--- a/src/sql/parts/dashboard/containers/dashboardGridContainer.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardGridContainer.contribution.ts
@@ -6,14 +6,15 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 
 import { generateDashboardGridLayoutSchema } from 'sql/parts/dashboard/pages/dashboardPageContribution';
-import { registerTabContent } from 'sql/platform/dashboard/common/dashboardRegistry';
+import { registerContainerType, registerNavSectionContainerType } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 
 export const GRID_CONTAINER = 'grid-container';
 
 let gridContainersSchema: IJSONSchema = {
 	type: 'array',
-	description: nls.localize('dashboard.gridtab.content.items', "The list of widgets or webviews that will be displayed in this tab."),
+	description: nls.localize('dashboard.container.gridtab.items', "The list of widgets or webviews that will be displayed in this tab."),
 	items: generateDashboardGridLayoutSchema(undefined, true)
 };
 
-registerTabContent(GRID_CONTAINER, gridContainersSchema);
+registerContainerType(GRID_CONTAINER, gridContainersSchema);
+registerNavSectionContainerType(GRID_CONTAINER, gridContainersSchema);

--- a/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
@@ -8,9 +8,8 @@ import 'vs/css!./dashboardNavSection';
 import { Component, Inject, Input, forwardRef, ViewChild, ElementRef, ViewChildren, QueryList, OnDestroy, ChangeDetectorRef, EventEmitter, OnChanges, AfterContentInit } from '@angular/core';
 
 import { DashboardServiceInterface } from 'sql/parts/dashboard/services/dashboardServiceInterface.service';
-import { WidgetConfig, TabConfig } from 'sql/parts/dashboard/common/dashboardWidget';
+import { WidgetConfig, TabConfig, NavSectionConfig } from 'sql/parts/dashboard/common/dashboardWidget';
 import { PanelComponent, IPanelOptions, NavigationBarLayout } from 'sql/base/browser/ui/panel/panel.component';
-import { IDashboardContainerRegistry, Extensions as InnerTabExtensions, IDashboardContainer } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 import { TabComponent } from 'sql/base/browser/ui/panel/tab.component';
 import { DashboardTab } from 'sql/parts/dashboard/common/interfaces';
 import { error } from 'sql/base/common/log';
@@ -19,8 +18,6 @@ import * as widgetHelper from 'sql/parts/dashboard/common/dashboardWidgetHelper'
 
 import { Registry } from 'vs/platform/registry/common/platform';
 import Event, { Emitter } from 'vs/base/common/event';
-
-const innerTabRegistry = Registry.as<IDashboardContainerRegistry>(InnerTabExtensions.dashboardContainerContributions);
 
 @Component({
 	selector: 'dashboard-nav-section',
@@ -63,19 +60,10 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 
 	ngOnChanges() {
 		this.tabs = [];
-		let innerTabIds = [];
-		let allPosibleInnerTab = innerTabRegistry.containers;
-		let filteredTabs: IDashboardContainer[] = [];
+		let navSectionContainers: NavSectionConfig[] = [];
 		if (this.tab.container) {
-			innerTabIds = Object.values(this.tab.container)[0];
-			if (innerTabIds && innerTabIds.length > 0) {
-				innerTabIds.forEach(tabId => {
-					let tab = allPosibleInnerTab.find(i => i.id === tabId);
-					filteredTabs.push(tab);
-				});
-				this.loadNewTabs(filteredTabs);
-			}
-			this._cd.detectChanges();
+			navSectionContainers = Object.values(this.tab.container)[0];
+			this.loadNewTabs(navSectionContainers);
 		}
 	}
 
@@ -93,7 +81,7 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 		this.dispose();
 	}
 
-	private loadNewTabs(dashboardTabs: IDashboardContainer[]) {
+	private loadNewTabs(dashboardTabs: NavSectionConfig[]) {
 		if (dashboardTabs && dashboardTabs.length > 0) {
 			let selectedTabs = dashboardTabs.map(v => {
 

--- a/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
@@ -98,10 +98,10 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 						configs = cb.apply(this, [configs]);
 					});
 					if (key === WIDGETS_CONTAINER) {
-						return { id: v.id, title: v.title, container: { 'widgets-container': configs }};
+						return { id: v.id, title: v.title, container: { 'widgets-container': configs } };
 
 					} else {
-						return { id: v.id, title: v.title, container: { 'grid-container': configs }};
+						return { id: v.id, title: v.title, container: { 'grid-container': configs } };
 					}
 				}
 				return { id: v.id, title: v.title, container: container };

--- a/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
@@ -86,7 +86,7 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 		if (dashboardTabs && dashboardTabs.length > 0) {
 			let selectedTabs = dashboardTabs.map(v => {
 
-				let container = dashboardHelper.getOrSetContainer(v.container);
+				let container = dashboardHelper.getDashboardContainer(v.container);
 				let key = Object.keys(container)[0];
 
 				if (key === WIDGETS_CONTAINER || key === GRID_CONTAINER) {

--- a/src/sql/parts/dashboard/containers/dashboardNavSection.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.contribution.ts
@@ -9,15 +9,15 @@ import { registerContainerType, generateNavSectionContainerTypeSchemaProperties 
 
 export const NAV_SECTION = 'nav-section';
 
-const nevSectionContainerSchema: IJSONSchema = {
+const navSectionContainerSchema: IJSONSchema = {
 	type: 'object',
 	properties: {
 		id: {
 			type: 'string',
-			description: nls.localize('dashboard.container.left-nav-bar.id', "Unique identifier for this inner tab. Will be passed to the extension for any requests.")
+			description: nls.localize('dashboard.container.left-nav-bar.id', "Unique identifier for this nav section. Will be passed to the extension for any requests.")
 		},
 		icon: {
-			description: nls.localize('dashboard.container.left-nav-bar.icon', '(Optional) Icon which is used to represent this inner tab in the UI. Either a file path or a themable configuration'),
+			description: nls.localize('dashboard.container.left-nav-bar.icon', '(Optional) Icon which is used to represent this nav section in the UI. Either a file path or a themeable configuration'),
 			anyOf: [{
 				type: 'string'
 			},
@@ -37,10 +37,10 @@ const nevSectionContainerSchema: IJSONSchema = {
 		},
 		title: {
 			type: 'string',
-			description: nls.localize('dashboard.container.left-nav-bar.title', "Title of the inner tab to show the user.")
+			description: nls.localize('dashboard.container.left-nav-bar.title', "Title of the nav section to show the user.")
 		},
 		container: {
-			description: nls.localize('dashboard.container.left-nav-bar.container', "The container that will be displayed in this inner tab."),
+			description: nls.localize('dashboard.container.left-nav-bar.container', "The container that will be displayed in this nav section."),
 			type: 'object',
 			properties: generateNavSectionContainerTypeSchemaProperties()
 		}
@@ -50,7 +50,7 @@ const nevSectionContainerSchema: IJSONSchema = {
 let NavSectionSchema: IJSONSchema = {
 	type: 'array',
 	description: nls.localize('dashboard.container.left-nav-bar', "The list of dashboard containers that will be displayed in this navigation section."),
-	items: nevSectionContainerSchema
+	items: navSectionContainerSchema
 };
 
 registerContainerType(NAV_SECTION, NavSectionSchema);

--- a/src/sql/parts/dashboard/containers/dashboardNavSection.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.contribution.ts
@@ -5,16 +5,52 @@
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 
-import { registerTabContent } from 'sql/platform/dashboard/common/dashboardRegistry';
+import { registerContainerType, generateNavSectionContainerTypeSchemaProperties } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 
 export const NAV_SECTION = 'nav-section';
 
-let NavSectionSchema: IJSONSchema = {
-	type: 'array',
-	description: nls.localize('dashboard.tab.content.left-nav-bar', "The list of inner tabs IDs that will be displayed in this vertical navigation bar."),
-	items: {
-		type: 'string'
+const nevSectionContainerSchema: IJSONSchema = {
+	type: 'object',
+	properties: {
+		id: {
+			type: 'string',
+			description: nls.localize('dashboard.container.left-nav-bar.id', "Unique identifier for this inner tab. Will be passed to the extension for any requests.")
+		},
+		icon: {
+			description: nls.localize('dashboard.container.left-nav-bar.icon', '(Optional) Icon which is used to represent this inner tab in the UI. Either a file path or a themable configuration'),
+			anyOf: [{
+				type: 'string'
+			},
+			{
+				type: 'object',
+				properties: {
+					light: {
+						description: nls.localize('dashboard.container.left-nav-bar.icon.light', 'Icon path when a light theme is used'),
+						type: 'string'
+					},
+					dark: {
+						description: nls.localize('dashboard.container.left-nav-bar.icon.dark', 'Icon path when a dark theme is used'),
+						type: 'string'
+					}
+				}
+			}]
+		},
+		title: {
+			type: 'string',
+			description: nls.localize('dashboard.container.left-nav-bar.title', "Title of the inner tab to show the user.")
+		},
+		container: {
+			description: nls.localize('dashboard.container.left-nav-bar.container', "The container that will be displayed in this inner tab."),
+			type: 'object',
+			properties: generateNavSectionContainerTypeSchemaProperties()
+		}
 	}
 };
 
-registerTabContent(NAV_SECTION, NavSectionSchema);
+let NavSectionSchema: IJSONSchema = {
+	type: 'array',
+	description: nls.localize('dashboard.container.left-nav-bar', "The list of dashboard containers that will be displayed in this navigation section."),
+	items: nevSectionContainerSchema
+};
+
+registerContainerType(NAV_SECTION, NavSectionSchema);

--- a/src/sql/parts/dashboard/containers/dashboardWebviewContainer.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardWebviewContainer.contribution.ts
@@ -5,16 +5,15 @@
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 
-import { registerTabContent } from 'sql/platform/dashboard/common/dashboardRegistry';
-import { registerContainerType } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
+import { registerContainerType, registerNavSectionContainerType } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 
 export const WEBVIEW_CONTAINER = 'webview-container';
 
 let webviewSchema: IJSONSchema = {
 	type: 'null',
-	description: nls.localize('dashboard.tab.widgets', "The list of widgets that will be displayed in this tab."),
+	description: nls.localize('dashboard.container.webview', "The webview that will be displayed in this tab."),
 	default: null
 };
 
-registerTabContent(WEBVIEW_CONTAINER, webviewSchema);
 registerContainerType(WEBVIEW_CONTAINER, webviewSchema);
+registerNavSectionContainerType(WEBVIEW_CONTAINER, webviewSchema);

--- a/src/sql/parts/dashboard/containers/dashboardWidgetContainer.contribution.ts
+++ b/src/sql/parts/dashboard/containers/dashboardWidgetContainer.contribution.ts
@@ -6,16 +6,15 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 
 import { generateDashboardWidgetSchema } from 'sql/parts/dashboard/pages/dashboardPageContribution';
-import { registerTabContent } from 'sql/platform/dashboard/common/dashboardRegistry';
-import { registerContainerType } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
+import { registerContainerType, registerNavSectionContainerType } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 
 export const WIDGETS_CONTAINER = 'widgets-container';
 
 let widgetsSchema: IJSONSchema = {
 	type: 'array',
-	description: nls.localize('dashboard.tab.content.widgets', "The list of widgets that will be displayed in this tab."),
+	description: nls.localize('dashboard.container.widgets', "The list of widgets that will be displayed in this tab."),
 	items: generateDashboardWidgetSchema(undefined, true)
 };
 
-registerTabContent(WIDGETS_CONTAINER, widgetsSchema);
 registerContainerType(WIDGETS_CONTAINER, widgetsSchema);
+registerNavSectionContainerType(WIDGETS_CONTAINER, widgetsSchema);

--- a/src/sql/platform/dashboard/common/dashboardContainerRegistry.ts
+++ b/src/sql/platform/dashboard/common/dashboardContainerRegistry.ts
@@ -16,21 +16,22 @@ export const Extensions = {
 
 export interface IDashboardContainer {
 	id: string;
-	title: string;
-	hasIcon: boolean;
 	container?: object;
 }
 
 export interface IDashboardContainerRegistry {
 	registerContainer(tab: IDashboardContainer): void;
 	registerContainerType(id: string, schema: IJSONSchema): void;
+	registerNavSectionContainerType(id: string, schema: IJSONSchema): void;
 	containers: Array<IDashboardContainer>;
 	containerTypeSchemaProperties: IJSONSchemaMap;
+	navSectionContainerTypeSchemaProperties: IJSONSchemaMap;
 }
 
 class DashboardContainerRegistry implements IDashboardContainerRegistry {
 	private _containers = new Array<IDashboardContainer>();
 	private _dashboardContainerTypeSchemaProperties: IJSONSchemaMap = {};
+	private _dashboardNavSectionContainerTypeSchemaProperties: IJSONSchemaMap = {};
 
 	public registerContainer(tab: IDashboardContainer): void {
 		this._containers.push(tab);
@@ -41,9 +42,9 @@ class DashboardContainerRegistry implements IDashboardContainerRegistry {
 	}
 
 	/**
-	 * Register a dashboard widget
-	 * @param id id of the widget
-	 * @param schema config schema of the widget
+	 * Register a dashboard container
+	 * @param id id of the container
+	 * @param schema config schema of the container
 	 */
 	public registerContainerType(id: string, schema: IJSONSchema): void {
 		this._dashboardContainerTypeSchemaProperties[id] = schema;
@@ -52,13 +53,26 @@ class DashboardContainerRegistry implements IDashboardContainerRegistry {
 	public get containerTypeSchemaProperties(): IJSONSchemaMap {
 		return deepClone(this._dashboardContainerTypeSchemaProperties);
 	}
+
+	/**
+	 * Register a dashboard nav section container
+	 * @param id id of the container
+	 * @param schema config schema of the container
+	 */
+	public registerNavSectionContainerType(id: string, schema: IJSONSchema): void {
+		this._dashboardNavSectionContainerTypeSchemaProperties[id] = schema;
+	}
+
+	public get navSectionContainerTypeSchemaProperties(): IJSONSchemaMap {
+		return deepClone(this._dashboardNavSectionContainerTypeSchemaProperties);
+	}
 }
 
 const dashboardContainerRegistry = new DashboardContainerRegistry();
 Registry.add(Extensions.dashboardContainerContributions, dashboardContainerRegistry);
 
-export function registerContainer(innerTab: IDashboardContainer): void {
-	dashboardContainerRegistry.registerContainer(innerTab);
+export function registerContainer(container: IDashboardContainer): void {
+	dashboardContainerRegistry.registerContainer(container);
 }
 
 export function registerContainerType(id: string, schema: IJSONSchema): void {
@@ -67,4 +81,12 @@ export function registerContainerType(id: string, schema: IJSONSchema): void {
 
 export function generateContainerTypeSchemaProperties(): IJSONSchemaMap {
 	return dashboardContainerRegistry.containerTypeSchemaProperties;
+}
+
+export function registerNavSectionContainerType(id: string, schema: IJSONSchema): void {
+	dashboardContainerRegistry.registerNavSectionContainerType(id, schema);
+}
+
+export function generateNavSectionContainerTypeSchemaProperties(): IJSONSchemaMap {
+	return dashboardContainerRegistry.navSectionContainerTypeSchemaProperties;
 }

--- a/src/sql/platform/dashboard/common/dashboardContainerRegistry.ts
+++ b/src/sql/platform/dashboard/common/dashboardContainerRegistry.ts
@@ -20,25 +20,25 @@ export interface IDashboardContainer {
 }
 
 export interface IDashboardContainerRegistry {
-	registerContainer(tab: IDashboardContainer): void;
+	registerContainer(container: IDashboardContainer): void;
 	registerContainerType(id: string, schema: IJSONSchema): void;
 	registerNavSectionContainerType(id: string, schema: IJSONSchema): void;
-	containers: Array<IDashboardContainer>;
+	getRegisteredContainer(id: string): IDashboardContainer;
 	containerTypeSchemaProperties: IJSONSchemaMap;
 	navSectionContainerTypeSchemaProperties: IJSONSchemaMap;
 }
 
 class DashboardContainerRegistry implements IDashboardContainerRegistry {
-	private _containers = new Array<IDashboardContainer>();
+	private _containers: { [x: string]: IDashboardContainer } = {};
 	private _dashboardContainerTypeSchemaProperties: IJSONSchemaMap = {};
 	private _dashboardNavSectionContainerTypeSchemaProperties: IJSONSchemaMap = {};
 
-	public registerContainer(tab: IDashboardContainer): void {
-		this._containers.push(tab);
+	public registerContainer(container: IDashboardContainer): void {
+		this._containers[container.id] = container;
 	}
 
-	public get containers(): Array<IDashboardContainer> {
-		return this._containers;
+	public getRegisteredContainer(id: string): IDashboardContainer {
+		return this._containers[id];
 	}
 
 	/**

--- a/src/sql/platform/dashboard/common/dashboardRegistry.ts
+++ b/src/sql/platform/dashboard/common/dashboardRegistry.ts
@@ -34,9 +34,7 @@ export interface IDashboardRegistry {
 	registerDashboardProvider(id: string, properties: ProviderProperties): void;
 	getProperties(id: string): ProviderProperties;
 	registerTab(tab: IDashboardTab): void;
-	registerTabContent(id: string, schema: IJSONSchema): void;
 	tabs: Array<IDashboardTab>;
-	tabContentSchemaProperties: IJSONSchemaMap;
 }
 
 class DashboardRegistry implements IDashboardRegistry {
@@ -77,19 +75,6 @@ class DashboardRegistry implements IDashboardRegistry {
 	public get tabs(): Array<IDashboardTab> {
 		return this._tabs;
 	}
-
-	/**
-	 * Register a dashboard widget
-	 * @param id id of the widget
-	 * @param schema config schema of the widget
-	 */
-	public registerTabContent(id: string, schema: IJSONSchema): void {
-		this._dashboardTabContentSchemaProperties[id] = schema;
-	}
-
-	public get tabContentSchemaProperties(): IJSONSchemaMap {
-		return deepClone(this._dashboardTabContentSchemaProperties);
-	}
 }
 
 const dashboardRegistry = new DashboardRegistry();
@@ -97,14 +82,6 @@ Registry.add(Extensions.DashboardContributions, dashboardRegistry);
 
 export function registerTab(tab: IDashboardTab): void {
 	dashboardRegistry.registerTab(tab);
-}
-
-export function registerTabContent(id: string, schema: IJSONSchema): void {
-	dashboardRegistry.registerTabContent(id, schema);
-}
-
-export function generateTabContentSchemaProperties(): IJSONSchemaMap {
-	return dashboardRegistry.tabContentSchemaProperties;
 }
 
 const dashboardPropertiesPropertyContrib: IJSONSchema = {

--- a/src/vs/workbench/workbench.main.ts
+++ b/src/vs/workbench/workbench.main.ts
@@ -160,11 +160,11 @@ import 'sql/parts/dashboard/widgets/tasks/tasksWidget.contribution';
 import 'sql/parts/dashboard/widgets/webview/webviewWidget.contribution';
 import 'sql/parts/dashboard/dashboardConfig.contribution';
 /* Containers */
-import 'sql/parts/dashboard/containers/dashboardNavSection.contribution';
 import 'sql/parts/dashboard/containers/dashboardWebviewContainer.contribution';
 import 'sql/parts/dashboard/containers/dashboardGridContainer.contribution';
 import 'sql/parts/dashboard/containers/dashboardWidgetContainer.contribution';
 import 'sql/parts/dashboard/containers/dashboardContainer.contribution';
+import 'sql/parts/dashboard/containers/dashboardNavSection.contribution';
 import 'sql/parts/dashboard/common/dashboardTab.contribution';
 /* Tasks */
 import 'sql/workbench/common/actions.contribution';


### PR DESCRIPTION
example of tab contribution
innerTab 1 are provided in line while the innerTab2 are using registered container
```
    "dashboard.tabs": {
      "id": "test-tab2",
      "title": "test-tab2",
      "provider": "MSSQL",
      "description": "The test-tab2 uses the ESLint library.",
      "edition": 4,
      "container": {
        "nav-section": [
         {
            "id": "innerTab1",
            "title": "inner-tab1",
            "container": {
              "widgets-container": [
                {
                  "widget": {
                    "query-data-store-db-insight": {
                    }
                  }
                },
                {
                  "widget": {
                    "explorer-widget": {
                    }
                  }
                }
              ]
            }
          },
          {
            "id": "innerTab2",
            "title": "inner-tab2",
            "container": {
              "innerTab2": {
              }
            }
          }
        ]
      },
      "alwaysShow": true
    }

    "dashboard.containers": [
      {
        "id": "innerTab2",
        "container": {
          "widgets-container": [
            {
              "widget": {
                "query-data-store-db-insight": {
                }
              }
            },
            {
              "widget": {
                "explorer-widget": {
                }
              }
            }
          ]
        }
      }
    ]
```