### PR TITLE
Expose custom dialog extension APIs

### DIFF
--- a/src/sql/platform/dialog/customDialogService.ts
+++ b/src/sql/platform/dialog/customDialogService.ts
@@ -12,7 +12,7 @@ import { Dialog } from 'sql/platform/dialog/dialogTypes';
 import { IModalOptions } from 'sql/base/browser/ui/modal/modal';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
-const defaultOptions: IModalOptions = { hasBackButton: true, isWide: true };
+const defaultOptions: IModalOptions = { hasBackButton: true, isWide: false };
 
 export class CustomDialogService {
 	constructor( @IInstantiationService private _instantiationService: IInstantiationService) { }

--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -8,7 +8,7 @@
 import 'vs/css!./media/dialogModal';
 import { Modal, IModalOptions } from 'sql/base/browser/ui/modal/modal';
 import { attachModalDialogStyler } from 'sql/common/theme/styler';
-import { Dialog } from 'sql/platform/dialog/dialogTypes';
+import { Dialog, DialogButton } from 'sql/platform/dialog/dialogTypes';
 import { DialogPane } from 'sql/platform/dialog/dialogPane';
 import { IBootstrapService } from 'sql/services/bootstrap/bootstrapService';
 import { Builder } from 'vs/base/browser/builder';
@@ -23,9 +23,6 @@ import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { localize } from 'vs/nls';
 
 export class DialogModal extends Modal {
-	private static readonly DONE_BUTTON_LABEL = localize('dialogModalDoneButtonLabel', 'Done');
-	private static readonly CANCEL_BUTTON_LABEL = localize('dialogModalCancelButtonLabel', 'Cancel');
-
 	private _dialogPane: DialogPane;
 
 	// Wizard HTML elements
@@ -61,10 +58,23 @@ export class DialogModal extends Modal {
 			attachButtonStyler(this.backButton, this._themeService, { buttonBackground: SIDE_BAR_BACKGROUND, buttonHoverBackground: SIDE_BAR_BACKGROUND });
 		}
 
-		this._cancelButton = this.addFooterButton(DialogModal.CANCEL_BUTTON_LABEL, () => this.cancel());
-		this._doneButton = this.addFooterButton(DialogModal.DONE_BUTTON_LABEL, () => this.done());
+		if (this._dialog.customButtons) {
+			this._dialog.customButtons.forEach(button => {
+				let buttonElement = this.addDialogButton(button);
+				attachButtonStyler(buttonElement, this._themeService);
+			});
+		}
+
+		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel());
+		this._doneButton = this.addDialogButton(this._dialog.okButton, () => this.done());
 		attachButtonStyler(this._cancelButton, this._themeService);
 		attachButtonStyler(this._doneButton, this._themeService);
+	}
+
+	private addDialogButton(button: DialogButton, onSelect: () => void = () => undefined): Button {
+		let buttonElement = this.addFooterButton(button.label, onSelect);
+		button.registerClickEvent(buttonElement.onDidClick);
+		return buttonElement;
 	}
 
 	protected renderBody(container: HTMLElement): void {

--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -61,12 +61,15 @@ export class DialogModal extends Modal {
 		if (this._dialog.customButtons) {
 			this._dialog.customButtons.forEach(button => {
 				let buttonElement = this.addDialogButton(button);
+				buttonElement.enabled = button.enabled;
 				attachButtonStyler(buttonElement, this._themeService);
 			});
 		}
 
 		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel());
+		this._cancelButton.enabled = this._dialog.cancelButton.enabled;
 		this._doneButton = this.addDialogButton(this._dialog.okButton, () => this.done());
+		this._doneButton.enabled = this._dialog.okButton.enabled;
 		attachButtonStyler(this._cancelButton, this._themeService);
 		attachButtonStyler(this._doneButton, this._themeService);
 	}

--- a/src/sql/platform/dialog/dialogTypes.ts
+++ b/src/sql/platform/dialog/dialogTypes.ts
@@ -6,6 +6,7 @@
 'use strict';
 
 import * as sqlops from 'sqlops';
