### PR TITLE
Enable keyboard for explain button and Line1 link in message pane

### DIFF
--- a/src/sql/base/browser/ui/taskbar/actionbar.ts
+++ b/src/sql/base/browser/ui/taskbar/actionbar.ts
@@ -153,11 +153,17 @@ export class ActionBar extends ActionRunner implements IActionRunner {
 	}
 
 	private updateFocusedItem(): void {
+		let actionIndex = 0;
 		for (let i = 0; i < this._actionsList.children.length; i++) {
 			let elem = this._actionsList.children[i];
+
 			if (DOM.isAncestor(document.activeElement, elem)) {
-				this._focusedItem = i;
+				this._focusedItem = actionIndex;
 				break;
+			}
+
+			if (elem.classList.contains('action-item')) {
+				actionIndex++;
 			}
 		}
 	}

--- a/src/sql/parts/grid/views/query/query.component.html
+++ b/src/sql/parts/grid/views/query/query.component.html
@@ -58,7 +58,7 @@
 				<ng-template ngFor let-message [ngForOf]="messages">
 					<tr class='messageRow'>
 						<td><span *ngIf="message.link">[{{message.time}}]</span></td>
-						<td class="resultsMessageValue" [class.errorMessage]="message.isError" [class.batchMessage]="!message.link">{{message.message}} <a class="queryLink" *ngIf="message.link" (click)="onSelectionLinkClicked(message.batchId)">{{message.link.text}}</a>
+						<td class="resultsMessageValue" [class.errorMessage]="message.isError" [class.batchMessage]="!message.link">{{message.message}} <a tabindex="0" #queryLink class="queryLink" *ngIf="message.link" (click)="onSelectionLinkClicked(message.batchId)" (keyup)="onKey($event, message.batchId)">{{message.link.text}}</a>
 						</td>
 					</tr>
 				</ng-template>

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -26,10 +26,12 @@ import { IBootstrapService, BOOTSTRAP_SERVICE_ID } from 'sql/services/bootstrap/
 import { QueryComponentParams } from 'sql/services/bootstrap/bootstrapParams';
 import { error } from 'sql/base/common/log';
 import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
+import { clone } from 'sql/base/common/objects';
 
 import * as strings from 'vs/base/common/strings';
-import { clone } from 'sql/base/common/objects';
 import * as DOM from 'vs/base/browser/dom';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { KeyCode } from 'vs/base/common/keyCodes';
 
 export const QUERY_SELECTOR: string = 'query-component';
 
@@ -150,7 +152,7 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 	@ViewChildren('slickgrid') slickgrids: QueryList<SlickGrid>;
 	// tslint:disable-next-line:no-unused-variable
 	@ViewChild('resultsPane', { read: ElementRef }) private _resultsPane: ElementRef;
-
+	@ViewChild('queryLink', { read: ElementRef }) private _queryLinkElement: ElementRef;
 	constructor(
 		@Inject(forwardRef(() => ElementRef)) el: ElementRef,
 		@Inject(forwardRef(() => ChangeDetectorRef)) cd: ChangeDetectorRef,
@@ -402,6 +404,16 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 
 	onSelectionLinkClicked(index: number): void {
 		this.dataService.setEditorSelection(index);
+	}
+
+	onKey(e: Event, index: number) {
+		if (DOM.isAncestor(<HTMLElement>e.target, this._queryLinkElement.nativeElement) && e instanceof KeyboardEvent) {
+			let event = new StandardKeyboardEvent(e);
+			if (event.equals(KeyCode.Enter)) {
+				this.onSelectionLinkClicked(index);
+				e.stopPropagation();
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
Issues:
Action cannot be performed on the "Explain" button using keyboard. (Defect 11688001, 11459052)
The keyboard focus does not move to "Line 1" link in Messages section (Defect 11464296).