### PR TITLE
Add empty dependencies to keep yarn from erroring

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -664,6 +664,8 @@
     "service-downloader": "github:anthonydresser/service-downloader#0.1.2",
     "vscode-extension-telemetry": "^0.0.15"
   },
+  "devDependencies": {
+  },
   "resolutions": {
     "vscode-jsonrpc": "3.5.0",
     "vscode-languageclient": "3.5.0",


### PR DESCRIPTION
Yarn throws an error during the release process if you don't have this object defined.