### PR TITLE
Reenable logging for SQL Tools Service

### DIFF
--- a/extensions/mssql/src/constants.ts
+++ b/extensions/mssql/src/constants.ts
@@ -9,3 +9,5 @@ export const providerId = 'MSSQL';
 export const serviceCrashMessage = 'SQL Tools Service component exited unexpectedly. Please restart SQL Operations Studio.';
 export const serviceCrashButton = 'View Known Issues';
 export const serviceCrashLink = 'https://github.com/Microsoft/vscode-mssql/wiki/SqlToolsService-Known-Issues';
+export const configLogDebugInfo = 'logDebugInfo';
+export const extensionConfigSectionName = 'mssql';

--- a/extensions/mssql/src/main.ts
+++ b/extensions/mssql/src/main.ts
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	let clientOptions: ClientOptions = {
 		documentSelector: ['sql'],
 		synchronize: {
-			configurationSection: 'mssql'
+			configurationSection: Constants.extensionConfigSectionName
 		},
 		providerId: Constants.providerId,
 		errorHandler: new LanguageClientErrorHandler(),
@@ -99,6 +99,13 @@ function generateServerOptions(executablePath: string): ServerOptions {
 	launchArgs.push('--log-dir');
 	let logFileLocation = path.join(Utils.getDefaultLogLocation(), 'mssql');
 	launchArgs.push(logFileLocation);
+	let config = vscode.workspace.getConfiguration(Constants.extensionConfigSectionName);
+	if (config) {
+		let logDebugInfo = config[Constants.configLogDebugInfo];
+		if (logDebugInfo) {
+			launchArgs.push('--enable-logging');
+		}
+	}
 
 	return { command: executablePath, args: launchArgs, transport: TransportKind.stdio };
 }


### PR DESCRIPTION
The code to activate SQL Tools Service logging got lost in the recent changes to our extension code, so this PR puts it back