### PR TITLE
writing telemetry into a file when running the app for perf tests

### DIFF
--- a/src/sql/platform/telemetry/fileTelemetryService.ts
+++ b/src/sql/platform/telemetry/fileTelemetryService.ts
@@ -1,0 +1,43 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { TPromise } from 'vs/base/common/winjs.base';
+import { ITelemetryService, ITelemetryInfo, ITelemetryData } from 'vs/platform/telemetry/common/telemetry';
+const fs = require('fs');
+
+/**
+ * Write telemetry into a file for test purposes
+ */
+export class FileTelemetryService implements ITelemetryService {
+	_serviceBrand: undefined;
+	private _isFirst = true;
+
+	constructor(private _outputFile: string) {
+	}
+
+	publicLog(eventName: string, data?: ITelemetryData) {
+		let telemetryData = JSON.stringify(Object.assign({eventName: eventName, data: data}));
+		if (this._outputFile) {
+			if (this._isFirst) {
+				fs.open(this._outputFile,  fs.O_WRONLY | fs.O_CREAT, (err, fr) => {
+					fs.writeFileSync(this._outputFile, telemetryData + '\n');
+					this._isFirst = false;
+				});
+			} else {
+				fs.appendFileSync(this._outputFile, telemetryData + '\n');
+			}
+		}
+		return TPromise.wrap<void>(null);
+	}
+	isOptedIn: true;
+	getTelemetryInfo(): TPromise<ITelemetryInfo> {
+		return TPromise.wrap({
+			instanceId: 'someValue.instanceId',
+			sessionId: 'someValue.sessionId',
+			machineId: 'someValue.machineId'
+		});
+	}
+};

--- a/src/vs/workbench/electron-browser/shell.ts
+++ b/src/vs/workbench/electron-browser/shell.ts
@@ -89,6 +89,9 @@ import { HashService } from 'vs/workbench/services/hash/node/hashService';
 import { IHashService } from 'vs/workbench/services/hash/common/hashService';
 import { ILogService } from 'vs/platform/log/common/log';
 
+// {{SQL CARBON EDIT}}
+import { FileTelemetryService } from 'sql/platform/telemetry/fileTelemetryService';
+
 /**
  * Services that we require for the Shell
  */
@@ -315,9 +318,12 @@ export class WorkbenchShell {
 		// Experiments
 		this.experimentService = instantiationService.createInstance(ExperimentService);
 		serviceCollection.set(IExperimentService, this.experimentService);
-
+		// {{SQL CARBON EDIT}}
+		if (this.environmentService.args['perf-test']) {
+			let telemetryOutput = this.environmentService.args['telemetry-output'];
+			this.telemetryService = new FileTelemetryService(telemetryOutput);
 		// Telemetry
-		if (this.environmentService.isBuilt && !this.environmentService.isExtensionDevelopment && !this.environmentService.args['disable-telemetry'] && !!product.enableTelemetry) {
+		} else if (this.environmentService.isBuilt && !this.environmentService.isExtensionDevelopment && !this.environmentService.args['disable-telemetry'] && !!product.enableTelemetry) {
 			const channel = getDelayedChannel<ITelemetryAppenderChannel>(sharedProcess.then(c => c.getChannel('telemetryAppender')));
 			const commit = product.commit;
 			const version = pkg.version;


### PR DESCRIPTION
when running sqlops with the following parameters: --perf-test --telemetry-output
telemetry data will be added to the file that is passed as "telemetry-output"

This will be useful for doing testing to verify the value of a telemetry event 