### PR TITLE
Go back to using VS Code's tab close icons

### DIFF
--- a/src/sql/media/overwriteVsIcons.css
+++ b/src/sql/media/overwriteVsIcons.css
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 /* Overwrite close editor action icon */
-.vs .monaco-workbench .close-editor-action {
+/* .vs .monaco-workbench .close-editor-action {
 	background: url('icons/close.svg') center center no-repeat !important;
 	background-size: 10px !important;
 }
@@ -11,4 +11,4 @@
 .vs-dark .monaco-workbench .close-editor-action,
 .hc-black .monaco-workbench .close-editor-action {
     background: url('icons/close_inverse.svg') center center no-repeat !important;
-}
+} */


### PR DESCRIPTION
We'll use VS Code's tab close icons for this release since we still need to figure out what the right UX is for inactive icons that have changes

Now:
![Tab icons match VS Code, including a circular dot to indicate an inactive tab that has changes](https://user-images.githubusercontent.com/3758704/37936558-da2b18f8-310a-11e8-91ff-ee922e5284ec.png)

Before:
![SQL Operations Studio's tab close icons that do not differentiate between the active tab and inactive tabs that have changes](https://user-images.githubusercontent.com/599935/37935397-344864ee-3106-11e8-88c8-3c9c512b0b8f.png)