### PR TITLE
Chart display and query plan tabs now use 100% height

### DIFF
--- a/src/sql/parts/grid/media/flexbox.css
+++ b/src/sql/parts/grid/media/flexbox.css
@@ -3,10 +3,6 @@
     width: 100%;
 }
 
-.headersVisible > .fullsize {
-    height: calc(100% - 38px);
-}
-
 /* vertical box styles */
 .vertBox {
     display: flex;


### PR DESCRIPTION
Recent changes to how tabbed content is displayed meant that some old CSS was no longer needed in order to make them take up 100% of the available height.