### PR TITLE
Fix for duplicate extensions shown in "Save File" dialog.

### DIFF
--- a/src/vs/editor/common/services/languagesRegistry.ts
+++ b/src/vs/editor/common/services/languagesRegistry.ts
@@ -128,7 +128,9 @@ export class LanguagesRegistry {
 		if (Array.isArray(lang.extensions)) {
 			for (let extension of lang.extensions) {
 				mime.registerTextMime({ id: langId, mime: primaryMime, extension: extension }, this._warnOnOverwrite);
-				resolvedLanguage.extensions.push(extension);
+				if (!resolvedLanguage.extensions.includes(extension)){
+					resolvedLanguage.extensions.push(extension);
+				}
 			}
 		}
 


### PR DESCRIPTION
In the file save dialog if a language have 2 or more configuration files in /extensions folder that contains the same extensions it adds the extension again. 
Fixes #760 