+import { localize } from 'vs/nls';
 import Event, { Emitter } from 'vs/base/common/event';
 
 export class DialogTab implements sqlops.window.modelviewdialog.DialogTab {
@@ -21,15 +22,13 @@ export class DialogTab implements sqlops.window.modelviewdialog.DialogTab {
 }
 
 export class Dialog implements sqlops.window.modelviewdialog.Dialog {
-	public content: string | DialogTab[];
-	public okTitle: string;
-	public cancelTitle: string;
-	public customButtons: DialogButton[];
+	private static readonly DONE_BUTTON_LABEL = localize('dialogModalDoneButtonLabel', 'Done');
+	private static readonly CANCEL_BUTTON_LABEL = localize('dialogModalCancelButtonLabel', 'Cancel');
 
-	private _onOk: Emitter<void> = new Emitter<void>();
-	public readonly onOk: Event<void> = this._onOk.event;
-	private _onCancel: Emitter<void> = new Emitter<void>();
-	public readonly onCancel: Event<void> = this._onCancel.event;
+	public content: string | DialogTab[];
+	public okButton: DialogButton = new DialogButton(Dialog.DONE_BUTTON_LABEL, true);
+	public cancelButton: DialogButton = new DialogButton(Dialog.CANCEL_BUTTON_LABEL, true);
+	public customButtons: DialogButton[];
 
 	constructor(public title: string, content?: string | DialogTab[]) {
 		if (content) {
@@ -51,5 +50,12 @@ export class DialogButton implements sqlops.window.modelviewdialog.Button {
 	constructor(label: string, enabled: boolean) {
 		this.label = label;
 		this.enabled = enabled;
+	}
+
+	/**
+	 * Register an event that notifies the button that it has been clicked
+	 */
+	public registerClickEvent(clickEvent: Event<void>): void {
+		clickEvent(() => this._onClick.fire());
 	}
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -257,14 +257,14 @@ declare module 'sqlops' {
 				content: string | DialogTab[],
 
 				/**
-				 * The caption of the OK button
+				 * The ok button
 				 */
-				okTitle: string;
+				okButton: Button;
 
 				/**
-				 * The caption of the Cancel button
+				 * The cancel button
 				 */
-				cancelTitle: string;
+				cancelButton: Button;
 
 				/**
 				 * Any additional buttons that should be displayed
@@ -285,16 +285,6 @@ declare module 'sqlops' {
 				 * Updates the dialog on screen to reflect changes to the buttons or content
 				 */
 				updateContent(): void;
-
-				/**
-				 * Raised when dialog's ok button is pressed
-				 */
-				readonly onOk: vscode.Event<void>;
-
-				/**
-				 * Raised when dialog is canceled
-				 */
-				readonly onCancel: vscode.Event<void>;
 			}
 
 			export interface DialogTab {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -98,8 +98,8 @@ export interface IComponentEventArgs {
 export interface IModelViewDialogDetails {
 	title: string;
 	content: string | number[];
-	okTitle: string;
-	cancelTitle: string;
+	okButton: number;
+	cancelButton: number;
 	customButtons: number[];
 }
 

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -83,3 +83,21 @@ export interface IItemConfig {
 	componentShape: IComponentShape;
 	config: any;
 }
+
+export interface IModelViewDialogDetails {
+	title: string;
+	content: string | number[];
+	okTitle: string;
+	cancelTitle: string;
+	customButtons: number[];
+}
+
+export interface IModelViewTabDetails {
+	title: string;
+	content: string;
+}
+
+export interface IModelViewButtonDetails {
+	label: string;
+	enabled: boolean;
+}

--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -1,0 +1,204 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { IMainContext } from 'vs/workbench/api/node/extHost.protocol';
+import Event, { Emitter } from 'vs/base/common/event';
+import { deepClone } from 'vs/base/common/objects';
+import * as nls from 'vs/nls';
+
+import * as vscode from 'vscode';
+import * as sqlops from 'sqlops';
+
+import { SqlMainContext, ExtHostModelViewDialogShape, MainThreadModelViewDialogShape } from 'sql/workbench/api/node/sqlExtHost.protocol';
+import { IItemConfig, ModelComponentTypes, IComponentShape } from 'sql/workbench/api/common/sqlExtHostTypes';
+
+class DialogImpl implements sqlops.window.modelviewdialog.Dialog {
+	public title: string;
+	public content: string | TabImpl[];
+	public okTitle: string;
+	public cancelTitle: string;
+	public customButtons: ButtonImpl[];
+
+	private readonly _onOk = new Emitter<void>();
+	public readonly onOk = this._onOk.event;
+	private readonly _onCancel = new Emitter<void>();
+	public readonly onCancel = this._onCancel.event;
+
+	constructor(private _handle: number, private _extHostModelViewDialog: ExtHostModelViewDialog) {
+		this._extHostModelViewDialog.registerOnOkCallback(this._handle, () => this._onOk.fire());
+		this._extHostModelViewDialog.registerOnCancelCallback(this._handle, () => this._onCancel.fire());
+	}
+
+	public open(): void {
+		this._extHostModelViewDialog.open(this._handle);
+	}
+
+	public close(): void {
+		this._extHostModelViewDialog.close(this._handle);
+	}
+
+	public updateContent(): void {
+		this._extHostModelViewDialog.updateDialogContent(this._handle);
+	}
+}
+
+class TabImpl implements sqlops.window.modelviewdialog.DialogTab {
+	public title: string;
+	public content: string;
+
+	constructor(private _handle: number, private _extHostModelViewDialog: ExtHostModelViewDialog) { }
+
+	public updateContent(): void {
+		this._extHostModelViewDialog.updateTabContent(this._handle);
+	}
+}
+
+class ButtonImpl implements sqlops.window.modelviewdialog.Button {
+	private _label: string;
+	private _enabled: boolean;
+
+	private _onClick = new Emitter<void>();
+	public onClick = this._onClick.event;
+
+	constructor(private _handle: number, private _extHostModelViewDialog: ExtHostModelViewDialog) {
+		this._extHostModelViewDialog.registerOnClickCallback(this._handle, () => this._onClick.fire());
+	}
+
+	public get label(): string {
+		return this._label;
+	}
+
+	public set label(label: string) {
+		this._label = label;
+		this._extHostModelViewDialog.updateButton(this._handle);
+	}
+
+	public get enabled(): boolean {
+		return this._enabled;
+	}
+
+	public set enabled(enabled: boolean) {
+		this._enabled = enabled;
+		this._extHostModelViewDialog.updateButton(this._handle);
+	}
+}
+
+export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
+	private static _currentHandle = 0;
+
+	private readonly _proxy: MainThreadModelViewDialogShape;
+
+	private readonly _dialogs = new Map<number, DialogImpl>();
+	private readonly _tabs = new Map<number, TabImpl>();
+	private readonly _buttons = new Map<number, ButtonImpl>();
+
+	private readonly _onOkCallbacks = new Map<number, () => void>();
+	private readonly _onCancelCallbacks = new Map<number, () => void>();
+	private readonly _onClickCallbacks = new Map<number, () => void>();
+
+	constructor(
+		mainContext: IMainContext
+	) {
+		this._proxy = mainContext.getProxy(SqlMainContext.MainThreadModelViewDialog);
+	}
+
+	public $onOk(handle: number): void {
+		this._onOkCallbacks.get(handle)();
+	}
+
+	public $onCancel(handle: number): void {
+		this._onCancelCallbacks.get(handle)();
+	}
+
+	public $onButtonClick(handle: number): void {
+		this._onClickCallbacks.get(handle)();
+	}
+
+	public open(handle: number): void {
+		this.updateDialogContent(handle);
+		this._proxy.$open(handle);
+	}
+
+	public close(handle: number): void {
+		this._proxy.$close(handle);
+	}
+
+	public updateDialogContent(handle: number): void {
+		let dialog = this._dialogs.get(handle);
+		let tabs = dialog.content;
+		if (tabs && typeof tabs !== 'string') {
+			tabs.forEach(tab => this._proxy.$setTabDetails((tab as any)._handle, {
+				title: tab.title,
+				content: tab.content
+			}));
+		}
+		if (dialog.customButtons) {
+			dialog.customButtons.forEach(button => this._proxy.$setButtonDetails((button as any)._handle, {
+				label: button.label,
+				enabled: button.enabled
+			}));
+		}
+		this._proxy.$setDialogDetails(handle, {
+			title: dialog.title,
+			okTitle: dialog.okTitle,
+			cancelTitle: dialog.cancelTitle,
+			content: dialog.content && typeof dialog.content !== 'string' ? dialog.content.map(tab => (tab as any)._handle) : dialog.content as string,
+			customButtons: dialog.customButtons ? dialog.customButtons.map(button => (button as any)._handle) : undefined
+		});
+	}
+
+	public updateTabContent(handle: number): void {
+		let tab = this._tabs.get(handle);
+		this._proxy.$setTabDetails(handle, {
+			title: tab.title,
+			content: tab.content
+		});
+	}
+
+	public updateButton(handle: number): void {
+		let button = this._buttons.get(handle);
+		this._proxy.$setButtonDetails(handle, {
+			label: button.label,
+			enabled: button.enabled
+		});
+	}
+
+	public registerOnOkCallback(handle: number, callback: () => void) {
+		this._onOkCallbacks.set(handle, callback);
+	}
+
+	public registerOnCancelCallback(handle: number, callback: () => void) {
+		this._onCancelCallbacks.set(handle, callback);
+	}
+
+	public registerOnClickCallback(handle: number, callback: () => void) {
+		this._onClickCallbacks.set(handle, callback);
+	}
+
+	public createDialog(title: string): sqlops.window.modelviewdialog.Dialog {
+		let dialog = new DialogImpl(ExtHostModelViewDialog._currentHandle, this);
+		dialog.title = title;
+		this._dialogs.set(ExtHostModelViewDialog._currentHandle, dialog);
+		ExtHostModelViewDialog._currentHandle += 1;
+		return dialog;
+	}
+
+	public createTab(title: string): sqlops.window.modelviewdialog.DialogTab {
+		let tab = new TabImpl(ExtHostModelViewDialog._currentHandle, this);
+		tab.title = title;
+		this._tabs.set(ExtHostModelViewDialog._currentHandle, tab);
+		ExtHostModelViewDialog._currentHandle += 1;
+		return tab;
+	}
+
+	public createButton(label: string): sqlops.window.modelviewdialog.Button {
+		let button = new ButtonImpl(ExtHostModelViewDialog._currentHandle, this);
+		button.label = label;
+		this._buttons.set(ExtHostModelViewDialog._currentHandle, button);
+		ExtHostModelViewDialog._currentHandle += 1;
+		return button;
+	}
+}

--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -58,7 +58,9 @@ class ButtonImpl implements sqlops.window.modelviewdialog.Button {
 	private _onClick = new Emitter<void>();
 	public onClick = this._onClick.event;
 
-	constructor(private _extHostModelViewDialog: ExtHostModelViewDialog) { }
+	constructor(private _extHostModelViewDialog: ExtHostModelViewDialog) {
+		this._enabled = true;
+	}
 
 	public get label(): string {
 		return this._label;

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -48,15 +48,14 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 		let dialog = this._dialogs.get(handle);
 		if (!dialog) {
 			dialog = new Dialog(details.title);
-			dialog.onOk(() => this.onOk(handle));
-			dialog.onCancel(() => this.onCancel(handle));
+			let okButton = this.getButton(details.okButton);
+			let cancelButton = this.getButton(details.cancelButton);
+			dialog.okButton = okButton;
+			dialog.cancelButton = cancelButton;
 			this._dialogs.set(handle, dialog);
 		}
 
 		dialog.title = details.title;
-		dialog.okTitle = details.okTitle;
-		dialog.cancelTitle = details.cancelTitle;
-
 		if (details.content && typeof details.content !== 'string') {
 			dialog.content = details.content.map(tabHandle => this.getTab(tabHandle));
 		} else {
@@ -128,13 +127,5 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 
 	private onButtonClick(handle: number): void {
 		this._proxy.$onButtonClick(handle);
-	}
-
-	private onOk(handle: number): void {
-		this._proxy.$onOk(handle);
-	}
-
-	private onCancel(handle: number): void {
-		this._proxy.$onCancel(handle);
 	}
 }

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -10,7 +10,7 @@ import { Dialog, DialogTab, DialogButton } from 'sql/platform/dialog/dialogTypes
 import { IExtHostContext } from 'vs/workbench/api/node/extHost.protocol';
 import { CustomDialogService } from 'sql/platform/dialog/customDialogService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IModelViewDialogDetails, IModelViewTabDetails, IModelViewButtonDetails } from '../common/sqlExtHostTypes';
+import { IModelViewDialogDetails, IModelViewTabDetails, IModelViewButtonDetails } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadModelViewDialog)
 export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape {

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -67,7 +67,7 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 			dialog.customButtons = details.customButtons.map(buttonHandle => this.getButton(buttonHandle));
 		}
 
-		// TODO: Update the dialog if it is displayed
+		dialog.updateContent();
 		return Promise.resolve();
 	}
 
@@ -81,7 +81,7 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 		tab.title = details.title;
 		tab.content = details.content;
 
-		// TODO: Update the tab if it is displayed
+		tab.updateContent();
 		return Promise.resolve();
 	}
 
@@ -96,7 +96,6 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 			button.enabled = details.enabled;
 		}
 
-		// TODO: Update the button if it is displayed
 		return Promise.resolve();
 	}
 

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -1,0 +1,141 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+'use strict';
+
+import { MainThreadModelViewDialogShape, SqlMainContext, ExtHostModelViewDialogShape, SqlExtHostContext } from 'sql/workbench/api/node/sqlExtHost.protocol';
+import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
+import { Dialog, DialogTab, DialogButton } from 'sql/platform/dialog/dialogTypes';
+import { IExtHostContext } from 'vs/workbench/api/node/extHost.protocol';
+import { CustomDialogService } from 'sql/platform/dialog/customDialogService';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IModelViewDialogDetails, IModelViewTabDetails, IModelViewButtonDetails } from '../common/sqlExtHostTypes';
+
+@extHostNamedCustomer(SqlMainContext.MainThreadModelViewDialog)
+export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape {
+	private readonly _proxy: ExtHostModelViewDialogShape;
+	private readonly _dialogs = new Map<number, Dialog>();
+	private readonly _tabs = new Map<number, DialogTab>();
+	private readonly _buttons = new Map<number, DialogButton>();
+	private _dialogService: CustomDialogService;
+
+	constructor(
+		context: IExtHostContext,
+		@IInstantiationService instatiationService: IInstantiationService
+	) {
+		this._proxy = context.getProxy(SqlExtHostContext.ExtHostModelViewDialog);
+		this._dialogService = new CustomDialogService(instatiationService);
+	}
+
+	public dispose(): void {
+		throw new Error('Method not implemented.');
+	}
+
+	public $open(handle: number): Thenable<void> {
+		let dialog = this.getDialog(handle);
+		this._dialogService.showDialog(dialog);
+		return Promise.resolve();
+	}
+
+	public $close(handle: number): Thenable<void> {
+		let dialog = this.getDialog(handle);
+		dialog.close();
+		return Promise.resolve();
+	}
+
+	public $setDialogDetails(handle: number, details: IModelViewDialogDetails): Thenable<void> {
+		let dialog = this._dialogs.get(handle);
+		if (!dialog) {
+			dialog = new Dialog(details.title);
+			dialog.onOk(() => this.onOk(handle));
+			dialog.onCancel(() => this.onCancel(handle));
+			this._dialogs.set(handle, dialog);
+		}
+
+		dialog.title = details.title;
+		dialog.okTitle = details.okTitle;
+		dialog.cancelTitle = details.cancelTitle;
+
+		if (details.content && typeof details.content !== 'string') {
+			dialog.content = details.content.map(tabHandle => this.getTab(tabHandle));
+		} else {
+			dialog.content = details.content as string;
+		}
+
+		if (details.customButtons) {
+			dialog.customButtons = details.customButtons.map(buttonHandle => this.getButton(buttonHandle));
+		}
+
+		// TODO: Update the dialog if it is displayed
+		return Promise.resolve();
+	}
+
+	public $setTabDetails(handle: number, details: IModelViewTabDetails): Thenable<void> {
+		let tab = this._tabs.get(handle);
+		if (!tab) {
+			tab = new DialogTab(details.title);
+			this._tabs.set(handle, tab);
+		}
+
+		tab.title = details.title;
+		tab.content = details.content;
+
+		// TODO: Update the tab if it is displayed
+		return Promise.resolve();
+	}
+
+	public $setButtonDetails(handle: number, details: IModelViewButtonDetails): Thenable<void> {
+		let button = this._buttons.get(handle);
+		if (!button) {
+			button = new DialogButton(details.label, details.enabled);
+			button.onClick(() => this.onButtonClick(handle));
+			this._buttons.set(handle, button);
+		} else {
+			button.label = details.label;
+			button.enabled = details.enabled;
+		}
+
+		// TODO: Update the button if it is displayed
+		return Promise.resolve();
+	}
+
+	private getDialog(handle: number): Dialog {
+		let dialog = this._dialogs.get(handle);
+		if (!dialog) {
+			throw new Error('No dialog matching the given handle');
+		}
+
+		return dialog;
+	}
+
+	private getTab(handle: number): DialogTab {
+		let tab = this._tabs.get(handle);
+		if (!tab) {
+			throw new Error('No tab matching the given handle');
+		}
+
+		return tab;
+	}
+
+	private getButton(handle: number): DialogButton {
+		let button = this._buttons.get(handle);
+		if (!button) {
+			throw new Error('No button matching the given handle');
+		}
+
+		return button;
+	}
+
+	private onButtonClick(handle: number): void {
+		this._proxy.$onButtonClick(handle);
+	}
+
+	private onOk(handle: number): void {
+		this._proxy.$onOk(handle);
+	}
+
+	private onCancel(handle: number): void {
+		this._proxy.$onCancel(handle);
+	}
+}

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -32,6 +32,7 @@ import { ExtHostConnectionManagement } from 'sql/workbench/api/node/extHostConne
 import { ExtHostDashboard } from 'sql/workbench/api/node/extHostDashboard';
 import { ExtHostObjectExplorer } from 'sql/workbench/api/node/extHostObjectExplorer';
 import { ExtHostLogService } from 'vs/workbench/api/node/extHostLogService';
+import { ExtHostModelViewDialog } from './extHostModelViewDialog';
 
 export interface ISqlExtensionApiFactory {
 	vsCodeFactory(extension: IExtensionDescription): typeof vscode;
@@ -64,6 +65,7 @@ export function createApiFactory(
 	const extHostWebviewWidgets = rpcProtocol.set(SqlExtHostContext.ExtHostDashboardWebviews, new ExtHostDashboardWebviews(rpcProtocol));
 	const extHostModelView = rpcProtocol.set(SqlExtHostContext.ExtHostModelView, new ExtHostModelView(rpcProtocol));
 	const extHostDashboard = rpcProtocol.set(SqlExtHostContext.ExtHostDashboard, new ExtHostDashboard(rpcProtocol));
+	const extHostModelViewDialog = rpcProtocol.set(SqlExtHostContext.ExtHostModelViewDialog, new ExtHostModelViewDialog(rpcProtocol));
 
 
 	return {
@@ -281,10 +283,15 @@ export function createApiFactory(
 			};
 
 			const modelViewDialog: typeof sqlops.window.modelviewdialog = {
-				// TODO mairvine 4/18/18: Implement the extension layer for custom dialogs
-				createDialog(title: string): sqlops.window.modelviewdialog.Dialog { return undefined; },
-				createTab(title: string): sqlops.window.modelviewdialog.DialogTab { return undefined; },
-				createButton(label: string): sqlops.window.modelviewdialog.Button { return undefined; }
+				createDialog(title: string): sqlops.window.modelviewdialog.Dialog {
+					return extHostModelViewDialog.createDialog(title);
+				},
+				createTab(title: string): sqlops.window.modelviewdialog.DialogTab {
+					return extHostModelViewDialog.createTab(title);
+				},
+				createButton(label: string): sqlops.window.modelviewdialog.Button {
+					return extHostModelViewDialog.createButton(label);
+				}
 			};
 
 			const window: typeof sqlops.window = {

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -32,7 +32,7 @@ import { ExtHostConnectionManagement } from 'sql/workbench/api/node/extHostConne
 import { ExtHostDashboard } from 'sql/workbench/api/node/extHostDashboard';
 import { ExtHostObjectExplorer } from 'sql/workbench/api/node/extHostObjectExplorer';
 import { ExtHostLogService } from 'vs/workbench/api/node/extHostLogService';
-import { ExtHostModelViewDialog } from './extHostModelViewDialog';
+import { ExtHostModelViewDialog } from 'sql/workbench/api/node/extHostModelViewDialog';
 import { ExtHostQueryEditor } from 'sql/workbench/api/node/extHostQueryEditor';
 
 export interface ISqlExtensionApiFactory {

--- a/src/sql/workbench/api/node/sqlExtHost.contribution.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.contribution.ts
@@ -20,6 +20,7 @@ import 'sql/workbench/api/electron-browser/mainThreadTasks';
 import 'sql/workbench/api/electron-browser/mainThreadDashboard';
 import 'sql/workbench/api/node/mainThreadDashboardWebview';
 import 'sql/workbench/api/node/mainThreadModelView';
+import 'sql/workbench/api/node/mainThreadModelViewDialog';
 import './mainThreadAccountManagement';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -448,7 +448,7 @@ export const SqlMainContext = {
 	MainThreadDashboardWebview: createMainId<MainThreadDashboardWebviewShape>('MainThreadDashboardWebview'),
 	MainThreadModelView: createMainId<MainThreadModelViewShape>('MainThreadModelView'),
 	MainThreadDashboard: createMainId<MainThreadDashboardShape>('MainThreadDashboard'),
-	MainThreadModelViewDialog: createMainId<MainThreadModelViewDialogShape>('MainThreadModelViewDialog')
+	MainThreadModelViewDialog: createMainId<MainThreadModelViewDialogShape>('MainThreadModelViewDialog'),
 	MainThreadQueryEditor: createMainId<MainThreadQueryEditorShape>('MainThreadQueryEditor'),
 };
 
@@ -465,7 +465,7 @@ export const SqlExtHostContext = {
 	ExtHostDashboardWebviews: createExtId<ExtHostDashboardWebviewsShape>('ExtHostDashboardWebviews'),
 	ExtHostModelView: createExtId<ExtHostModelViewShape>('ExtHostModelView'),
 	ExtHostDashboard: createExtId<ExtHostDashboardShape>('ExtHostDashboard'),
-	ExtHostModelViewDialog: createExtId<ExtHostModelViewDialogShape>('ExtHostModelViewDialog')
+	ExtHostModelViewDialog: createExtId<ExtHostModelViewDialogShape>('ExtHostModelViewDialog'),
 	ExtHostQueryEditor: createExtId<ExtHostQueryEditorShape>('ExtHostQueryEditor')
 };
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -16,7 +16,7 @@ import * as sqlops from 'sqlops';
 import * as vscode from 'vscode';
 
 import { ITaskHandlerDescription } from 'sql/platform/tasks/common/tasks';
-import { IItemConfig, ModelComponentTypes, IComponentShape } from 'sql/workbench/api/common/sqlExtHostTypes';
+import { IItemConfig, ModelComponentTypes, IComponentShape, IModelViewDialogDetails, IModelViewTabDetails, IModelViewButtonDetails } from 'sql/workbench/api/common/sqlExtHostTypes';
 
 export abstract class ExtHostAccountManagementShape {
 	$autoOAuthCancelled(handle: number): Thenable<void> { throw ni(); }
@@ -446,7 +446,8 @@ export const SqlMainContext = {
 	MainThreadTasks: createMainId<MainThreadTasksShape>('MainThreadTasks'),
 	MainThreadDashboardWebview: createMainId<MainThreadDashboardWebviewShape>('MainThreadDashboardWebview'),
 	MainThreadModelView: createMainId<MainThreadModelViewShape>('MainThreadModelView'),
-	MainThreadDashboard: createMainId<MainThreadDashboardShape>('MainThreadDashboard')
+	MainThreadDashboard: createMainId<MainThreadDashboardShape>('MainThreadDashboard'),
+	MainThreadModelViewDialog: createMainId<MainThreadModelViewDialogShape>('MainThreadModelViewDialog')
 };
 
 export const SqlExtHostContext = {
@@ -461,7 +462,8 @@ export const SqlExtHostContext = {
 	ExtHostTasks: createExtId<ExtHostTasksShape>('ExtHostTasks'),
 	ExtHostDashboardWebviews: createExtId<ExtHostDashboardWebviewsShape>('ExtHostDashboardWebviews'),
 	ExtHostModelView: createExtId<ExtHostModelViewShape>('ExtHostModelView'),
-	ExtHostDashboard: createExtId<ExtHostDashboardShape>('ExtHostDashboard')
+	ExtHostDashboard: createExtId<ExtHostDashboardShape>('ExtHostDashboard'),
+	ExtHostModelViewDialog: createExtId<ExtHostModelViewDialogShape>('ExtHostModelViewDialog')
 };
 
 export interface MainThreadDashboardShape extends IDisposable {
@@ -536,4 +538,18 @@ export interface MainThreadObjectExplorerShape extends IDisposable {
 	$getChildren(connectionId: string, nodePath: string): Thenable<sqlops.NodeInfo[]>;
 	$isExpanded(connectionId: string, nodePath: string): Thenable<boolean>;
 	$findNodes(connectionId: string, type: string, schema: string, name: string, database: string, parentObjectNames: string[]): Thenable<sqlops.NodeInfo[]>;
+}
+
+export interface ExtHostModelViewDialogShape {
+	$onOk(handle: number): void;
+	$onCancel(handle: number): void;
+	$onButtonClick(handle: number): void;
+}
+
+export interface MainThreadModelViewDialogShape extends IDisposable {
+	$open(handle: number): Thenable<void>;
+	$close(handle: number): Thenable<void>;
+	$setDialogDetails(handle: number, details: IModelViewDialogDetails): Thenable<void>;
+	$setTabDetails(handle: number, details: IModelViewTabDetails): Thenable<void>;
+	$setButtonDetails(handle: number, details: IModelViewButtonDetails): Thenable<void>;
 }

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -546,8 +546,6 @@ export interface MainThreadObjectExplorerShape extends IDisposable {
 }
 
 export interface ExtHostModelViewDialogShape {
-	$onOk(handle: number): void;
-	$onCancel(handle: number): void;
 	$onButtonClick(handle: number): void;
 }
 


### PR DESCRIPTION
This exposes the current version of the proposed custom dialog APIs for extension use. The APIs aren't finalized yet but this will make it easier to test and develop for now.

The following code can be used to register a command that shows a dialog when executed, assuming the `sqlservices` model view content provider is already registered:

```
	vscode.commands.registerCommand('mssql.openTestDialog', () => {
		let dialog = sqlops.window.modelviewdialog.createDialog('Test dialog');
		let tab1 = sqlops.window.modelviewdialog.createTab('Test tab 1');
		tab1.content = 'sqlservices';
		let tab2 = sqlops.window.modelviewdialog.createTab('Test tab 2');
		tab2.content = 'sqlservices';
		dialog.content = [tab1, tab2];
		dialog.okButton.onClick(() => console.log('ok clicked!'));
		dialog.cancelButton.onClick(() => console.log('cancel clicked!'));
		dialog.okButton.label = 'ok';
		dialog.cancelButton.label = 'no';
		let customButton1 = sqlops.window.modelviewdialog.createButton('Test button 1');
		customButton1.onClick(() => console.log('button 1 clicked!'));
		let customButton2 = sqlops.window.modelviewdialog.createButton('Test button 2');
		customButton2.onClick(() => console.log('button 2 clicked!'));
		dialog.customButtons = [customButton1, customButton2];
		dialog.open();
	});
```

![Modal with custom content, custom buttons, and custom labels for the ok and cancel buttons](https://user-images.githubusercontent.com/3758704/39218320-f26703ca-47d8-11e8-89ee-3b7a8546e945.png)
