### PR TITLE
Fixing the provider name

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -204,12 +204,14 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 	private handleShowUiComponent(input: OnShowUIResponse) {
 		this._currentProviderType = input.selectedProviderType;
+		this._model.providerName = this.getCurrentProviderName();
 		this._model = new ConnectionProfile(this._capabilitiesService, this._model);
 		this.uiController.showUiComponent(input.container);
 	}
 
 	private handleInitDialog() {
 		this.uiController.initDialog(this._model);
+
 	}
 
 	private handleFillInConnectionInputs(connectionInfo: IConnectionProfile): void {


### PR DESCRIPTION
When the provider options changed in the connection dialogue it didnt set the correct provider name in the connection profile. This will fix the issue