### PR TITLE
Capabilities Cache

### DIFF
--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -501,10 +501,8 @@ function prepareXlfFiles(projectName, extensionName) {
 }
 exports.prepareXlfFiles = prepareXlfFiles;
 var editorProject = 'vscode-editor', workbenchProject = 'vscode-workbench', extensionsProject = 'vscode-extensions', setupProject = 'vscode-setup';
-
 // {{SQL CARBON EDIT}}
 var sqlopsProject = 'sqlops-core';
-
 function getResource(sourceFile) {
     var resource;
     if (/^vs\/platform/.test(sourceFile)) {
@@ -533,12 +531,9 @@ function getResource(sourceFile) {
     else if (/^vs\/workbench/.test(sourceFile)) {
         return { name: 'vs/workbench', project: workbenchProject };
     }
-
-    // {{SQL CARBON EDIT}}
-	else if (/^sql/.test(sourceFile)) {
-		return { name: 'sql', project: sqlopsProject };
-	}
-
+    else if (/^sql/.test(sourceFile)) {
+        return { name: 'sql', project: sqlopsProject };
+    }
     throw new Error("Could not identify the XLF bundle for " + sourceFile);
 }
 exports.getResource = getResource;

--- a/src/sql/base/common/map.ts
+++ b/src/sql/base/common/map.ts
@@ -111,11 +111,3 @@ export class TrieMap<E> {
 		return result;
 	}
 }
-
-export function fromObject<T>(object: { [key: string]: T }): Map<string, T> {
-	let map = new Map<string, T>();
-	for(let key in object) {
-		map.set(key, object[key]);
-	}
-	return map;
-}

--- a/src/sql/base/common/map.ts
+++ b/src/sql/base/common/map.ts
@@ -112,3 +112,10 @@ export class TrieMap<E> {
 	}
 }
 
+export function fromObject<T>(object: { [key: string]: T }): Map<string, T> {
+	let map = new Map<string, T>();
+	for(let key in object) {
+		map.set(key, object[key]);
+	}
+	return map;
+}

--- a/src/sql/parts/admin/common/adminService.ts
+++ b/src/sql/parts/admin/common/adminService.ts
@@ -43,19 +43,12 @@ export class AdminService implements IAdminService {
 
 	private _providers: { [handle: string]: sqlops.AdminServicesProvider; } = Object.create(null);
 
-	private _providerOptions: { [handle: string]: sqlops.AdminServicesOptions; } = Object.create(null);
-
 	constructor(
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IWorkbenchEditorService private _editorService: IWorkbenchEditorService,
 		@IConnectionManagementService private _connectionService: IConnectionManagementService,
 		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService
 	) {
-		if (_capabilitiesService && _capabilitiesService.onProviderRegisteredEvent) {
-			_capabilitiesService.onProviderRegisteredEvent((capabilities => {
-				this._providerOptions[capabilities.providerName] = capabilities.adminServicesProvider;
-			}));
-		}
 	}
 
 	private _runAction<T>(uri: string, action: (handler: sqlops.AdminServicesProvider) => Thenable<T>): Thenable<T> {

--- a/src/sql/parts/connection/common/connectionManagement.ts
+++ b/src/sql/parts/connection/common/connectionManagement.ts
@@ -216,8 +216,6 @@ export interface IConnectionManagementService {
 
 	hasRegisteredServers(): boolean;
 
-	getCapabilities(providerName: string): sqlops.DataProtocolServerCapabilities;
-
 	canChangeConnectionConfig(profile: ConnectionProfile, newGroupID: string): boolean;
 
 	getTabColorForUri(uri: string): string;

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -137,6 +137,17 @@ export class ConnectionManagementService implements IConnectionManagementService
 			100 /* High Priority */
 		));
 
+		if (_capabilitiesService) {
+			_capabilitiesService.onCapabilitiesRegistered((p => {
+				if (p === 'MSSQL') {
+					if (!this.hasRegisteredServers()) {
+						// prompt the user for a new connection on startup if no profiles are registered
+						this.showConnectionDialog();
+					}
+				}
+			}));
+		}
+
 		this.disposables.push(this._onAddConnectionProfile);
 		this.disposables.push(this._onDeleteConnectionProfile);
 

--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -137,17 +137,6 @@ export class ConnectionManagementService implements IConnectionManagementService
 			100 /* High Priority */
 		));
 
-		if (_capabilitiesService && _capabilitiesService.onProviderRegisteredEvent) {
-			_capabilitiesService.onProviderRegisteredEvent((capabilities => {
-				if (capabilities.providerName === 'MSSQL') {
-					if (!this.hasRegisteredServers()) {
-						// prompt the user for a new connection on startup if no profiles are registered
-						this.showConnectionDialog();
-					}
-				}
-			}));
-		}
-
 		this.disposables.push(this._onAddConnectionProfile);
 		this.disposables.push(this._onDeleteConnectionProfile);
 
@@ -679,21 +668,13 @@ export class ConnectionManagementService implements IConnectionManagementService
 		return Object.keys(this._providers);
 	}
 
