### PR TITLE
Fix bug where Object Explorer loading icon did not show up

### DIFF
--- a/src/vs/base/parts/tree/browser/tree.css
+++ b/src/vs/base/parts/tree/browser/tree.css
@@ -78,12 +78,12 @@
 }
 
 /* {{SQL CARBON EDIT}} -- Display a high-contrast arrow when an expandable item is selected and expanded */
-.monaco-tree.focused .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected.expanded > .content:before {
+.monaco-tree.focused .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected.expanded:not(.loading) > .content:before {
 	background-image: url('expanded-hc.svg');
 }
 
 /* {{SQL CARBON EDIT}} -- Display a high-contrast arrow when an expandable item is selected and collapsed */
-.monaco-tree.focused .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected > .content:before {
+.monaco-tree.focused .monaco-tree-rows.show-twisties > .monaco-tree-row.has-children.selected:not(.loading) > .content:before {
 	background-image: url('collapsed-hc.svg');
 }
 


### PR DESCRIPTION
The Object Explorer loading icon stopped showing up because the new CSS rules to show high contrast arrows when an item is selected were taking precedence over the rules for the loading spinner.