### PR TITLE
Notify dashboard collapse action when the collapsed state changes

### DIFF
--- a/src/sql/parts/dashboard/common/actions.ts
+++ b/src/sql/parts/dashboard/common/actions.ts
@@ -8,6 +8,7 @@ import { TPromise } from 'vs/base/common/winjs.base';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import Event from 'vs/base/common/event';
 
 import { IAngularEventingService, AngularEventType, IAngularEvent } from 'sql/services/angularEventing/angularEventingService';
 import { INewDashboardTabDialogService } from 'sql/parts/dashboard/newDashboardTabDialog/interface';
@@ -209,6 +210,7 @@ export class CollapseWidgetAction extends Action {
 		private _uri: string,
 		private _widgetUuid: string,
 		private collpasedState: boolean,
+		private collapsedStateChangedEvent: Event<boolean>,
 		@IAngularEventingService private _angularEventService: IAngularEventingService
 	) {
 		super(
@@ -216,6 +218,7 @@ export class CollapseWidgetAction extends Action {
 			collpasedState ? CollapseWidgetAction.EXPAND_LABEL : CollapseWidgetAction.COLLPASE_LABEL,
 			collpasedState ? CollapseWidgetAction.EXPAND_ICON : CollapseWidgetAction.COLLAPSE_ICON
 		);
+		this.collapsedStateChangedEvent(collapsed => this._updateState(collapsed));
 	}
 
 	run(): TPromise<boolean> {
@@ -225,7 +228,11 @@ export class CollapseWidgetAction extends Action {
 	}
 
 	private _toggleState(): void {
-		this.collpasedState = !this.collpasedState;
+		this._updateState(!this.collpasedState);
+	}
+
+	private _updateState(collapsed: boolean): void {
+		this.collpasedState = collapsed;
 		this._setClass(this.collpasedState ? CollapseWidgetAction.EXPAND_ICON : CollapseWidgetAction.COLLAPSE_ICON);
 		this._setLabel(this.collpasedState ? CollapseWidgetAction.EXPAND_LABEL : CollapseWidgetAction.COLLPASE_LABEL);
 	}


### PR DESCRIPTION
Fixes #1081 

The dashboard collapse action didn't get notified when the collapsed state changed due to calls from outside the action, which could cause the arrow's direction to become incorrect. 