### PR TITLE
Update vscode-nls version for Azure extension

### DIFF
--- a/extensions/account-provider-azure/package.json
+++ b/extensions/account-provider-azure/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "adal-node": "0.1.25",
     "request": "2.63.0",
-    "vscode-nls": "2.0.2"
+    "vscode-nls": "^3.2.1"
   },
   "devDependencies": {
     "@types/node": "^8.0.24"

--- a/extensions/account-provider-azure/yarn.lock
+++ b/extensions/account-provider-azure/yarn.lock
@@ -591,9 +591,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vscode-nls@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-2.0.2.tgz#808522380844b8ad153499af5c3b03921aea02da"
+vscode-nls@^3.2.1:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-3.2.2.tgz#3817eca5b985c2393de325197cf4e15eb2aa5350"
 
 "xmldom@>= 0.1.x":
   version "0.1.27"


### PR DESCRIPTION
Fix the error launching the Azure account provider extension by using the updated version of vscode-nls 