### PR TITLE
Adjust ObjectExplorer spacing to 25px

### DIFF
--- a/src/sql/parts/registeredServer/viewlet/serverTreeRenderer.ts
+++ b/src/sql/parts/registeredServer/viewlet/serverTreeRenderer.ts
@@ -25,11 +25,11 @@ import { TreeNode } from 'sql/parts/registeredServer/common/treeNode';
  */
 export class ServerTreeRenderer implements IRenderer {
 
-	public static CONNECTION_HEIGHT = 28;
+	public static CONNECTION_HEIGHT = 25;
 	public static CONNECTION_GROUP_HEIGHT = 38;
 	private static CONNECTION_TEMPLATE_ID = 'connectionProfile';
 	private static CONNECTION_GROUP_TEMPLATE_ID = 'connectionProfileGroup';
-	public static OBJECTEXPLORER_HEIGHT = 28;
+	public static OBJECTEXPLORER_HEIGHT = 25;
 	private static OBJECTEXPLORER_TEMPLATE_ID = 'objectExplorer';
 	/**
 	 * _isCompact is used to render connections tiles with and without the action buttons.


### PR DESCRIPTION
This is an updated request by issue https://github.com/Microsoft/sqlopsstudio/issues/885 to tighten up the ObjectExplorer spacing.

The below image should current 28px next to proposed 25px.  The 25px look is clearly more compact, though I don't have a strong preference here.

![screen1](https://user-images.githubusercontent.com/599935/37230279-c21b7d92-239b-11e8-8324-4f5f998a1bc2.png)
