### PR TITLE
Enable object explorer find nodes API

### DIFF
--- a/extensions-modules/package.json
+++ b/extensions-modules/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Shared modules for Carbon extensions",
   "dependencies": {
-    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.1.3",
+    "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.1.5",
     "decompress": "^4.2.0",
     "fs-extra-promise": "^1.0.1",
     "http-proxy-agent": "^2.0.0",

--- a/extensions-modules/src/languageservice/serviceClient.ts
+++ b/extensions-modules/src/languageservice/serviceClient.ts
@@ -336,7 +336,6 @@ export class SqlToolsServiceClient {
 							configurationSection: SqlToolsServiceClient._constants.extensionConfigSectionName
 						},
 						errorHandler: new LanguageClientErrorHandler(SqlToolsServiceClient._constants),
-						serverConnectionMetadata: this._config.getConfigValue(Constants.serverConnectionMetadata),
 						outputChannel: {
 							append: () => {
 							},
@@ -414,7 +413,6 @@ export class SqlToolsServiceClient {
 				configurationSection: SqlToolsServiceClient._constants.extensionConfigSectionName
 			},
 			errorHandler: new LanguageClientErrorHandler(SqlToolsServiceClient._constants),
-			serverConnectionMetadata: this._config.getConfigValue(Constants.serverConnectionMetadata),
 			outputChannel: {
 				append: () => {
 				},

--- a/extensions-modules/yarn.lock
+++ b/extensions-modules/yarn.lock
@@ -321,9 +321,9 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.3":
-  version "0.1.0"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/5758b2a5804ea488d14326662f51d19cc970ccd0"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.5":
+  version "0.1.5"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/21b0bacfc759689a6c280408528c6029a21b1abf"
   dependencies:
     vscode-languageclient "3.5.0"
 

--- a/extensions/mssql/client/src/config.json
+++ b/extensions/mssql/client/src/config.json
@@ -1,7 +1,7 @@
 {
 	"service": {
 		"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-		"version": "1.4.0-alpha.10",
+		"version": "1.4.0-alpha.12",
 			"downloadFileNames": {
 			"Windows_86": "win-x86-netcoreapp2.0.zip",
 			"Windows_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
This PR bumps the SQL Tools Service and dataprotocol-client versions to enable the Object Explorer FindNodes API.

@anthonydresser Can you double check the changes in `serviceClient.ts`? It looks like you were working on some changes to the client that haven't made it in yet, so I had to remove `serverConnectionMetadata` in order to make it work.