### PR TITLE
Update version field in sql syntax file.

### DIFF
--- a/extensions/sql/syntaxes/sql.tmLanguage.json
+++ b/extensions/sql/syntaxes/sql.tmLanguage.json
@@ -4,7 +4,7 @@
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/Microsoft/vscode-mssql/commit/cfc8b65ed6daf8252b0cbfd5611aadbd49353bca",
+	"version": "https://github.com/Microsoft/vscode-mssql/commit/c8effddd6a9df117f3ed45b60b487163950a7ea5",
 	"fileTypes": [
 		"sql",
 		"ddl",


### PR DESCRIPTION
Changes to the SqlOps sql syntax file should come from the SQL.plist in the vscode-mssql repo via an update script. The syntax file was modified manually last time, so this commit version change was missed.