### PR TITLE
Add a SQL CARBON EDIT to previous change

### DIFF
--- a/src/vs/editor/common/services/languagesRegistry.ts
+++ b/src/vs/editor/common/services/languagesRegistry.ts
@@ -128,7 +128,8 @@ export class LanguagesRegistry {
 		if (Array.isArray(lang.extensions)) {
 			for (let extension of lang.extensions) {
 				mime.registerTextMime({ id: langId, mime: primaryMime, extension: extension }, this._warnOnOverwrite);
-				if (!resolvedLanguage.extensions.includes(extension)){
+				// {{SQL CARBON EDIT}}
+				if (!resolvedLanguage.extensions.includes(extension)) {
 					resolvedLanguage.extensions.push(extension);
 				}
 			}


### PR DESCRIPTION
The VS Code "edit tag" was missing from https://github.com/Microsoft/sqlopsstudio/pull/779.

@ntovas fyi, we add this tag when modifying code under `./vs/` directory so the changes don't get lost when refreshing VS Code source code.