### PR TITLE
Bump SQL Tools version to take OE findNodes fixes

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.4.0-alpha.18",
+	"version": "1.4.0-alpha.19",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.0.zip",
 		"Windows_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
This includes the fix for Object Explorer hanging for certain `findNodes` calls and the fix to make node paths include object names instead of the entire object labels 