### PR TITLE
Clear insights view before showing error

### DIFF
--- a/src/sql/parts/dashboard/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/insightsWidget.component.ts
@@ -187,13 +187,14 @@ export class InsightsWidget extends DashboardWidget implements IDashboardWidget,
 	}
 
 	private _updateChild(result: SimpleExecuteResult): void {
+		this.componentHost.viewContainerRef.clear();
+
 		if (result.rowCount === 0) {
 			this.showError(nls.localize('noResults', 'No results to show'));
 			return;
 		}
 
 		let componentFactory = this._componentFactoryResolver.resolveComponentFactory<IInsightsView>(insightRegistry.getCtorFromId(this._typeKey));
-		this.componentHost.viewContainerRef.clear();
 
 		let componentRef = this.componentHost.viewContainerRef.createComponent(componentFactory);
 		let componentInstance = componentRef.instance;


### PR DESCRIPTION
Clear the widget ui before it shows any potential errors. Prevents 
![image](https://user-images.githubusercontent.com/4324725/38266486-a5c38b76-372d-11e8-8377-131e5198c24d.png)
