### PR TITLE
Dashboard nav-section show 1st container on open by default

### DIFF
--- a/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
@@ -116,7 +116,7 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 
 			// put this immediately on the stack so that is ran *after* the tab is rendered
 			setTimeout(() => {
-				this._panel.selectTab(selectedTabs.pop().id);
+				this._panel.selectTab(selectedTabs[0].id);
 			});
 		}
 	}


### PR DESCRIPTION
Fix #817: dashboard nav-section should show 1st container on open but shows last instead