### PR TITLE
ensure npm install copies typings

### DIFF
--- a/samples/sqlservices/package.json
+++ b/samples/sqlservices/package.json
@@ -59,7 +59,7 @@
         "compile": "gulp compile",
         "watch": "gulp watch",
         "typings": "gulp copytypings",
-        "postinstall": "node ./node_modules/vscode/bin/install && node ./node_modules/sqlops/bin/install"
+        "postinstall": "node ./node_modules/vscode/bin/install && node ./node_modules/sqlops/bin/install && gulp copytypings"
     },
     "dependencies": {
         "vscode-nls": "^3.2.2"


### PR DESCRIPTION
- Important so that build of the extension "works" as expected