### PR TITLE
Fix server reports contribution link

### DIFF
--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -87,7 +87,7 @@
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Code.Manifest",
-								"source": "https://raw.githubusercontent.com/Microsoft/sqlopsstudio/master/samples/serverReports/package.jsonn"
+								"source": "https://raw.githubusercontent.com/Microsoft/sqlopsstudio/master/samples/serverReports/package.json"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Content.License",


### PR DESCRIPTION
Fixing typo in server reports that causes contributions tab to display incorrectly.