### PR TITLE
Publish SSMSKeymap extension

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -181,19 +181,19 @@
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
-								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/visualstudio-keyboard.png"
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/visualstudio-keyboard.png"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Content.Details",
-								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/README.md"
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/README.md"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Code.Manifest",
-								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/package.json"
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/package.json"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Content.License",
-								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/LICENSE.txt"
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/LICENSE.txt"
 							}
 						],
 						"properties": [

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -172,8 +172,8 @@
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
-								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://github.com/kevcunnane/ssmskeymap/releases/download/0.2.0/ssmskeymap-0.2.0.vsix"
+								"assetType": "Microsoft.SQLOps.DownloadPage",
+								"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/0.2.0"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -1,7 +1,7 @@
 {
 	"results": [{
 		"extensions": [
-		{
+			{
 				"extensionId": "10",
 				"extensionName": "agent",
 				"displayName": "SQL Server Agent",
@@ -138,11 +138,62 @@
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Code.Manifest",
-								"source": "https://raw.githubusercontent.com/Microsoft/sqlopsstudio/master/samples/serverReports/package.jsonn"
+								"source": "https://raw.githubusercontent.com/Microsoft/sqlopsstudio/master/samples/serverReports/package.json"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Content.License",
 								"source": "https://raw.githubusercontent.com/Microsoft/sqlopsstudio/master/samples/serverReports/LICENSE.txt"
+							}
+						],
+						"properties": [
+						{ "key": "Microsoft.VisualStudio.Code.ExtensionDependencies", "value":""},
+						{ "key": "Microsoft.VisualStudio.Code.Engine", "value":"*"}
+						]
+					}
+				],
+				"statistics": [],
+				"flags": "preview"
+			},
+			{
+				"extensionId": "13",
+				"extensionName": "ssmskeymap",
+				"displayName": "SSMS Keymap",
+				"shortDescription": "This extension ports popular SSMS keyboard shortcuts to SQL Operations Studio",
+				"publisher": {
+					"displayName":"Kevin Cunnane",
+					"publisherId": "kevcunnane",
+					"publisherName":"kevcunnane"
+				},
+				"versions": [
+					{
+						"version": "0.2.0",
+						"lastUpdated": "4/16/2018",
+						"assetUri": "",
+						"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+							{
+								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
+								"source": "https://github.com/kevcunnane/ssmskeymap/releases/download/0.2.0/ssmskeymap-0.2.0.vsix"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Links.Source",
+								"source": "https://github.com/kevcunnane/ssmskeymap"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/visualstudio-keyboard.png"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/README.md"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Code.Manifest",
+								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/package.json"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Content.License",
+								"source": "https://github.com/kevcunnane/ssmskeymap/blob/master/LICENSE.txt"
 							}
 						],
 						"properties": [
@@ -163,4 +214,4 @@
 			}]
 		}]
 	}]
-	}
+}

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -102,6 +102,57 @@
 				],
 				"statistics": [],
 				"flags": "preview"
+			},
+			{
+				"extensionId": "13",
+				"extensionName": "ssmskeymap",
+				"displayName": "SSMS Keymap",
+				"shortDescription": "This extension ports popular SSMS keyboard shortcuts to SQL Operations Studio",
+				"publisher": {
+					"displayName":"Kevin Cunnane",
+					"publisherId": "kevcunnane",
+					"publisherName":"kevcunnane"
+				},
+				"versions": [
+					{
+						"version": "0.2.0",
+						"lastUpdated": "4/16/2018",
+						"assetUri": "",
+						"fallbackAssetUri": "fallbackAssetUri",
+							"files": [
+							{
+								"assetType": "Microsoft.SQLOps.DownloadPage",
+								"source": "https://github.com/kevcunnane/ssmskeymap/releases/tag/0.2.0"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Links.Source",
+								"source": "https://github.com/kevcunnane/ssmskeymap"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Icons.Default",
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/visualstudio-keyboard.png"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Content.Details",
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/README.md"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Code.Manifest",
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/package.json"
+							},
+							{
+								"assetType": "Microsoft.VisualStudio.Services.Content.License",
+								"source": "https://raw.githubusercontent.com/kevcunnane/ssmskeymap/master/LICENSE.txt"
+							}
+						],
+						"properties": [
+						{ "key": "Microsoft.VisualStudio.Code.ExtensionDependencies", "value":""},
+						{ "key": "Microsoft.VisualStudio.Code.Engine", "value":"*"}
+						]
+					}
+				],
+				"statistics": [],
+				"flags": "preview"
 			}
 		],
 		"resultMetadata": [{


### PR DESCRIPTION
This submits the SSMSKeymap extension to the gallery for use by customers. This is a publicly contributed extension.

Submitting to the insiders channel for now so that we can perform local testing of the process. Once this is done I'll submit a separate PR for the main extensionGallery.json file.