### PR TITLE
Clear connection validation messages on open

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -343,6 +343,12 @@ export class ConnectionWidget {
 	public focusOnOpen(): void {
 		this._serverNameInputBox.focus();
 		this.focusPasswordIfNeeded();
+		this.clearValidationMessages();
+	}
+
+	private clearValidationMessages(): void {
+		this._serverNameInputBox.hideMessage();
+		this._userNameInputBox.hideMessage();
 	}
 
 	private getModelValue(value: string): string {


### PR DESCRIPTION
Fixes #1069 

The connection dialog's validation logic gets called when setting input values, which happens when the dialog is opened and we clear previous values. This fixes the problem by making sure that we hide any validation messages when the dialog first opens