### PR TITLE
Fix bar chart displaying extra series

### DIFF
--- a/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
@@ -255,17 +255,17 @@ export abstract class ChartInsight extends Disposable implements IInsightsView {
 			}
 		} else {
 			if (this._config.columnsAsLabels) {
-				return this._data.rows[0].map((row, i) => {
+				return this._data.rows[0].slice(1).map((row, i) => {
 					return {
-						data: this._data.rows.map(row => Number(row[i])),
-						label: this._data.columns[i]
+						data: this._data.rows.map(row => Number(row[i + 1])),
+						label: this._data.columns[i + 1]
 					};
 				});
 			} else {
-				return this._data.rows[0].map((row, i) => {
+				return this._data.rows[0].slice(1).map((row, i) => {
 					return {
-						data: this._data.rows.map(row => Number(row[i])),
-						label: 'Series' + i
+						data: this._data.rows.map(row => Number(row[i + 1])),
+						label: 'Series' + (i + 1)
 					};
 				});
 			}


### PR DESCRIPTION
Fixes #1228 

Bar charts use the first column of results as y (horizontal) or x (vertical) axis label names in the "vertical" data mode, but our logic didn't properly remove that column as a series for the data