### PR TITLE
Add registerAgentServicesProvider data protocol implementation

### DIFF
--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -255,6 +255,10 @@ export function createApiFactory(
 				return extHostDataProvider.$registerAdminServicesProvider(provider);
 			};
 
+			let registerAgentServicesProvider = (provider: sqlops.AgentServicesProvider): vscode.Disposable => {
+				return undefined;
+			};
+
 			// namespace: dataprotocol
 			const dataprotocol: typeof sqlops.dataprotocol = {
 				registerBackupProvider,
@@ -269,6 +273,7 @@ export function createApiFactory(
 				registerQueryProvider,
 				registerAdminServicesProvider,
 				registerCapabilitiesServiceProvider,
+				registerAgentServicesProvider,
 				onDidChangeLanguageFlavor(listener: (e: sqlops.DidChangeLanguageFlavorParams) => any, thisArgs?: any, disposables?: extHostTypes.Disposable[]) {
 					return extHostDataProvider.onDidChangeLanguageFlavor(listener, thisArgs, disposables);
 				}


### PR DESCRIPTION
Last night's daily builds failed because #965 added a new method to the data protocol interface but we don't have an implementation for it yet (see https://mssqltools.visualstudio.com/CrossPlatBuildScripts/_build/index?buildId=11838&_a=summary)

I've added this default implementation in order to get the build working again