### PR TITLE
Bump tools service for node path change

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.4.0-alpha.19",
+	"version": "1.4.0-alpha.20",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.0.zip",
 		"Windows_64": "win-x64-netcoreapp2.0.zip",


### PR DESCRIPTION
This brings in the change from https://github.com/Microsoft/sqltoolsservice/pull/601 to ensure that schemas are included in history tables' node paths