### PR TITLE
Fix/use sqlops engine version

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -105,6 +105,7 @@ export interface IExtensionManifest {
 	name: string;
 	publisher: string;
 	version: string;
+	// {{SQL CARBON EDIT}}
 	engines: { vscode: string; sqlops?: string };
 	displayName?: string;
 	description?: string;

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -105,7 +105,7 @@ export interface IExtensionManifest {
 	name: string;
 	publisher: string;
 	version: string;
-	engines: { vscode: string; sqlops?:string };
+	engines: { vscode: string; sqlops?: string };
 	displayName?: string;
 	description?: string;
 	main?: string;

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -105,7 +105,7 @@ export interface IExtensionManifest {
 	name: string;
 	publisher: string;
 	version: string;
-	engines: { vscode: string };
+	engines: { vscode: string; sqlops?:string };
 	displayName?: string;
 	description?: string;
 	main?: string;

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -451,11 +451,11 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		if (query.criteria) {
 			const ids = query.criteria.filter(x => x.filterType === FilterType.ExtensionId).map(v => v.value.toLocaleLowerCase());
 			if (ids && ids.length > 0) {
-					filteredExtensions = filteredExtensions.filter(e => e.extensionId && ids.includes(e.extensionId.toLocaleLowerCase()));
+				filteredExtensions = filteredExtensions.filter(e => e.extensionId && ids.includes(e.extensionId.toLocaleLowerCase()));
 			}
 			const names = query.criteria.filter(x => x.filterType === FilterType.ExtensionName).map(v => v.value.toLocaleLowerCase());
 			if (names && names.length > 0) {
-					filteredExtensions = filteredExtensions.filter(e => e.extensionName && e.publisher.publisherName && names.includes(`${e.publisher.publisherName.toLocaleLowerCase()}.${e.extensionName.toLocaleLowerCase()}`));
+				filteredExtensions = filteredExtensions.filter(e => e.extensionName && e.publisher.publisherName && names.includes(`${e.publisher.publisherName.toLocaleLowerCase()}.${e.extensionName.toLocaleLowerCase()}`));
 			}
 		}
 

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -263,8 +263,6 @@ function getVersionAsset(version: IRawGalleryExtensionVersion, type: string): IG
 			fallbackUri: `${version.fallbackAssetUri}/${type}`
 		};
 	}
-
-
 }
 
 function getDependencies(version: IRawGalleryExtensionVersion): string[] {
@@ -748,14 +746,17 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 		return this.getAsset(asset, { headers })
 			.then(context => asJson<IExtensionManifest>(context))
 			.then(manifest => {
-				const engine = manifest.engines.vscode;
+				if (manifest.engines && !manifest.engines.sqlops) {
+					manifest.engines.sqlops = '*';
+				}
+				const engine = manifest.engines.sqlops;
 
 				if (!this.isEngineValid(engine)) {
 					return this.getLastValidExtensionVersionReccursively(extension, versions.slice(1));
 				}
 
 				version.properties = version.properties || [];
-				version.properties.push({ key: PropertyType.Engine, value: manifest.engines.vscode });
+				version.properties.push({ key: PropertyType.Engine, value: manifest.engines.sqlops });
 				return version;
 			});
 	}

