### PR TITLE
Credentials and Serilization shouldn't register for all features

### DIFF
--- a/build/lib/i18n.js
+++ b/build/lib/i18n.js
@@ -501,10 +501,8 @@ function prepareXlfFiles(projectName, extensionName) {
 }
 exports.prepareXlfFiles = prepareXlfFiles;
 var editorProject = 'vscode-editor', workbenchProject = 'vscode-workbench', extensionsProject = 'vscode-extensions', setupProject = 'vscode-setup';
-
 // {{SQL CARBON EDIT}}
 var sqlopsProject = 'sqlops-core';
-
 function getResource(sourceFile) {
     var resource;
     if (/^vs\/platform/.test(sourceFile)) {
@@ -533,12 +531,9 @@ function getResource(sourceFile) {
     else if (/^vs\/workbench/.test(sourceFile)) {
         return { name: 'vs/workbench', project: workbenchProject };
     }
-
-    // {{SQL CARBON EDIT}}
-	else if (/^sql/.test(sourceFile)) {
-		return { name: 'sql', project: sqlopsProject };
-	}
-
+    else if (/^sql/.test(sourceFile)) {
+        return { name: 'sql', project: sqlopsProject };
+    }
     throw new Error("Could not identify the XLF bundle for " + sourceFile);
 }
 exports.getResource = getResource;

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -384,9 +384,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.2":
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease":
   version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/524cfc580e93f7ed85573e5291b5ca69fbda72f3"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/11e0f50fb67864ed40ba8463c8cd1caa1fc9386a"
   dependencies:
     vscode-languageclient "3.5.0"
 
@@ -569,7 +569,7 @@ extend@~1.2.1:
 "extensions-modules@file:../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#0.1.2"
+    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -384,9 +384,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease":
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.3":
   version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/11e0f50fb67864ed40ba8463c8cd1caa1fc9386a"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/cedce3c62e0f29790998f5a060390bde52b6618a"
   dependencies:
     vscode-languageclient "3.5.0"
 
@@ -569,7 +569,7 @@ extend@~1.2.1:
 "extensions-modules@file:../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease"
+    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#0.1.3"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"

--- a/extensions-modules/package.json
+++ b/extensions-modules/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Shared modules for Carbon extensions",
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.1.2",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease",
     "decompress": "^4.2.0",
     "fs-extra-promise": "^1.0.1",
     "http-proxy-agent": "^2.0.0",

--- a/extensions-modules/package.json
+++ b/extensions-modules/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Shared modules for Carbon extensions",
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.1.3",
     "decompress": "^4.2.0",
     "fs-extra-promise": "^1.0.1",
     "http-proxy-agent": "^2.0.0",

--- a/extensions-modules/src/languageservice/serviceClient.ts
+++ b/extensions-modules/src/languageservice/serviceClient.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import { ExtensionContext, workspace, window, OutputChannel, languages } from 'vscode';
-import { SqlOpsDataClient, LanguageClientOptions } from 'dataprotocol-client';
+import { SqlOpsDataClient, ClientOptions } from 'dataprotocol-client';
 import { CloseAction, ErrorAction, ServerOptions, NotificationHandler, NotificationType, RequestType, TransportKind } from 'vscode-languageclient';
 
 import { VscodeWrapper } from '../controllers/vscodeWrapper';
@@ -329,7 +329,7 @@ export class SqlToolsServiceClient {
 						languageClientHelper.createServerOptions(serverPath, runtimeId) : this.createServerOptions(serverPath);
 
 					// Options to control the language client
-					let clientOptions: LanguageClientOptions = {
+					let clientOptions: ClientOptions = {
 						documentSelector: [SqlToolsServiceClient._constants.languageId],
 						providerId: '',
 						synchronize: {
@@ -351,7 +351,9 @@ export class SqlToolsServiceClient {
 							name: '',
 							show: () => {
 							}
-						}
+						},
+						// pass in no features so we don't register features we don't want
+						features: []
 					};
 
 					this._serviceStatus.showServiceLoading();
@@ -405,7 +407,7 @@ export class SqlToolsServiceClient {
 
 	private createLanguageClient(serverOptions: ServerOptions): SqlOpsDataClient {
 		// Options to control the language client
-		let clientOptions: LanguageClientOptions = {
+		let clientOptions: ClientOptions = {
 			documentSelector: [SqlToolsServiceClient._constants.languageId],
 			providerId: SqlToolsServiceClient._constants.providerId,
 			synchronize: {

--- a/extensions-modules/yarn.lock
+++ b/extensions-modules/yarn.lock
@@ -321,9 +321,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease":
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.3":
   version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/11e0f50fb67864ed40ba8463c8cd1caa1fc9386a"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/cedce3c62e0f29790998f5a060390bde52b6618a"
   dependencies:
     vscode-languageclient "3.5.0"
 

--- a/extensions-modules/yarn.lock
+++ b/extensions-modules/yarn.lock
@@ -321,9 +321,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.2":
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease":
   version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/524cfc580e93f7ed85573e5291b5ca69fbda72f3"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/11e0f50fb67864ed40ba8463c8cd1caa1fc9386a"
   dependencies:
     vscode-languageclient "3.5.0"
 

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -333,9 +333,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.2":
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease":
   version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/524cfc580e93f7ed85573e5291b5ca69fbda72f3"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/11e0f50fb67864ed40ba8463c8cd1caa1fc9386a"
   dependencies:
     vscode-languageclient "3.5.0"
 
@@ -538,7 +538,7 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
 "extensions-modules@file:../../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#0.1.2"
+    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -333,9 +333,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease":
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.3":
   version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/11e0f50fb67864ed40ba8463c8cd1caa1fc9386a"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/cedce3c62e0f29790998f5a060390bde52b6618a"
   dependencies:
     vscode-languageclient "3.5.0"
 
@@ -538,7 +538,7 @@ extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
 "extensions-modules@file:../../extensions-modules":
   version "0.1.0"
   dependencies:
-    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#feat/initFeaturesrelease"
+    dataprotocol-client "github:Microsoft/sqlops-dataprotocolclient#0.1.3"
     decompress "^4.2.0"
     fs-extra-promise "^1.0.1"
     http-proxy-agent "^2.0.0"


### PR DESCRIPTION
dependent on Microsoft/sqlops-dataprotocolclient#4 

Changes so that credentials and serialization providers don't register as other features they don't provider, i.e connection, backup, restore, etc.