### PR TITLE
Update SQL Tools Service to 1.4.0-alpha.23

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,18 +1,18 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.4.0-alpha.20",
+	"version": "1.4.0-alpha.23",
 	"downloadFileNames": {
-		"Windows_86": "win-x86-netcoreapp2.0.zip",
-		"Windows_64": "win-x64-netcoreapp2.0.zip",
-		"OSX": "osx-x64-netcoreapp2.0.tar.gz",
-		"CentOS_7": "rhel-x64-netcoreapp2.0.tar.gz",
-		"Debian_8": "rhel-x64-netcoreapp2.0.tar.gz",
-		"Fedora_23": "rhel-x64-netcoreapp2.0.tar.gz",
-		"OpenSUSE_13_2": "rhel-x64-netcoreapp2.0.tar.gz",
-		"RHEL_7": "rhel-x64-netcoreapp2.0.tar.gz",
-		"SLES_12_2": "rhel-x64-netcoreapp2.0.tar.gz",
-		"Ubuntu_14": "rhel-x64-netcoreapp2.0.tar.gz",
-		"Ubuntu_16": "rhel-x64-netcoreapp2.0.tar.gz"
+		"Windows_86": "win-x86-netcoreapp2.1.zip",
+		"Windows_64": "win-x64-netcoreapp2.1.zip",
+		"OSX": "osx-x64-netcoreapp2.1.tar.gz",
+		"CentOS_7": "rhel-x64-netcoreapp2.1.tar.gz",
+		"Debian_8": "rhel-x64-netcoreapp2.1.tar.gz",
+		"Fedora_23": "rhel-x64-netcoreapp2.1.tar.gz",
+		"OpenSUSE_13_2": "rhel-x64-netcoreapp2.1.tar.gz",
+		"RHEL_7": "rhel-x64-netcoreapp2.1.tar.gz",
+		"SLES_12_2": "rhel-x64-netcoreapp2.1.tar.gz",
+		"Ubuntu_14": "rhel-x64-netcoreapp2.1.tar.gz",
+		"Ubuntu_16": "rhel-x64-netcoreapp2.1.tar.gz"
 	},
 	"installDirectory": "../sqltoolsservice/{#platform#}/{#version#}",
 	"executableFiles": ["MicrosoftSqlToolsServiceLayer.exe", "MicrosoftSqlToolsServiceLayer"]


### PR DESCRIPTION
Bump to latest tools service version.  This also pulls in bits built with the .Net Core 2.1 Preview SDK.