### PR TITLE
Add Redgate SQL Search to recommended extensions list

### DIFF
--- a/product.json
+++ b/product.json
@@ -34,7 +34,8 @@
 	"recommendedExtensions": [
 		"Microsoft.agent",
 		"Microsoft.whoisactive",
-		"Microsoft.server-report"
+		"Microsoft.server-report",
+		"Redgate.sql-search"
 	],
 	"extensionsGallery": {
 		"serviceUrl": "https://raw.githubusercontent.com/Microsoft/sqlopsstudio/release/extensions/extensionsGallery.json"


### PR DESCRIPTION
This adds the recommendation star to Redgate SQL Search in Extension Manager.

![screen](https://user-images.githubusercontent.com/599935/39149309-8478f926-46f3-11e8-851d-a949cc87a6d8.png)
