### PR TITLE
rename context key databasename to databaseName

### DIFF
--- a/src/sql/parts/connection/common/connectionContextKey.ts
+++ b/src/sql/parts/connection/common/connectionContextKey.ts
@@ -12,7 +12,7 @@ export class ConnectionContextkey implements IContextKey<IConnectionProfile> {
 
 	static Provider = new RawContextKey<string>('connectionProvider', undefined);
 	static Server = new RawContextKey<string>('serverName', undefined);
-	static Database = new RawContextKey<string>('databasename', undefined);
+	static Database = new RawContextKey<string>('databaseName', undefined);
 	static Connection = new RawContextKey<IConnectionProfile>('connection', undefined);
 
 	private _providerKey: IContextKey<string>;

--- a/src/sql/parts/dashboard/dashboardEditor.ts
+++ b/src/sql/parts/dashboard/dashboardEditor.ts
@@ -20,8 +20,8 @@ import { DashboardComponentParams } from 'sql/services/bootstrap/bootstrapParams
 import { DASHBOARD_SELECTOR } from 'sql/parts/dashboard/dashboard.component';
 import { ConnectionContextkey } from 'sql/parts/connection/common/connectionContextKey';
 import { IDashboardService } from 'sql/services/dashboard/common/dashboardService';
-import { ConnectionProfile } from '../connection/common/connectionProfile';
-import { IConnectionProfile } from 'sqlops';
+import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile';
+import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
 
 export class DashboardEditor extends BaseEditor {
@@ -117,7 +117,8 @@ export class DashboardEditor extends BaseEditor {
 		let params: DashboardComponentParams = {
 			connection: input.connectionProfile,
 			ownerUri: input.uri,
-			scopedContextService: scopedContextService
+			scopedContextService,
+			connectionContextKey
 		};
 
 		input.hasBootstrapped = true;

--- a/src/sql/services/bootstrap/bootstrapParams.ts
+++ b/src/sql/services/bootstrap/bootstrapParams.ts
@@ -5,7 +5,8 @@
 
 import { DataService } from 'sql/parts/grid/services/dataService';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ConnectionContextkey } from 'sql/parts/connection/common/connectionContextKey';
 
 export interface BootstrapParams {
 }
@@ -22,6 +23,7 @@ export interface DashboardComponentParams extends BootstrapParams {
 	connection: IConnectionProfile;
 	ownerUri: string;
 	scopedContextService: IContextKeyService;
+	connectionContextKey: ConnectionContextkey;
 }
 
 export interface TaskDialogComponentParams extends BootstrapParams {


### PR DESCRIPTION
Also fixes a bug where the database context isn't updated when you change database in dashboard.