-	public getCapabilities(providerName: string): sqlops.DataProtocolServerCapabilities {
-		let capabilities = this._capabilitiesService.getCapabilities();
-		if (capabilities !== undefined && capabilities.length > 0) {
-			return capabilities.find(c => c.providerName === providerName);
-		}
-		return undefined;
-	}
-
 	public getAdvancedProperties(): sqlops.ConnectionOption[] {
 
-		let capabilities = this._capabilitiesService.getCapabilities();
-		if (capabilities !== undefined && capabilities.length > 0) {
+		let providers = this._capabilitiesService.providers;
+		if (providers !== undefined && providers.length > 0) {
 			// just grab the first registered provider for now, this needs to change
 			// to lookup based on currently select provider
-			let providerCapabilities = capabilities[0];
+			let providerCapabilities = this._capabilitiesService.getCapabilities(providers[0]);
 			if (!!providerCapabilities.connectionProvider) {
 				return providerCapabilities.connectionProvider.options;
 			}
@@ -1362,7 +1343,7 @@ export class ConnectionManagementService implements IConnectionManagementService
 		}
 
 		// Find the password option for the connection provider
-		let passwordOption = this._capabilitiesService.getCapabilities().find(capability => capability.providerName === profile.providerName).connectionProvider.options.find(
+		let passwordOption = this._capabilitiesService.getCapabilities(profile.providerName).connectionProvider.options.find(
 			option => option.specialValueType === ConnectionOptionSpecialType.password);
 		if (!passwordOption) {
 			return undefined;

--- a/src/sql/parts/connection/common/connectionProfile.ts
+++ b/src/sql/parts/connection/common/connectionProfile.ts
@@ -12,6 +12,8 @@ import * as interfaces from 'sql/parts/connection/common/interfaces';
 import { equalsIgnoreCase } from 'vs/base/common/strings';
 import { generateUuid } from 'vs/base/common/uuid';
 import * as objects from 'sql/base/common/objects';
+import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
+import { isString } from 'vs/base/common/types';
 
 // Concrete implementation of the IConnectionProfile interface
 
@@ -28,9 +30,13 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 	public saveProfile: boolean;
 
 	public isDisconnecting: boolean = false;
-	public constructor(serverCapabilities?: sqlops.DataProtocolServerCapabilities, model?: interfaces.IConnectionProfile) {
-		super(serverCapabilities, model);
-		if (model) {
+
+	public constructor(
+		capabilitiesService: ICapabilitiesService,
+		model: string | interfaces.IConnectionProfile
+	) {
+		super(capabilitiesService, model);
+		if (!isString(model)) {
 			this.groupId = model.groupId;
 			this.groupFullName = model.groupFullName;
 			this.savePassword = model.savePassword;
@@ -91,7 +97,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 	}
 
 	public clone(): ConnectionProfile {
-		let instance = new ConnectionProfile(this._serverCapabilities, this);
+		let instance = new ConnectionProfile(this.capabilitiesService, this);
 		return instance;
 	}
 
@@ -137,12 +143,6 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		return super.getOptionsKey();
 	}
 
-	public onProviderRegistered(serverCapabilities: sqlops.DataProtocolServerCapabilities): void {
-		if (serverCapabilities.providerName === this.providerName) {
-			this.setServerCapabilities(serverCapabilities);
-		}
-	}
-
 	public toIConnectionProfile(): interfaces.IConnectionProfile {
 		let result: interfaces.IConnectionProfile = {
 			serverName: this.serverName,
@@ -170,8 +170,19 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		};
 	}
 
-	public static createFromStoredProfile(profile: interfaces.IConnectionProfileStore, serverCapabilities: sqlops.DataProtocolServerCapabilities): ConnectionProfile {
-		let connectionInfo = new ConnectionProfile(serverCapabilities, undefined);
+	public static fromIConnectionProfile(capabilitiesService: ICapabilitiesService, profile: interfaces.IConnectionProfile) {
+		if (profile) {
+			if (profile instanceof ConnectionProfile) {
+				return profile;
+			} else {
+				return new ConnectionProfile(capabilitiesService, profile);
+			}
+		}
+		return undefined;
+	}
+
+	public static createFromStoredProfile(profile: interfaces.IConnectionProfileStore, capabilitiesService: ICapabilitiesService): ConnectionProfile {
+		let connectionInfo = new ConnectionProfile(capabilitiesService, profile.providerName);
 		connectionInfo.options = profile.options;
 
 		// append group ID and original display name to build unique OE session ID
@@ -187,28 +198,11 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		return connectionInfo;
 	}
 
-	public static convertToConnectionProfile(serverCapabilities: sqlops.DataProtocolServerCapabilities, conn: interfaces.IConnectionProfile): ConnectionProfile {
-		if (conn) {
-			let connectionProfile: ConnectionProfile = undefined;
-			let connectionProfileInstance = conn as ConnectionProfile;
-			if (connectionProfileInstance && conn instanceof ConnectionProfile) {
-				connectionProfile = connectionProfileInstance;
-				connectionProfile.setServerCapabilities(serverCapabilities);
-			} else {
-				connectionProfile = new ConnectionProfile(serverCapabilities, conn);
-			}
-
-			return connectionProfile;
-		} else {
-			return undefined;
-		}
-	}
-
 	public static convertToProfileStore(
-		serverCapabilities: sqlops.DataProtocolServerCapabilities,
+		capabilitiesService: ICapabilitiesService,
 		connectionProfile: interfaces.IConnectionProfile): interfaces.IConnectionProfileStore {
 		if (connectionProfile) {
-			let connectionInfo = ConnectionProfile.convertToConnectionProfile(serverCapabilities, connectionProfile);
+			let connectionInfo = ConnectionProfile.fromIConnectionProfile(capabilitiesService, connectionProfile);
 			let profile: interfaces.IConnectionProfileStore = {
 				options: {},
 				groupId: connectionProfile.groupId,
@@ -224,5 +218,4 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 			return undefined;
 		}
 	}
-
 }

--- a/src/sql/parts/connection/common/connectionProfile.ts
+++ b/src/sql/parts/connection/common/connectionProfile.ts
@@ -36,7 +36,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 		model: string | interfaces.IConnectionProfile
 	) {
 		super(capabilitiesService, model);
-		if (!isString(model)) {
+		if (model && !isString(model)) {
 			this.groupId = model.groupId;
 			this.groupFullName = model.groupFullName;
 			this.savePassword = model.savePassword;

--- a/src/sql/parts/connection/common/connectionStatusManager.ts
+++ b/src/sql/parts/connection/common/connectionStatusManager.ts
@@ -22,25 +22,6 @@ export class ConnectionStatusManager {
 		this._providerCapabilitiesMap = {};
 	}
 
-	public getCapabilities(providerName: string): sqlops.DataProtocolServerCapabilities {
-		let result: sqlops.DataProtocolServerCapabilities;
-
-		if (providerName in this._providerCapabilitiesMap) {
-			result = this._providerCapabilitiesMap[providerName];
-		} else {
-			let capabilities = this._capabilitiesService.getCapabilities();
-			if (capabilities) {
-				let providerCapabilities = capabilities.find(c => c.providerName === providerName);
-				if (providerCapabilities) {
-					this._providerCapabilitiesMap[providerName] = providerCapabilities;
-					result = providerCapabilities;
-				}
-			}
-		}
-
-		return result;
-	}
-
 	public findConnection(id: string): ConnectionManagementInfo {
 		if (id in this._connections) {
 			return this._connections[id];
@@ -80,15 +61,14 @@ export class ConnectionStatusManager {
 
 	public addConnection(connection: IConnectionProfile, id: string): ConnectionManagementInfo {
 		// Always create a copy and save that in the list
-		let connectionProfile = new ConnectionProfile(this.getCapabilities(connection.providerName), connection);
-		const self = this;
+		let connectionProfile = new ConnectionProfile(this._capabilitiesService.getCapabilities(connection.providerName), connection);
 		let connectionInfo: ConnectionManagementInfo = new ConnectionManagementInfo();
 		connectionInfo.providerId = connection.providerName;
 		connectionInfo.extensionTimer = StopWatch.create();
 		connectionInfo.intelliSenseTimer = StopWatch.create();
 		connectionInfo.connectionProfile = connectionProfile;
 		connectionInfo.connecting = true;
-		self._connections[id] = connectionInfo;
+		this._connections[id] = connectionInfo;
 		connectionInfo.serviceTimer = StopWatch.create();
 		connectionInfo.ownerUri = id;
 

--- a/src/sql/parts/connection/common/connectionStatusManager.ts
+++ b/src/sql/parts/connection/common/connectionStatusManager.ts
@@ -61,7 +61,7 @@ export class ConnectionStatusManager {
 
 	public addConnection(connection: IConnectionProfile, id: string): ConnectionManagementInfo {
 		// Always create a copy and save that in the list
-		let connectionProfile = new ConnectionProfile(this._capabilitiesService.getCapabilities(connection.providerName), connection);
+		let connectionProfile = new ConnectionProfile(this._capabilitiesService, connection);
 		let connectionInfo: ConnectionManagementInfo = new ConnectionManagementInfo();
 		connectionInfo.providerId = connection.providerName;
 		connectionInfo.extensionTimer = StopWatch.create();

--- a/src/sql/parts/connection/common/connectionStore.ts
+++ b/src/sql/parts/connection/common/connectionStore.ts
@@ -50,14 +50,8 @@ export class ConnectionStore {
 		this._groupIdToFullNameMap = {};
 		this._groupFullNameToIdMap = {};
 		if (!this._connectionConfig) {
-			let cachedServerCapabilities = this.getCachedServerCapabilities();
 			this._connectionConfig = new ConnectionConfig(this._configurationEditService,
-				this._workspaceConfigurationService, this._capabilitiesService, cachedServerCapabilities);
-		}
-		if (_capabilitiesService) {
-			_capabilitiesService.onProviderRegisteredEvent(e => {
-				this.saveCachedServerCapabilities();
-			});
+				this._workspaceConfigurationService, this._capabilitiesService);
 		}
 	}
 
@@ -85,7 +79,7 @@ export class ConnectionStore {
 	 */
 	public formatCredentialId(connectionProfile: IConnectionProfile, itemType?: string): string {
 		let connectionProfileInstance: ConnectionProfile = ConnectionProfile.convertToConnectionProfile(
-			this._connectionConfig.getCapabilities(connectionProfile.providerName), connectionProfile);
+			this._capabilitiesService.getCapabilities(connectionProfile.providerName), connectionProfile);
 		if (!connectionProfileInstance.getConnectionInfoId()) {
 			throw new Error('Missing Id, which is required');
 		}
@@ -111,7 +105,7 @@ export class ConnectionStore {
 	 */
 	public isPasswordRequired(connection: IConnectionProfile): boolean {
 		if (connection) {
-			let connectionProfile = ConnectionProfile.convertToConnectionProfile(this._connectionConfig.getCapabilities(connection.providerName), connection);
+			let connectionProfile = ConnectionProfile.convertToConnectionProfile(this._capabilitiesService.getCapabilities(connection.providerName), connection);
 			return connectionProfile.isPasswordRequired();
 		} else {
 			return false;
@@ -174,7 +168,6 @@ export class ConnectionStore {
 					// Add necessary default properties before returning
 					// this is needed to support immediate connections
 					ConnInfo.fixupConnectionCredentials(profile);
-					this.saveCachedServerCapabilities();
 					resolve(profile);
 				}, err => {
 					reject(err);
@@ -214,23 +207,6 @@ export class ConnectionStore {
 		});
 	}
 
-	private getCachedServerCapabilities(): sqlops.DataProtocolServerCapabilities[] {
-		if (this._memento) {
-			let metadata: sqlops.DataProtocolServerCapabilities[] = this._memento[Constants.capabilitiesOptions];
-			return metadata;
-		} else {
-			return undefined;
-		}
-
-	}
-
-	private saveCachedServerCapabilities(): void {
-		if (this._memento) {
-			let capabilities = this._capabilitiesService.getCapabilities();
-			this._memento[Constants.capabilitiesOptions] = capabilities;
-		}
-	}
-
 	/**
 	 * Gets the list of recently used connections. These will not include the password - a separate call to
 	 * {addSavedPassword} is needed to fill that before connecting
@@ -250,11 +226,8 @@ export class ConnectionStore {
 	private convertConfigValuesToConnectionProfiles(configValues: IConnectionProfile[]): ConnectionProfile[] {
 		return configValues.map(c => {
 			if (c) {
-				let capabilities = this._connectionConfig.getCapabilities(c.providerName);
+				let capabilities = this._capabilitiesService.getCapabilities(c.providerName);
 				let connectionProfile = new ConnectionProfile(capabilities, c);
-				this._capabilitiesService.onProviderRegisteredEvent((serverCapabilities) => {
-					connectionProfile.onProviderRegistered(serverCapabilities);
-				});
 				if (connectionProfile.saveProfile) {
 					if (!connectionProfile.groupFullName && connectionProfile.groupId) {
 						connectionProfile.groupFullName = this.getGroupFullName(connectionProfile.groupId);
@@ -289,7 +262,7 @@ export class ConnectionStore {
 
 	public getProfileWithoutPassword(conn: IConnectionProfile): ConnectionProfile {
 		if (conn) {
-			let savedConn: ConnectionProfile = ConnectionProfile.convertToConnectionProfile(this._connectionConfig.getCapabilities(conn.providerName), conn);
+			let savedConn: ConnectionProfile = ConnectionProfile.convertToConnectionProfile(this._capabilitiesService.getCapabilities(conn.providerName), conn);
 			savedConn = savedConn.withoutPassword();
 
 			return savedConn;

--- a/src/sql/parts/connection/common/connectionStore.ts
+++ b/src/sql/parts/connection/common/connectionStore.ts
@@ -78,8 +78,8 @@ export class ConnectionStore {
 	 * @returns {string} formatted string with server, DB and username
 	 */
 	public formatCredentialId(connectionProfile: IConnectionProfile, itemType?: string): string {
-		let connectionProfileInstance: ConnectionProfile = ConnectionProfile.convertToConnectionProfile(
-			this._capabilitiesService.getCapabilities(connectionProfile.providerName), connectionProfile);
+		let connectionProfileInstance: ConnectionProfile = ConnectionProfile.fromIConnectionProfile(
+			this._capabilitiesService, connectionProfile);
 		if (!connectionProfileInstance.getConnectionInfoId()) {
 			throw new Error('Missing Id, which is required');
 		}
@@ -105,7 +105,7 @@ export class ConnectionStore {
 	 */
 	public isPasswordRequired(connection: IConnectionProfile): boolean {
 		if (connection) {
-			let connectionProfile = ConnectionProfile.convertToConnectionProfile(this._capabilitiesService.getCapabilities(connection.providerName), connection);
+			let connectionProfile = ConnectionProfile.fromIConnectionProfile(this._capabilitiesService, connection);
 			return connectionProfile.isPasswordRequired();
 		} else {
 			return false;
@@ -226,8 +226,7 @@ export class ConnectionStore {
 	private convertConfigValuesToConnectionProfiles(configValues: IConnectionProfile[]): ConnectionProfile[] {
 		return configValues.map(c => {
 			if (c) {
-				let capabilities = this._capabilitiesService.getCapabilities(c.providerName);
-				let connectionProfile = new ConnectionProfile(capabilities, c);
+				let connectionProfile = new ConnectionProfile(this._capabilitiesService, c);
 				if (connectionProfile.saveProfile) {
 					if (!connectionProfile.groupFullName && connectionProfile.groupId) {
 						connectionProfile.groupFullName = this.getGroupFullName(connectionProfile.groupId);
@@ -262,7 +261,7 @@ export class ConnectionStore {
 
 	public getProfileWithoutPassword(conn: IConnectionProfile): ConnectionProfile {
 		if (conn) {
-			let savedConn: ConnectionProfile = ConnectionProfile.convertToConnectionProfile(this._capabilitiesService.getCapabilities(conn.providerName), conn);
+			let savedConn: ConnectionProfile = ConnectionProfile.fromIConnectionProfile(this._capabilitiesService, conn);
 			savedConn = savedConn.withoutPassword();
 
 			return savedConn;

--- a/src/sql/parts/connection/common/iconnectionConfig.ts
+++ b/src/sql/parts/connection/common/iconnectionConfig.ts
@@ -23,8 +23,6 @@ export interface IConnectionConfig {
 	getAllGroups(): IConnectionProfileGroup[];
 	changeGroupIdForConnectionGroup(source: ConnectionProfileGroup, target: ConnectionProfileGroup): Promise<void>;
 	changeGroupIdForConnection(source: ConnectionProfile, targetGroupId: string): Promise<void>;
-	setCachedMetadata(cachedMetaData: sqlops.DataProtocolServerCapabilities[]): void;
-	getCapabilities(providerName: string): sqlops.DataProtocolServerCapabilities;
 	editGroup(group: ConnectionProfileGroup): Promise<void>;
 	deleteConnection(profile: ConnectionProfile): Promise<void>;
 	deleteGroup(group: ConnectionProfileGroup): Promise<void>;

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -240,7 +240,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		let defaultProvider = this.getDefaultProviderName();
 		let providerName = model ? model.providerName : defaultProvider;
 		providerName = providerName ? providerName : defaultProvider;
-		let newProfile = new ConnectionProfile(this._capabilitiesService, model);
+		let newProfile = new ConnectionProfile(this._capabilitiesService, model || providerName);
 		newProfile.saveProfile = true;
 		newProfile.generateNewId();
 		// If connecting from a query editor set "save connection" to false

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -207,7 +207,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 	private handleShowUiComponent(input: OnShowUIResponse) {
 		this._currentProviderType = input.selectedProviderType;
-		this._model = new ConnectionProfile(this._capabilitiesService.getCapabilities(this._currentProviderType), this._model);
+		this._model = new ConnectionProfile(this._capabilitiesService, this._model);
 		this.uiController.showUiComponent(input.container);
 	}
 
@@ -244,8 +244,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		let defaultProvider = this.getDefaultProviderName();
 		let providerName = model ? model.providerName : defaultProvider;
 		providerName = providerName ? providerName : defaultProvider;
-		let serverCapabilities = this._capabilitiesService.getCapabilities(providerName);
-		let newProfile = new ConnectionProfile(serverCapabilities, model);
+		let newProfile = new ConnectionProfile(this._capabilitiesService, model);
 		newProfile.saveProfile = true;
 		newProfile.generateNewId();
 		// If connecting from a query editor set "save connection" to false

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -85,28 +85,14 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		@IClipboardService private _clipboardService: IClipboardService,
 		@ICommandService private _commandService: ICommandService
 	) {
-		this._capabilitiesMaps = {};
 		this._providerNameToDisplayNameMap = {};
 		this._connectionControllerMap = {};
 		this._providerTypes = [];
-		if (_capabilitiesService) {
-			_capabilitiesService.onProviderRegisteredEvent((capabilities => {
-				let defaultProvider = this.getDefaultProviderName();
-				if (capabilities.providerName === defaultProvider) {
-					this.showDialogWithModel();
-				}
-			}));
-		}
 	}
 
 	private getDefaultProviderName() {
 		if (this._workspaceConfigurationService) {
 			let defaultProvider = WorkbenchUtils.getSqlConfigValue<string>(this._workspaceConfigurationService, Constants.defaultEngine);
-			if (defaultProvider
-				&& this._capabilitiesMaps
-				&& defaultProvider in this._capabilitiesMaps) {
-				return defaultProvider;
-			}
 		}
 		// as a fallback, default to MSSQL if the value from settings is not available
 		return Constants.mssqlProviderName;
@@ -208,7 +194,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		// Set the model name, initialize the controller if needed, and return the controller
 		this._model.providerName = providerName;
 		if (!this._connectionControllerMap[providerName]) {
-			this._connectionControllerMap[providerName] = this._instantiationService.createInstance(ConnectionController, this._container, this._connectionManagementService, this._capabilitiesMaps[providerName], {
+			this._connectionControllerMap[providerName] = this._instantiationService.createInstance(ConnectionController, this._container, this._connectionManagementService, this._capabilitiesService.getCapabilities(providerName), {
 				onSetConnectButton: (enable: boolean) => this.handleSetConnectButtonEnable(enable)
 			}, providerName);
 		}
@@ -221,7 +207,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 	private handleShowUiComponent(input: OnShowUIResponse) {
 		this._currentProviderType = input.selectedProviderType;
-		this._model = new ConnectionProfile(this._capabilitiesMaps[this.getCurrentProviderName()], this._model);
+		this._model = new ConnectionProfile(this._capabilitiesService.getCapabilities(this._currentProviderType), this._model);
 		this.uiController.showUiComponent(input.container);
 	}
 
@@ -258,7 +244,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		let defaultProvider = this.getDefaultProviderName();
 		let providerName = model ? model.providerName : defaultProvider;
 		providerName = providerName ? providerName : defaultProvider;
-		let serverCapabilities = this._capabilitiesMaps[providerName];
+		let serverCapabilities = this._capabilitiesService.getCapabilities(providerName);
 		let newProfile = new ConnectionProfile(serverCapabilities, model);
 		newProfile.saveProfile = true;
 		newProfile.generateNewId();
@@ -269,23 +255,11 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		return newProfile;
 	}
 
-	private cacheCapabilities(capabilities: sqlops.DataProtocolServerCapabilities) {
-		if (capabilities) {
-			this._providerTypes.push(capabilities.providerDisplayName);
-			this._capabilitiesMaps[capabilities.providerName] = capabilities;
-			this._providerNameToDisplayNameMap[capabilities.providerName] = capabilities.providerDisplayName;
-		}
-	}
-
 	private showDialogWithModel(): TPromise<void> {
 		return new TPromise<void>((resolve, reject) => {
-			if (this.getDefaultProviderName() in this._capabilitiesMaps) {
-				this.updateModelServerCapabilities(this._inputModel);
-
-				this.doShowDialog(this._params);
-			}
-			let none: void;
-			resolve(none);
+			this.updateModelServerCapabilities(this._inputModel);
+			this.doShowDialog(this._params);
+			resolve(null);
 		});
 	}
 
@@ -300,30 +274,17 @@ export class ConnectionDialogService implements IConnectionDialogService {
 		this._inputModel = model;
 
 		return new Promise<void>((resolve, reject) => {
-			// only create the provider maps first time the dialog gets called
-			let capabilitiesPromise: Promise<void> = Promise.resolve();
-			if (this._providerTypes.length === 0) {
-				capabilitiesPromise = this._capabilitiesService.onCapabilitiesReady().then(() => {
-					let capabilities = this._capabilitiesService.getCapabilities();
-					capabilities.forEach(c => {
-						this.cacheCapabilities(c);
-					});
-				});
+			this.updateModelServerCapabilities(model);
+			// If connecting from a query editor set "save connection" to false
+			if (params && params.input && params.connectionType === ConnectionType.editor) {
+				this._model.saveProfile = false;
 			}
 
-			capabilitiesPromise.then(success => {
-				this.updateModelServerCapabilities(model);
-				// If connecting from a query editor set "save connection" to false
-				if (params && params.input && params.connectionType === ConnectionType.editor) {
-					this._model.saveProfile = false;
+			resolve(this.showDialogWithModel().then(() => {
+				if (connectionResult && connectionResult.errorMessage) {
+					this.showErrorDialog(Severity.Error, this._connectionErrorTitle, connectionResult.errorMessage, connectionResult.callStack);
 				}
-
-				resolve(this.showDialogWithModel().then(() => {
-					if (connectionResult && connectionResult.errorMessage) {
-						this.showErrorDialog(Severity.Error, this._connectionErrorTitle, connectionResult.errorMessage, connectionResult.callStack);
-					}
-				}));
-			}, err => reject(err));
+			}));
 		});
 	}
 

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -69,7 +69,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	private _model: ConnectionProfile;
 	private _params: INewConnectionParams;
 	private _inputModel: IConnectionProfile;
-	private _capabilitiesMaps: { [providerDisplayName: string]: sqlops.DataProtocolServerCapabilities };
 	private _providerNameToDisplayNameMap: { [providerDisplayName: string]: string };
 	private _providerTypes: string[];
 	private _currentProviderType: string = 'Microsoft SQL Server';

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -230,9 +230,11 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 	private updateModelServerCapabilities(model: IConnectionProfile) {
 		this._model = this.createModel(model);
-		this._currentProviderType = this._providerNameToDisplayNameMap[this._model.providerName];
-		if (this._connectionDialog) {
-			this._connectionDialog.updateProvider(this._currentProviderType);
+		if (this._model.providerName) {
+			this._currentProviderType = this._providerNameToDisplayNameMap[this._model.providerName];
+			if (this._connectionDialog) {
+				this._connectionDialog.updateProvider(this._currentProviderType);
+			}
 		}
 	}
 

--- a/src/sql/parts/connection/connectionDialog/connectionDialogWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogWidget.ts
@@ -453,7 +453,6 @@ export class ConnectionDialogWidget extends Modal {
 
 	public updateProvider(displayName: string) {
 		this._providerTypeSelectBox.selectWithOptionName(displayName);
-		this.onProviderTypeSelected(displayName);
 	}
 
 	public set databaseDropdownExpanded(val: boolean) {

--- a/src/sql/parts/connection/connectionDialog/connectionDialogWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogWidget.ts
@@ -274,7 +274,7 @@ export class ConnectionDialogWidget extends Modal {
 			resolve(confirmed);
 		});
 
-			//this._messageService.confirm(confirm).then(confirmation => {
+		//this._messageService.confirm(confirm).then(confirmation => {
 		// 	if (!confirmation.confirmed) {
 		// 		return TPromise.as(false);
 		// 	} else {

--- a/src/sql/parts/dashboard/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/explorer/explorerWidget.component.ts
@@ -101,7 +101,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			this._register(toDisposableSubscription(this._bootstrap.metadataService.databaseNames.subscribe(
 				data => {
 					let profileData = data.map(d => {
-						let profile = new ConnectionProfile(currentProfile.serverCapabilities, currentProfile);
+						let profile = new ConnectionProfile(this._bootstrap.capabilitiesService, currentProfile);
 						profile.databaseName = d;
 						return profile;
 					});

--- a/src/sql/parts/disasterRecovery/restore/common/restoreServiceImpl.ts
+++ b/src/sql/parts/disasterRecovery/restore/common/restoreServiceImpl.ts
@@ -139,7 +139,7 @@ export class RestoreDialogController implements IRestoreDialogController {
 	private _sessionId: string;
 	private readonly _restoreFeature = 'Restore';
 	private readonly _restoreTaskName: string = 'Restore Database';
-	private readonly _restoreCompleted : string = 'Completed';
+	private readonly _restoreCompleted: string = 'Completed';
 	private _optionValues: { [optionName: string]: any } = {};
 
 	constructor(
@@ -178,11 +178,11 @@ export class RestoreDialogController implements IRestoreDialogController {
 
 	private isSuccessfulRestore(response: TaskNode): boolean {
 		return (response.taskName === this._restoreTaskName &&
-				response.message === this._restoreCompleted &&
-				(response.status === TaskStatus.succeeded ||
-					response.status === TaskStatus.succeededWithWarning) &&
-				(response.taskExecutionMode === TaskExecutionMode.execute ||
-					response.taskExecutionMode === TaskExecutionMode.executeAndScript));
+			response.message === this._restoreCompleted &&
+			(response.status === TaskStatus.succeeded ||
+				response.status === TaskStatus.succeededWithWarning) &&
+			(response.taskExecutionMode === TaskExecutionMode.execute ||
+				response.taskExecutionMode === TaskExecutionMode.executeAndScript));
 	}
 
 	private handleMssqlOnValidateFile(overwriteTargetDatabase: boolean = false): void {

--- a/src/sql/parts/disasterRecovery/restore/common/restoreServiceImpl.ts
+++ b/src/sql/parts/disasterRecovery/restore/common/restoreServiceImpl.ts
@@ -266,7 +266,7 @@ export class RestoreDialogController implements IRestoreDialogController {
 	private getRestoreOption(): sqlops.ServiceOption[] {
 		let options: sqlops.ServiceOption[] = [];
 		let providerId: string = this.getCurrentProviderId();
-		let providerCapabilities = this._capabilitiesService.getCapabilities().find(c => c.providerName === providerId);
+		let providerCapabilities = this._capabilitiesService.getCapabilities(providerId);
 
 		if (providerCapabilities) {
 			let restoreMetadataProvider = providerCapabilities.features.find(f => f.featureName === this._restoreFeature);

--- a/src/sql/parts/insights/browser/insightsDialogView.ts
+++ b/src/sql/parts/insights/browser/insightsDialogView.ts
@@ -38,7 +38,7 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { MenuRegistry, ExecuteCommandAction } from 'vs/platform/actions/common/actions';
-import { ICapabilitiesService } from '../../../services/capabilities/capabilitiesService';
+import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
 
 const labelDisplay = nls.localize("insights.item", "Item");
 const valueDisplay = nls.localize("insights.value", "Value");

--- a/src/sql/parts/insights/browser/insightsDialogView.ts
+++ b/src/sql/parts/insights/browser/insightsDialogView.ts
@@ -38,6 +38,7 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { MenuRegistry, ExecuteCommandAction } from 'vs/platform/actions/common/actions';
+import { ICapabilitiesService } from '../../../services/capabilities/capabilitiesService';
 
 const labelDisplay = nls.localize("insights.item", "Item");
 const valueDisplay = nls.localize("insights.value", "Value");
@@ -129,7 +130,8 @@ export class InsightsDialogView extends Modal {
 		@IContextMenuService private _contextMenuService: IContextMenuService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@ICommandService private _commandService: ICommandService
+		@ICommandService private _commandService: ICommandService,
+		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService
 	) {
 		super(nls.localize("InsightsDialogTitle", "Insights"), TelemetryKeys.Insights, partService, telemetryService, contextKeyService);
 		this._model.onDataChange(e => this.build());
@@ -388,7 +390,7 @@ export class InsightsDialogView extends Modal {
 		}
 
 		let currentProfile = this._connectionProfile as ConnectionProfile;
-		let profile = new ConnectionProfile(currentProfile.serverCapabilities, currentProfile);
+		let profile = new ConnectionProfile(this._capabilitiesService, currentProfile);
 		profile.databaseName = database;
 		profile.serverName = server;
 		profile.userName = user;

--- a/src/sql/parts/registeredServer/common/objectExplorerService.ts
+++ b/src/sql/parts/registeredServer/common/objectExplorerService.ts
@@ -19,6 +19,7 @@ import * as TelemetryUtils from 'sql/common/telemetryUtilities';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { warn, error } from 'sql/base/common/log';
 import { ServerTreeView } from 'sql/parts/registeredServer/viewlet/serverTreeView';
+import { ICapabilitiesService } from '../../../services/capabilities/capabilitiesService';
 
 export const SERVICE_ID = 'ObjectExplorerService';
 
@@ -102,7 +103,8 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 	constructor(
 		@IConnectionManagementService private _connectionManagementService: IConnectionManagementService,
-		@ITelemetryService private _telemetryService: ITelemetryService
+		@ITelemetryService private _telemetryService: ITelemetryService,
+		@ICapabilitiesService private _capabilitiesService: ICapabilitiesService
 	) {
 		this._onUpdateObjectExplorerNodes = new Emitter<ObjectExplorerNodeEventArgs>();
 		this._activeObjectExplorerNodes = {};
@@ -125,7 +127,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	public updateObjectExplorerNodes(connection: IConnectionProfile): Promise<void> {
 		return this._connectionManagementService.addSavedPassword(connection).then(withPassword => {
 			let connectionProfile = ConnectionProfile.convertToConnectionProfile(
-				this._connectionManagementService.getCapabilities(connection.providerName), withPassword);
+				this._capabilitiesService.getCapabilities(connection.providerName), withPassword);
 			return this.updateNewObjectExplorerNode(connectionProfile);
 		});
 	}

--- a/src/sql/parts/registeredServer/common/objectExplorerService.ts
+++ b/src/sql/parts/registeredServer/common/objectExplorerService.ts
@@ -126,8 +126,7 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 	public updateObjectExplorerNodes(connection: IConnectionProfile): Promise<void> {
 		return this._connectionManagementService.addSavedPassword(connection).then(withPassword => {
-			let connectionProfile = ConnectionProfile.convertToConnectionProfile(
-				this._capabilitiesService.getCapabilities(connection.providerName), withPassword);
+			let connectionProfile = ConnectionProfile.fromIConnectionProfile(this._capabilitiesService, withPassword);
 			return this.updateNewObjectExplorerNode(connectionProfile);
 		});
 	}

--- a/src/sql/parts/registeredServer/common/objectExplorerService.ts
+++ b/src/sql/parts/registeredServer/common/objectExplorerService.ts
@@ -19,7 +19,7 @@ import * as TelemetryUtils from 'sql/common/telemetryUtilities';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { warn, error } from 'sql/base/common/log';
 import { ServerTreeView } from 'sql/parts/registeredServer/viewlet/serverTreeView';
-import { ICapabilitiesService } from '../../../services/capabilities/capabilitiesService';
+import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
 
 export const SERVICE_ID = 'ObjectExplorerService';
 

--- a/src/sql/services/capabilities/capabilitiesService.ts
+++ b/src/sql/services/capabilities/capabilitiesService.ts
@@ -19,7 +19,6 @@ import { Memento } from 'vs/workbench/common/memento';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IDisposable, dispose, Disposable } from 'vs/base/common/lifecycle';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { fromObject } from 'sql/base/common/map';
 
 export const SERVICE_ID = 'capabilitiesService';
 export const HOST_NAME = 'sqlops';

--- a/src/sql/services/capabilities/capabilitiesService.ts
+++ b/src/sql/services/capabilities/capabilitiesService.ts
@@ -57,6 +57,11 @@ export interface ICapabilitiesService {
 	 */
 	onCapabilitiesReady(): Promise<void>;
 
+	/**
+	 * Get an array of all known providers
+	 */
+	readonly providers: string[];
+
 }
 
 /**
@@ -75,7 +80,6 @@ export class CapabilitiesService implements ICapabilitiesService {
 	private _onProviderRegistered: Emitter<sqlops.DataProtocolServerCapabilities>;
 
 	private _clientCapabilties: sqlops.DataProtocolClientCapabilities = {
-
 		hostName: HOST_NAME,
 		hostVersion: HOST_VERSION
 	};
@@ -150,6 +154,10 @@ export class CapabilitiesService implements ICapabilitiesService {
 	 */
 	public getCapabilities(provider: string): sqlops.DataProtocolServerCapabilities {
 		return this._momento_data[provider];
+	}
+
+	public get providers(): string[] {
+		return Object.keys(this._momento_data);
 	}
 
 	/**

--- a/src/sql/services/serialization/serializationService.ts
+++ b/src/sql/services/serialization/serializationService.ts
@@ -74,7 +74,7 @@ export class SerializationService implements ISerializationService {
 
 	public getSerializationFeatureMetadataProvider(ownerUri: string): sqlops.FeatureMetadataProvider {
 		let providerId: string = this._connectionService.getProviderIdFromUri(ownerUri);
-		let providerCapabilities = this._capabilitiesService.getCapabilities().find(c => c.providerName === providerId);
+		let providerCapabilities = this._capabilitiesService.getCapabilities(providerId);
 
 		if (providerCapabilities) {
 			return providerCapabilities.features.find(f => f.featureName === SERVICE_ID);

--- a/src/sqltest/parts/connection/connectionProfile.test.ts
+++ b/src/sqltest/parts/connection/connectionProfile.test.ts
@@ -11,7 +11,7 @@ import { IConnectionProfile, IConnectionProfileStore } from 'sql/parts/connectio
 import * as sqlops from 'sqlops';
 import * as assert from 'assert';
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
-import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
+import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 
 suite('SQL ConnectionProfileInfo tests', () => {
 	let msSQLCapabilities: sqlops.DataProtocolServerCapabilities;

--- a/src/sqltest/parts/connection/connectionStatusManager.test.ts
+++ b/src/sqltest/parts/connection/connectionStatusManager.test.ts
@@ -93,7 +93,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 		let id: string = connection1Id;
 		let expected = connectionProfileObject;
 		let actual = connections.findConnection(id);
-		assert.deepEqual(actual.connectionProfile, expected);
+		assert.equal(connectionProfileObject.matches(actual.connectionProfile), true);
 	});
 
 	test('getConnectionProfile should return undefined given invalid id', () => {
@@ -107,7 +107,7 @@ suite('SQL ConnectionStatusManager tests', () => {
 		let id: string = connection1Id;
 		let expected = connectionProfileObject;
 		let actual = connections.getConnectionProfile(id);
-		assert.deepEqual(actual, expected);
+		assert.equal(connectionProfileObject.matches(actual), true);
 	});
 
 	test('hasConnection should return false given invalid id', () => {

--- a/src/sqltest/parts/connection/connectionStatusManager.test.ts
+++ b/src/sqltest/parts/connection/connectionStatusManager.test.ts
@@ -72,8 +72,7 @@ let connection3Id: string;
 suite('SQL ConnectionStatusManager tests', () => {
 	setup(() => {
 		capabilitiesService = new CapabilitiesTestService();
-		connectionProfileObject = new ConnectionProfile(capabilitiesService.getCapabilities('MSSQL')
-			, connectionProfile);
+		connectionProfileObject = new ConnectionProfile(capabilitiesService, connectionProfile);
 		connections = new ConnectionStatusManager(capabilitiesService);
 		connection1Id = Utils.generateUri(connectionProfile);
 		connection2Id = 'connection2Id';

--- a/src/sqltest/parts/connection/connectionStatusManager.test.ts
+++ b/src/sqltest/parts/connection/connectionStatusManager.test.ts
@@ -72,7 +72,7 @@ let connection3Id: string;
 suite('SQL ConnectionStatusManager tests', () => {
 	setup(() => {
 		capabilitiesService = new CapabilitiesTestService();
-		connectionProfileObject = new ConnectionProfile(capabilitiesService.getCapabilities().find(x => x.providerName === 'MSSQL')
+		connectionProfileObject = new ConnectionProfile(capabilitiesService.getCapabilities('MSSQL')
 			, connectionProfile);
 		connections = new ConnectionStatusManager(capabilitiesService);
 		connection1Id = Utils.generateUri(connectionProfile);

--- a/src/sqltest/parts/connection/connectionStore.test.ts
+++ b/src/sqltest/parts/connection/connectionStore.test.ts
@@ -20,6 +20,7 @@ import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile
 import { Emitter } from 'vs/base/common/event';
 import { ConnectionProfileGroup, IConnectionProfileGroup } from 'sql/parts/connection/common/connectionProfileGroup';
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
 
 suite('SQL ConnectionStore tests', () => {
 	let defaultNamedProfile: IConnectionProfile;
@@ -29,12 +30,11 @@ suite('SQL ConnectionStore tests', () => {
 	let connectionConfig: TypeMoq.Mock<ConnectionConfig>;
 	let workspaceConfigurationServiceMock: TypeMoq.Mock<WorkspaceConfigurationTestService>;
 	let storageServiceMock: TypeMoq.Mock<StorageTestService>;
-	let capabilitiesService: TypeMoq.Mock<CapabilitiesService>;
+	let capabilitiesService: CapabilitiesTestService;
 	let mementoArray: any = [];
 	let maxRecent = 5;
 	let msSQLCapabilities: sqlops.DataProtocolServerCapabilities;
 	let defaultNamedConnectionProfile: ConnectionProfile;
-	let onCapabilitiesRegistered = new Emitter<string>();
 
 	setup(() => {
 		defaultNamedProfile = Object.assign({}, {
@@ -95,7 +95,7 @@ suite('SQL ConnectionStore tests', () => {
 			}
 		};
 
-		capabilitiesService = TypeMoq.Mock.ofType(CapabilitiesService, TypeMoq.MockBehavior.Loose, extensionManagementServiceMock, {});
+		capabilitiesService = new CapabilitiesTestService();
 		let capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities } = {};
 		let connectionProvider: sqlops.ConnectionProviderOptions = {
 			options: [
@@ -170,8 +170,7 @@ suite('SQL ConnectionStore tests', () => {
 			features: undefined
 		};
 		capabilities['MSSQL'] = msSQLCapabilities;
-		capabilitiesService.setup(x => x.getCapabilities(TypeMoq.It.isAnyString())).returns((x) => capabilities[x]);
-		capabilitiesService.setup(x => x.onCapabilitiesRegistered).returns(() => onCapabilitiesRegistered.event);
+		capabilitiesService.capabilities['MSSQL'] = msSQLCapabilities;
 		let groups: IConnectionProfileGroup[] = [
 			{
 				id: 'root',
@@ -190,7 +189,7 @@ suite('SQL ConnectionStore tests', () => {
 		];
 		connectionConfig.setup(x => x.getAllGroups()).returns(() => groups);
 
-		defaultNamedConnectionProfile = new ConnectionProfile(capabilitiesService.object, defaultNamedProfile);
+		defaultNamedConnectionProfile = new ConnectionProfile(capabilitiesService, defaultNamedProfile);
 	});
 
 	test('addActiveConnection should limit recent connection saves to the MaxRecentConnections amount', (done) => {
@@ -204,11 +203,11 @@ suite('SQL ConnectionStore tests', () => {
 		// When saving 4 connections
 		// Expect all of them to be saved even if size is limited to 3
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		let promise = Promise.resolve();
 		for (let i = 0; i < numCreds; i++) {
 			let cred = Object.assign({}, defaultNamedProfile, { serverName: defaultNamedProfile.serverName + i });
-			let connectionProfile = new ConnectionProfile(capabilitiesService.object, cred);
+			let connectionProfile = new ConnectionProfile(capabilitiesService, cred);
 			promise = promise.then(() => {
 				return connectionStore.addActiveConnection(connectionProfile);
 			}).then(() => {
@@ -241,12 +240,12 @@ suite('SQL ConnectionStore tests', () => {
 		// Given we save the same connection twice
 		// Then expect the only 1 instance of that connection to be listed in the MRU
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		connectionStore.clearActiveConnections();
 		connectionStore.clearRecentlyUsed();
 		let promise = Promise.resolve();
 		let cred = Object.assign({}, defaultNamedProfile, { serverName: defaultNamedProfile.serverName + 1 });
-		let connectionProfile = new ConnectionProfile(capabilitiesService.object, cred);
+		let connectionProfile = new ConnectionProfile(capabilitiesService, cred);
 		promise = promise.then(() => {
 			return connectionStore.addActiveConnection(defaultNamedConnectionProfile);
 		}).then(() => {
@@ -276,7 +275,7 @@ suite('SQL ConnectionStore tests', () => {
 
 		// Given we save 1 connection with password and multiple other connections without
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		connectionStore.clearActiveConnections();
 		connectionStore.clearRecentlyUsed();
 		let integratedCred = Object.assign({}, defaultNamedProfile, {
@@ -289,7 +288,7 @@ suite('SQL ConnectionStore tests', () => {
 			serverName: defaultNamedProfile.serverName + 'NoPwd',
 			password: ''
 		});
-		let connectionProfile = new ConnectionProfile(capabilitiesService.object, defaultNamedProfile);
+		let connectionProfile = new ConnectionProfile(capabilitiesService, defaultNamedProfile);
 
 		let expectedCredCount = 0;
 		let promise = Promise.resolve();
@@ -307,7 +306,7 @@ suite('SQL ConnectionStore tests', () => {
 		}).then(() => {
 			// When add integrated auth connection
 			expectedCredCount++;
-			let integratedCredConnectionProfile = new ConnectionProfile(capabilitiesService.object, integratedCred);
+			let integratedCredConnectionProfile = new ConnectionProfile(capabilitiesService, integratedCred);
 			return connectionStore.addActiveConnection(integratedCredConnectionProfile);
 		}).then(() => {
 			let current = connectionStore.getRecentlyUsedConnections();
@@ -317,7 +316,7 @@ suite('SQL ConnectionStore tests', () => {
 		}).then(() => {
 			// When add connection without password
 			expectedCredCount++;
-			let noPwdCredConnectionProfile = new ConnectionProfile(capabilitiesService.object, noPwdCred);
+			let noPwdCredConnectionProfile = new ConnectionProfile(capabilitiesService, noPwdCred);
 			return connectionStore.addActiveConnection(noPwdCredConnectionProfile);
 		}).then(() => {
 			let current = connectionStore.getRecentlyUsedConnections();
@@ -331,7 +330,7 @@ suite('SQL ConnectionStore tests', () => {
 		connectionConfig.setup(x => x.getConnections(TypeMoq.It.isAny())).returns(() => []);
 
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 
 		// When we clear the connections list and get the list of available connection items
 		connectionStore.clearActiveConnections();
@@ -349,7 +348,7 @@ suite('SQL ConnectionStore tests', () => {
 	test('isPasswordRequired should return true for MSSQL SqlLogin', () => {
 
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 
 		let expected: boolean = true;
 		let actual = connectionStore.isPasswordRequired(defaultNamedProfile);
@@ -359,8 +358,8 @@ suite('SQL ConnectionStore tests', () => {
 
 	test('isPasswordRequired should return true for MSSQL SqlLogin for connection profile object', () => {
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
-		let connectionProfile = new ConnectionProfile(capabilitiesService.object, defaultNamedProfile);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
+		let connectionProfile = new ConnectionProfile(capabilitiesService, defaultNamedProfile);
 		let expected: boolean = true;
 		let actual = connectionStore.isPasswordRequired(connectionProfile);
 
@@ -386,8 +385,10 @@ suite('SQL ConnectionStore tests', () => {
 			features: undefined
 		};
 
+		capabilitiesService.capabilities[providerName] = providerCapabilities;
+
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		let connectionProfile: IConnectionProfile = Object.assign({}, defaultNamedProfile, { providerName: providerName });
 		let expected: boolean = false;
 		let actual = connectionStore.isPasswordRequired(connectionProfile);
@@ -404,7 +405,7 @@ suite('SQL ConnectionStore tests', () => {
 		credentialStore.setup(x => x.saveCredential(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve(true));
 
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 
 		connectionStore.saveProfile(connectionProfile).then(profile => {
 			// add connection should be called with a profile without password
@@ -421,7 +422,7 @@ suite('SQL ConnectionStore tests', () => {
 
 	test('addConnectionToMemento should not add duplicate items', () => {
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		let mementoKey = 'RECENT_CONNECTIONS2';
 		connectionStore.clearFromMemento(mementoKey);
 		let connectionProfile: IConnectionProfile = Object.assign({}, defaultNamedProfile);
@@ -463,7 +464,7 @@ suite('SQL ConnectionStore tests', () => {
 
 	test('getGroupFromId returns undefined when there is no group with the given ID', () => {
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		let group = connectionStore.getGroupFromId('invalidId');
 		assert.equal(group, undefined, 'Returned group was not undefined when there was no group with the given ID');
 	});
@@ -479,7 +480,7 @@ suite('SQL ConnectionStore tests', () => {
 		let newConnectionConfig = TypeMoq.Mock.ofType(ConnectionConfig);
 		newConnectionConfig.setup(x => x.getAllGroups()).returns(() => groups);
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, newConnectionConfig.object);
+			credentialStore.object, capabilitiesService, newConnectionConfig.object);
 
 		// If I look up the parent group using its ID, then I get back the correct group
 		let actualGroup = connectionStore.getGroupFromId(parentGroupId);
@@ -492,14 +493,14 @@ suite('SQL ConnectionStore tests', () => {
 
 	test('getProfileWithoutPassword can return the profile without credentials in the password property or options dictionary', () => {
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
-			credentialStore.object, capabilitiesService.object, connectionConfig.object);
+			credentialStore.object, capabilitiesService, connectionConfig.object);
 		let profile = Object.assign({}, defaultNamedProfile);
 		profile.options['password'] = profile.password;
 		profile.id = 'testId';
 		let expectedProfile = Object.assign({}, profile);
 		expectedProfile.password = '';
 		expectedProfile.options['password'] = '';
-		expectedProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService.object, expectedProfile).toIConnectionProfile();
+		expectedProfile = ConnectionProfile.fromIConnectionProfile(capabilitiesService, expectedProfile).toIConnectionProfile();
 		let profileWithoutCredentials = connectionStore.getProfileWithoutPassword(profile);
 		assert.deepEqual(profileWithoutCredentials.toIConnectionProfile(), expectedProfile);
 	});

--- a/src/sqltest/parts/connection/connectionStore.test.ts
+++ b/src/sqltest/parts/connection/connectionStore.test.ts
@@ -97,7 +97,7 @@ suite('SQL ConnectionStore tests', () => {
 		};
 
 		capabilitiesService = TypeMoq.Mock.ofType(CapabilitiesService, TypeMoq.MockBehavior.Loose, extensionManagementServiceMock, {});
-		let capabilities: sqlops.DataProtocolServerCapabilities[] = [];
+		let capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities } = {};
 		let connectionProvider: sqlops.ConnectionProviderOptions = {
 			options: [
 				{
@@ -170,10 +170,9 @@ suite('SQL ConnectionStore tests', () => {
 			adminServicesProvider: undefined,
 			features: undefined
 		};
-		capabilities.push(msSQLCapabilities);
-		capabilitiesService.setup(x => x.getCapabilities()).returns(() => capabilities);
+		capabilities['MSSQL'] = msSQLCapabilities;
+		capabilitiesService.setup(x => x.getCapabilities(TypeMoq.It.isAnyString())).returns((x) => capabilities[x]);
 		capabilitiesService.setup(x => x.onProviderRegisteredEvent).returns(() => onProviderRegistered.event);
-		connectionConfig.setup(x => x.getCapabilities('MSSQL')).returns(() => msSQLCapabilities);
 		let groups: IConnectionProfileGroup[] = [
 			{
 				id: 'root',
@@ -387,7 +386,6 @@ suite('SQL ConnectionStore tests', () => {
 			adminServicesProvider: undefined,
 			features: undefined
 		};
-		connectionConfig.setup(x => x.getCapabilities(providerName)).returns(() => providerCapabilities);
 
 		let connectionStore = new ConnectionStore(storageServiceMock.object, context.object, undefined, workspaceConfigurationServiceMock.object,
 			credentialStore.object, capabilitiesService.object, connectionConfig.object);

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -33,6 +33,7 @@ import Severity from 'vs/base/common/severity';
 import { ObjectExplorerActionsContext, ManageConnectionAction } from 'sql/parts/registeredServer/viewlet/objectExplorerActions';
 import { IConnectionResult, IConnectionParams } from 'sql/parts/connection/common/connectionManagement';
 import { TreeSelectionHandler } from 'sql/parts/registeredServer/viewlet/treeSelectionHandler';
+import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
 
 suite('SQL Connection Tree Action tests', () => {
 	let errorMessageService: TypeMoq.Mock<ErrorMessageServiceStub>;
@@ -42,7 +43,9 @@ suite('SQL Connection Tree Action tests', () => {
 		errorCode: undefined,
 		callStack: undefined
 	};
+	let capabilitiesService: CapabilitiesTestService;
 	setup(() => {
+		let capabilitiesService = new CapabilitiesTestService();
 		errorMessageService = TypeMoq.Mock.ofType(ErrorMessageServiceStub, TypeMoq.MockBehavior.Loose);
 		let nothing: void;
 		errorMessageService.setup(x => x.showDialog(Severity.Error, TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => nothing);
@@ -348,7 +351,9 @@ suite('SQL Connection Tree Action tests', () => {
 			features: undefined
 		};
 
-		var connection = new ConnectionProfile(sqlProvider, {
+		capabilitiesService.capabilities['MSSQL'] = sqlProvider;
+
+		var connection = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -437,7 +442,9 @@ suite('SQL Connection Tree Action tests', () => {
 			features: undefined
 		};
 
-		var connection = new ConnectionProfile(sqlProvider, {
+		capabilitiesService.capabilities['MSSQL'] = sqlProvider;
+
+		var connection = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -33,7 +33,7 @@ import Severity from 'vs/base/common/severity';
 import { ObjectExplorerActionsContext, ManageConnectionAction } from 'sql/parts/registeredServer/viewlet/objectExplorerActions';
 import { IConnectionResult, IConnectionParams } from 'sql/parts/connection/common/connectionManagement';
 import { TreeSelectionHandler } from 'sql/parts/registeredServer/viewlet/treeSelectionHandler';
-import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
+import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 
 suite('SQL Connection Tree Action tests', () => {
 	let errorMessageService: TypeMoq.Mock<ErrorMessageServiceStub>;

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -43,9 +43,8 @@ suite('SQL Connection Tree Action tests', () => {
 		errorCode: undefined,
 		callStack: undefined
 	};
-	let capabilitiesService: CapabilitiesTestService;
+	let capabilitiesService = new CapabilitiesTestService();
 	setup(() => {
-		let capabilitiesService = new CapabilitiesTestService();
 		errorMessageService = TypeMoq.Mock.ofType(ErrorMessageServiceStub, TypeMoq.MockBehavior.Loose);
 		let nothing: void;
 		errorMessageService.setup(x => x.showDialog(Severity.Error, TypeMoq.It.isAnyString(), TypeMoq.It.isAnyString())).returns(() => nothing);
@@ -94,7 +93,7 @@ suite('SQL Connection Tree Action tests', () => {
 
 		let manageConnectionAction: ManageConnectionAction = new ManageConnectionAction(ManageConnectionAction.ID,
 			ManageConnectionAction.LABEL, connectionManagementService.object, instantiationService.object, objectExplorerService.object);
-		let connection: ConnectionProfile = new ConnectionProfile(undefined, {
+		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -129,7 +128,7 @@ suite('SQL Connection Tree Action tests', () => {
 
 		let manageConnectionAction: ManageConnectionAction = new ManageConnectionAction(ManageConnectionAction.ID,
 			ManageConnectionAction.LABEL, connectionManagementService.object, instantiationService.object, objectExplorerService.object);
-		let connection: ConnectionProfile = new ConnectionProfile(undefined, {
+		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -161,7 +160,7 @@ suite('SQL Connection Tree Action tests', () => {
 		let objectExplorerService = createObjectExplorerService(connectionManagementService.object);
 
 		let changeConnectionAction: DisconnectConnectionAction = new DisconnectConnectionAction(DisconnectConnectionAction.ID, DisconnectConnectionAction.LABEL, connectionManagementService.object, objectExplorerService.object, errorMessageService.object);
-		let connection: ConnectionProfile = new ConnectionProfile(undefined, {
+		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -268,7 +267,7 @@ suite('SQL Connection Tree Action tests', () => {
 	test('DeleteConnectionAction - test delete connection', (done) => {
 		let connectionManagementService = createConnectionManagementService(true);
 
-		let connection: ConnectionProfile = new ConnectionProfile(undefined, {
+		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -314,7 +313,7 @@ suite('SQL Connection Tree Action tests', () => {
 		let isConnectedReturnValue: boolean = false;
 		let connectionManagementService = createConnectionManagementService(isConnectedReturnValue);
 
-		let connection: ConnectionProfile = new ConnectionProfile(undefined, {
+		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -20,7 +20,7 @@ import { ServerTreeView } from 'sql/parts/registeredServer/viewlet/serverTreeVie
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
 import Event, { Emitter } from 'vs/base/common/event';
 import { CapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
-import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
+import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 
 suite('SQL Object Explorer Service tests', () => {
 	var sqlOEProvider: TypeMoq.Mock<ObjectExplorerProviderTestService>;

--- a/src/sqltest/parts/connection/providerConnectionInfo.test.ts
+++ b/src/sqltest/parts/connection/providerConnectionInfo.test.ts
@@ -12,7 +12,7 @@ import * as sqlops from 'sqlops';
 import * as assert from 'assert';
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
 import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
-import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
+import { CapabilitiesTestService } from 'sqltest/stubs/capabilitiesTestService';
 
 suite('SQL ProviderConnectionInfo tests', () => {
 	let msSQLCapabilities: sqlops.DataProtocolServerCapabilities;

--- a/src/sqltest/parts/connection/providerConnectionInfo.test.ts
+++ b/src/sqltest/parts/connection/providerConnectionInfo.test.ts
@@ -11,9 +11,12 @@ import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import * as sqlops from 'sqlops';
 import * as assert from 'assert';
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
+import { CapabilitiesTestService } from '../../stubs/capabilitiesTestService';
 
 suite('SQL ProviderConnectionInfo tests', () => {
 	let msSQLCapabilities: sqlops.DataProtocolServerCapabilities;
+	let capabilitiesService: CapabilitiesTestService;
 
 	let connectionProfile: IConnectionProfile = {
 		serverName: 'new server',
@@ -119,6 +122,8 @@ suite('SQL ProviderConnectionInfo tests', () => {
 			features: undefined
 		};
 		capabilities.push(msSQLCapabilities);
+		capabilitiesService = new CapabilitiesTestService();
+		capabilitiesService.capabilities['MSSQL'] = msSQLCapabilities;
 	});
 
 	test('constructor should accept undefined parameters', () => {
@@ -127,7 +132,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('set properties should set the values correctly', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, undefined);
+		let conn = new ProviderConnectionInfo(capabilitiesService, 'MSSQL');
 		assert.equal(conn.serverName, undefined);
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName;
@@ -142,7 +147,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('set properties should store the values in the options', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, undefined);
+		let conn = new ProviderConnectionInfo(capabilitiesService, 'MSSQL');
 		assert.equal(conn.serverName, undefined);
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName;
@@ -157,7 +162,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('constructor should initialize the options given a valid model', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, connectionProfile);
+		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
 		assert.equal(conn.serverName, connectionProfile.serverName);
 		assert.equal(conn.databaseName, connectionProfile.databaseName);
@@ -167,7 +172,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('clone should create a new instance that equals the old one', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, connectionProfile);
+		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
 		let conn2 = conn.clone();
 		assert.equal(conn.serverName, conn2.serverName);
@@ -178,7 +183,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('Changing the cloned object should not change the original one', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, connectionProfile);
+		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
 		let conn2 = conn.clone();
 		conn2.serverName = conn.serverName + '1';
@@ -189,7 +194,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let options = {};
 		options['encrypt'] = 'test value';
 		let conn2 = Object.assign({}, connectionProfile, { options: options });
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, conn2);
+		let conn = new ProviderConnectionInfo(capabilitiesService, conn2);
 
 		assert.equal(conn.serverName, conn2.serverName);
 		assert.equal(conn.databaseName, conn2.databaseName);
@@ -200,21 +205,21 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	});
 
 	test('getOptionsKey should create a valid unique id', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, connectionProfile);
+		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 		let expectedId = 'providerName:MSSQL|authenticationType:|databaseName:database|serverName:new server|userName:user';
 		let id = conn.getOptionsKey();
 		assert.equal(id, expectedId);
 	});
 
 	test('getOptionsKey should create different id for different server names', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, connectionProfile);
-		let conn2 = new ProviderConnectionInfo(msSQLCapabilities, Object.assign({}, connectionProfile, { serverName: connectionProfile.serverName + '1' }));
+		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
+		let conn2 = new ProviderConnectionInfo(capabilitiesService, Object.assign({}, connectionProfile, { serverName: connectionProfile.serverName + '1' }));
 
 		assert.notEqual(conn.getOptionsKey(), conn2.getOptionsKey());
 	});
 
 	test('titleParts should return server, database and auth type as first items', () => {
-		let conn = new ProviderConnectionInfo(msSQLCapabilities, connectionProfile);
+		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 		let titleParts = conn.titleParts;
 		assert.equal(titleParts.length, 4);
 		assert.equal(titleParts[0], connectionProfile.serverName);

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -105,6 +105,10 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 		return this._capabilities[provider];
 	}
 
+	public get providers(): string[] {
+		return Object.keys(this._capabilities);
+	}
+
 	/**
 	 * Register the capabilities provider and query the provider for its capabilities
 	 * @param provider

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -6,11 +6,11 @@
 'use strict';
 import * as sqlops from 'sqlops';
 import { ConnectionManagementInfo } from 'sql/parts/connection/common/connectionManagementInfo';
-import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
-import Event from 'vs/base/common/event';
-import { Action } from 'vs/base/common/actions';
+import { ICapabilitiesService, clientCapabilities } from 'sql/services/capabilities/capabilitiesService';
 import { ConnectionOptionSpecialType } from 'sql/workbench/api/common/sqlExtHostTypes';
 
+import Event, { Emitter } from 'vs/base/common/event';
+import { Action } from 'vs/base/common/actions';
 
 export class CapabilitiesTestService implements ICapabilitiesService {
 
@@ -18,7 +18,7 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 
 	private _providers: sqlops.CapabilitiesProvider[] = [];
 
-	private _capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities} = { };
+	public capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities} = { };
 
 	constructor() {
 
@@ -94,7 +94,7 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 			adminServicesProvider: undefined,
 			features: undefined
 		};
-		this._capabilities['MSSQL'] = msSQLCapabilities;
+		this.capabilities['MSSQL'] = msSQLCapabilities;
 
 	}
 
@@ -102,11 +102,11 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 	 * Retrieve a list of registered server capabilities
 	 */
 	public getCapabilities(provider: string): sqlops.DataProtocolServerCapabilities {
-		return this._capabilities[provider];
+		return this.capabilities[provider];
 	}
 
 	public get providers(): string[] {
-		return Object.keys(this._capabilities);
+		return Object.keys(this.capabilities);
 	}
 
 	/**
@@ -128,5 +128,8 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 	public onCapabilitiesReady(): Promise<void> {
 		return Promise.resolve(null);
 	}
+
+	private _onCapabilitiesRegistered = new Emitter<string>();
+	public readonly onCapabilitiesRegistered = this._onCapabilitiesRegistered.event;
 }
 

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -18,7 +18,7 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 
 	private _providers: sqlops.CapabilitiesProvider[] = [];
 
-	public capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities} = { };
+	public capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities } = {};
 
 	constructor() {
 

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -18,8 +18,7 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 
 	private _providers: sqlops.CapabilitiesProvider[] = [];
 
-	private _capabilities: sqlops.DataProtocolServerCapabilities[] = [];
-
+	private _capabilities: { [id: string]: sqlops.DataProtocolServerCapabilities} = { };
 
 	constructor() {
 
@@ -95,15 +94,15 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 			adminServicesProvider: undefined,
 			features: undefined
 		};
-		this._capabilities.push(msSQLCapabilities);
+		this._capabilities['MSSQL'] = msSQLCapabilities;
 
 	}
 
 	/**
 	 * Retrieve a list of registered server capabilities
 	 */
-	public getCapabilities(): sqlops.DataProtocolServerCapabilities[] {
-		return this._capabilities;
+	public getCapabilities(provider: string): sqlops.DataProtocolServerCapabilities {
+		return this._capabilities[provider];
 	}
 
 	/**


### PR DESCRIPTION
Cleans up how we handle cacheing capabilities for services and isolates it all to the capabilities service. Removes a lot of unnecessary code, while also fixing the bug that the connection wouldn't be buffered properly.