### PR TITLE
Fix #1095 "Run kinit" helper no longer runs kinit

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -346,7 +346,10 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				this._connectionDialog.close();
 				this._clipboardService.writeText('kinit\r');
 				this._commandService.executeCommand('workbench.action.terminal.focus').then(resolve => {
-					return this._commandService.executeCommand('workbench.action.terminal.paste');
+					// setTimeout to allow for terminal Instance to load.
+					setTimeout(() => {
+						return this._commandService.executeCommand('workbench.action.terminal.paste');
+					}, 10);
 				}).then(resolve => null, reject => null);
 				return null;
 			}));


### PR DESCRIPTION
VSCode refactored their terminal to have more delayed initialization,
but still return as complete before the actual instance is ready for focus
and paste events. The fix is to add a delay so this can complete before
calling the paste action. As this doesn't affect extensions (the hop to the
extension host causes a delay) I'm not raising this with VSCode as an
upstream issue, just fixing on our side