### PR TITLE
Connection dialog tabbed panel should use block display

### DIFF
--- a/src/sql/parts/connection/connectionDialog/media/connectionDialog.css
+++ b/src/sql/parts/connection/connectionDialog/media/connectionDialog.css
@@ -21,6 +21,7 @@
 .connection-dialog .tabbedPanel {
 	border-top-color: transparent;
 	height: calc(100% - 350px);
+	display: block;
 }
 
 .connection-recent, .connection-saved {


### PR DESCRIPTION
Fixes #958 

This bug happened because tabbed panels were updated to use flex display for the dashboard (see #758), but the tabbed panel in the connection dialog should use block.