### PR TITLE
supporting sql built-in extensions

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -71,7 +71,7 @@ const excludedExtensions = [
 const vsce = require('vsce');
 const sqlBuiltInExtensions = [
 	// Add SQL built-in extensions here.
-	// the extension will be excluded from SQLOps package and ill have separate vsix packages
+	// the extension will be excluded from SQLOps package and will have separate vsix packages
 ];
 
 const vscodeEntryPoints = _.flatten([
@@ -250,7 +250,7 @@ function computeChecksum(filename) {
 }
 
 function packageBuiltInExtensions() {
-	const sqlBuiltInlocalExtensionDescriptions = glob.sync('extensions/*/package.json')
+	const sqlBuiltInLocalExtensionDescriptions = glob.sync('extensions/*/package.json')
 			.map(manifestPath => {
 				const extensionPath = path.dirname(path.join(root, manifestPath));
 				const extensionName = path.basename(extensionPath);
@@ -259,7 +259,7 @@ function packageBuiltInExtensions() {
 			.filter(({ name }) => excludedExtensions.indexOf(name) === -1)
 			.filter(({ name }) => builtInExtensions.every(b => b.name !== name))
 			.filter(({ name }) => sqlBuiltInExtensions.indexOf(name) >= 0);
-	sqlBuiltInlocalExtensionDescriptions.forEach(element => {
+	sqlBuiltInLocalExtensionDescriptions.forEach(element => {
 		const packagePath = path.join(path.dirname(root), element.name + '.vsix');
 		console.info('Creating vsix for ' + element.path + ' result:' + packagePath);
 		vsce.createVSIX({

--- a/product.json
+++ b/product.json
@@ -32,7 +32,6 @@
 	"extensionsGallery": {
 		"serviceUrl":"https://raw.githubusercontent.com/Microsoft/sqlopsstudio/release/extensions/extensionsGallery.json"
 	},
-	"extensionTips": {
-		"TestExtension": "{**/*.*}"
-	}
+	"recommendedExtensions": [
+	]
 }

--- a/src/vs/platform/node/product.ts
+++ b/src/vs/platform/node/product.ts
@@ -28,6 +28,8 @@ export interface IProductConfiguration {
 		controlUrl: string;
 	};
 	extensionTips: { [id: string]: string; };
+	// {{SQL CARBON EDIT}}
+	recommendedExtensions: string[];
 	extensionImportantTips: { [id: string]: { name: string; pattern: string; }; };
 	exeBasedExtensionTips: { [id: string]: any; };
 	extensionKeywords: { [extension: string]: string[]; };

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
@@ -41,6 +41,8 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 	_serviceBrand: any;
 
 	private _fileBasedRecommendations: { [id: string]: number; } = Object.create(null);
+	// {{SQL CARBON EDIT}}
+	private _recommendations: string[] = Object.create(null);
 	private _exeBasedRecommendations: { [id: string]: string; } = Object.create(null);
 	private _availableRecommendations: { [pattern: string]: string[] } = Object.create(null);
 	private importantRecommendations: { [id: string]: { name: string; pattern: string; } } = Object.create(null);
@@ -83,6 +85,8 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 		let output: { [id: string]: string; } = Object.create(null);
 		Object.keys(this._fileBasedRecommendations).forEach(x => output[x.toLowerCase()] = localize('fileBasedRecommendation', "This extension is recommended based on the files you recently opened."));
 		this._allWorkspaceRecommendedExtensions.forEach(x => output[x.toLowerCase()] = localize('workspaceRecommendation', "This extension is recommended by users of the current workspace."));
+		// {{SQL CARBON EDIT}}
+		this._recommendations.forEach(x => output[x.toLowerCase()] = localize('defaultRecommendations', "This extension is recommended by Sql Ops Studio."));
 		forEach(this._exeBasedRecommendations, entry => output[entry.key.toLowerCase()] = localize('exeBasedRecommendation', "This extension is recommended because you have {0} installed.", entry.value));
 		return output;
 	}
@@ -150,7 +154,9 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 	}
 
 	getOtherRecommendations(): string[] {
-		return Object.keys(this._exeBasedRecommendations);
+		// {{SQL CARBON EDIT}}
+		let recommendations =  Object.keys(this._exeBasedRecommendations);
+		return recommendations.concat(this._recommendations);
 	}
 
 
@@ -161,6 +167,8 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 
 	private _suggestTips() {
 		const extensionTips = product.extensionTips;
+		// {{SQL CARBON EDIT}}
+		this._recommendations = product.recommendedExtensions;
 		if (!extensionTips) {
 			return;
 		}


### PR DESCRIPTION
- Adding extension to "recommendedExtensions" in product.json will show them as "Recommended Extensions" by default

- The list of extensions that should be excluded from SQL Ops package are added to sqlBuiltInExtensions  in build/gulpfile.vscode.js
Vsix package will be created for those extensions when creating package for SQL Ops

- Fixed the bug in GalleryService which the list of extensions were not correctly filtered 