### PR TITLE
Add showTopNData option to insight charts

### DIFF
--- a/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
@@ -79,13 +79,14 @@ export interface IChartConfig {
 	legendPosition?: LegendPosition;
 	dataDirection?: DataDirection;
 	columnsAsLabels?: boolean;
+	showTopNData?: number;
 }
 
 export const defaultChartConfig: IChartConfig = {
 	labelFirstColumn: false,
 	columnsAsLabels: false,
 	legendPosition: LegendPosition.Top,
-	dataDirection: DataDirection.Vertical
+	dataDirection: DataDirection.Vertical,
 };
 
 @Component({
@@ -212,14 +213,14 @@ export abstract class ChartInsight extends Disposable implements IInsightsView {
 			if (this._config.labelFirstColumn) {
 				return this._data.rows.map((row) => {
 					return {
-						data: row.map(item => Number(item)).slice(1),
+						data: this.getTopNData(row.map(item => Number(item)).slice(1)),
 						label: row[0]
 					};
 				});
 			} else {
 				return this._data.rows.map((row, i) => {
 					return {
-						data: row.map(item => Number(item)),
+						data: this.getTopNData(row.map(item => Number(item))),
 						label: 'Series' + i
 					};
 				});
@@ -228,18 +229,26 @@ export abstract class ChartInsight extends Disposable implements IInsightsView {
 			if (this._config.columnsAsLabels) {
 				return this._data.rows[0].map((row, i) => {
 					return {
-						data: this._data.rows.map(row => Number(row[i])),
+						data: this.getTopNData(this._data.rows.map(row => Number(row[i]))),
 						label: this._data.columns[i]
 					};
 				});
 			} else {
 				return this._data.rows[0].map((row, i) => {
 					return {
-						data: this._data.rows.map(row => Number(row[i])),
+						data: this.getTopNData(this._data.rows.map(row => Number(row[i]))),
 						label: 'Series' + i
 					};
 				});
 			}
+		}
+	}
+
+	private getTopNData(data: any[]): any[] {
+		if (this._config.showTopNData) {
+			return data.slice(0, this._config.showTopNData);
+		} else {
+			return data;
 		}
 	}
 
@@ -250,9 +259,9 @@ export abstract class ChartInsight extends Disposable implements IInsightsView {
 	@memoize
 	public getLabels(): Array<string> {
 		if (this._config.dataDirection === 'horizontal') {
-			return this._data.columns;
+			return this.getTopNData(this._data.columns);
 		} else {
-			return this._data.rows.map(row => row[0]);
+			return this.getTopNData(this._data.rows.map(row => row[0]));
 		}
 	}
 

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
@@ -279,7 +279,11 @@ export abstract class ChartInsight extends Disposable implements IInsightsView {
 	@memoize
 	public getLabels(): Array<string> {
 		if (this._config.dataDirection === 'horizontal') {
-			return this._data.columns;
+			if (this._config.labelFirstColumn) {
+				return this._data.columns.slice(1);
+			} else {
+				return this._data.columns;
+			}
 		} else {
 			return this._data.rows.map(row => row[0]);
 		}

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.contribution.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.contribution.ts
@@ -35,6 +35,10 @@ export const chartInsightSchema: IJSONSchema = {
 			default: 'vertical',
 			enum: ['vertical', 'horizontal'],
 			enumDescriptions: ['When vertical, the first column is used to define the x-axis labels, with other columns expected to be numerical.', 'When horizontal, the column names are used as the x-axis labels.']
+		},
+		showTopNData: {
+			type: 'number',
+			description: nls.localize('showTopNData', 'If showTopNData is set, showing only top N data in the chart.')
 		}
 	}
 };

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution.ts
@@ -12,7 +12,7 @@ import { chartInsightSchema } from 'sql/parts/dashboard/widgets/insights/views/c
 
 import BarChart from './barChart.component';
 
-export const properties: IJSONSchema = {
+const properties: IJSONSchema = {
 	properties: {
 		yAxisMin: {
 			type: 'number',
@@ -41,6 +41,6 @@ export const properties: IJSONSchema = {
 	}
 };
 
-const barSchema = mixin(clone(chartInsightSchema), properties) as IJSONSchema;
+export const barChartSchema = mixin(clone(chartInsightSchema), properties) as IJSONSchema;
 
-registerInsight('bar', '', barSchema, BarChart);
+registerInsight('bar', '', barChartSchema, BarChart);

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/horizontalBarChart.contribution.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/horizontalBarChart.contribution.ts
@@ -7,7 +7,7 @@ import { mixin } from 'vs/base/common/objects';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
 import { registerInsight } from 'sql/platform/dashboard/common/insightRegistry';
-import { properties as BarChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
+import { barChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
 
 import HorizontalBarChart from './horizontalBarChart.component';
 
@@ -15,6 +15,6 @@ const properties: IJSONSchema = {
 
 };
 
-const horizontalBarSchema = mixin(clone(BarChartSchema), properties) as IJSONSchema;
+const horizontalBarSchema = mixin(clone(barChartSchema), properties) as IJSONSchema;
 
 registerInsight('horizontalBar', '', horizontalBarSchema, HorizontalBarChart);

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.contribution.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.contribution.ts
@@ -8,7 +8,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
 
 import { registerInsight } from 'sql/platform/dashboard/common/insightRegistry';
-import { properties as BarChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
+import { barChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
 
 import LineChart from './lineChart.component';
 
@@ -24,6 +24,6 @@ const properties: IJSONSchema = {
 	}
 };
 
-export const lineSchema = mixin(clone(BarChartSchema), properties) as IJSONSchema;
+export const lineSchema = mixin(clone(barChartSchema), properties) as IJSONSchema;
 
 registerInsight('line', '', lineSchema, LineChart);

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/scatterChart.contribution.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/scatterChart.contribution.ts
@@ -7,13 +7,13 @@ import { clone } from 'sql/base/common/objects';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
 import { registerInsight } from 'sql/platform/dashboard/common/insightRegistry';
-import { properties as BarChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
+import { barChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
 
 import ScatterChart from './scatterChart.component';
 
 const properties: IJSONSchema = {
 };
 
-const scatterSchema = mixin(clone(BarChartSchema), properties) as IJSONSchema;
+const scatterSchema = mixin(clone(barChartSchema), properties) as IJSONSchema;
 
 registerInsight('scatter', '', scatterSchema, ScatterChart);

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/timeSeriesChart.contribution.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/timeSeriesChart.contribution.ts
@@ -7,13 +7,13 @@ import { clone } from 'sql/base/common/objects';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
 import { registerInsight } from 'sql/platform/dashboard/common/insightRegistry';
-import { properties as BarChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
+import { barChartSchema } from 'sql/parts/dashboard/widgets/insights/views/charts/types/barChart.contribution';
 
 import TimeSeriesChart from './timeSeriesChart.component';
 
 const properties: IJSONSchema = {
 };
 
-const timeSeriesSchema = mixin(clone(BarChartSchema), properties) as IJSONSchema;
+const timeSeriesSchema = mixin(clone(barChartSchema), properties) as IJSONSchema;
 
 registerInsight('timeSeries', '', timeSeriesSchema, TimeSeriesChart);


### PR DESCRIPTION
Example
```
      "widget": {
        "insights-widget": {
          "type": {
            "horizontalBar": {
              "dataDirection": "vertical",
              "dataType": "number",
              "legendPosition": "none",
              "labelFirstColumn": false,
              "columnsAsLabels": false,
              "showTopNData": 5
            }
          },
          "queryFile": "C:\\Users\\appetcht\\Documents\\SQLQuery1.sql"
        }
      }
```