--- a/src/vs/platform/extensions/common/extensions.ts
+++ b/src/vs/platform/extensions/common/extensions.ts
@@ -23,6 +23,8 @@ export interface IExtensionDescription {
 	readonly activationEvents?: string[];
 	readonly engines: {
 		vscode: string;
+		// {{SQL CARBON EDIT}}
+		sqlops?: string;
 	};
 	readonly main?: string;
 	readonly contributes?: { [point: string]: any; };

--- a/src/vs/platform/extensions/node/extensionValidator.ts
+++ b/src/vs/platform/extensions/node/extensionValidator.ts
@@ -222,7 +222,7 @@ export function isValidExtensionVersion(version: string, extensionDesc: IReduced
 	}
 
 	// {{SQL CARBON EDIT}}
-	return (extensionDesc.engines.sqlops && extensionDesc.engines.sqlops === '*') || isVersionValid(version, extensionDesc.engines.vscode, notices);
+	return (extensionDesc.engines.sqlops && extensionDesc.engines.sqlops === '*') || isVersionValid(version, extensionDesc.engines.sqlops, notices);
 }
 
 export function isVersionValid(currentVersion: string, requestedVersion: string, notices: string[] = []): boolean {

--- a/src/vs/platform/extensions/node/extensionValidator.ts
+++ b/src/vs/platform/extensions/node/extensionValidator.ts
@@ -222,7 +222,7 @@ export function isValidExtensionVersion(version: string, extensionDesc: IReduced
 	}
 
 	// {{SQL CARBON EDIT}}
-	return (extensionDesc.engines.sqlops && extensionDesc.engines.sqlops === '*') ||  isVersionValid(version, extensionDesc.engines.vscode, notices);
+	return (extensionDesc.engines.sqlops && extensionDesc.engines.sqlops === '*') || isVersionValid(version, extensionDesc.engines.vscode, notices);
 }
 
 export function isVersionValid(currentVersion: string, requestedVersion: string, notices: string[] = []): boolean {

--- a/src/vs/platform/extensions/node/extensionValidator.ts
+++ b/src/vs/platform/extensions/node/extensionValidator.ts
@@ -208,6 +208,8 @@ export interface IReducedExtensionDescription {
 	isBuiltin: boolean;
 	engines: {
 		vscode: string;
+		// {{SQL CARBON EDIT}}
+		sqlops?: string;
 	};
 	main?: string;
 }
@@ -219,7 +221,8 @@ export function isValidExtensionVersion(version: string, extensionDesc: IReduced
 		return true;
 	}
 
-	return isVersionValid(version, extensionDesc.engines.vscode, notices);
+	// {{SQL CARBON EDIT}}
+	return (extensionDesc.engines.sqlops && extensionDesc.engines.sqlops === '*') ||  isVersionValid(version, extensionDesc.engines.vscode, notices);
 }
 
 export function isVersionValid(currentVersion: string, requestedVersion: string, notices: string[] = []): boolean {
@@ -289,8 +292,8 @@ function baseIsValidExtensionDescription(extensionFolderPath: string, extensionD
 		notices.push(nls.localize('extensionDescription.engines', "property `{0}` is mandatory and must be of type `object`", 'engines'));
 		return false;
 	}
-	if (typeof extensionDescription.engines.vscode !== 'string') {
-		notices.push(nls.localize('extensionDescription.engines.vscode', "property `{0}` is mandatory and must be of type `string`", 'engines.vscode'));
+	if (typeof extensionDescription.engines.sqlops !== 'string') {
+		notices.push(nls.localize('extensionDescription.engines.sqlops', "property `{0}` is mandatory and must be of type `string`", 'engines.sqlops'));
 		return false;
 	}
 	if (typeof extensionDescription.extensionDependencies !== 'undefined') {

--- a/src/vs/workbench/services/extensions/electron-browser/extensionPoints.ts
+++ b/src/vs/workbench/services/extensions/electron-browser/extensionPoints.ts
@@ -58,6 +58,10 @@ class ExtensionManifestParser extends ExtensionManifestHandler {
 				if (manifest.__metadata) {
 					manifest.uuid = manifest.__metadata.id;
 				}
+				// {{SQL CARBON EDIT}}
+				if (manifest.engines && !manifest.engines.sqlops) {
+					manifest.engines.sqlops = '*';
+				}
 				delete manifest.__metadata;
 				return manifest;
 			} catch (e) {


### PR DESCRIPTION
sqlops was checking the "vscode" version of the extensions for compatibility with engine. Changed the code to use "engine.sqlops" as the engine version and setting it to * as default so it won't break for the extensions that don't have the field 