### PR TITLE
Fix issue where chart type select is missing for tables

### DIFF
--- a/src/sql/parts/grid/views/query/chartViewer.component.html
+++ b/src/sql/parts/grid/views/query/chartViewer.component.html
@@ -1,7 +1,7 @@
 
 <div #taskbarContainer></div>
-<div style="display: flex; flex-flow: row; overflow: scroll; height: 100%; width: 100%">
-	<div style="flex:3 3 auto; margin: 5px">
+<div style="display: flex; flex-flow: row; overflow: hidden; height: 100%; width: 100%">
+	<div style="flex:3 3 auto; margin: 5px; overflow: scroll">
 		<div style="position: relative; width: calc(100% - 20px); height: calc(100% - 20px)">
 			<ng-template component-host></ng-template>
 		</div>


### PR DESCRIPTION
Fixes #1229 

Fixing this since I was working with chart viewer code anyway. 

Before:
![Table chart with chart type select box missing](https://user-images.githubusercontent.com/3758704/39158712-773aa8a4-4716-11e8-942d-58af63b80be9.png)
After:
![Table chart with chart type select box displayed](https://user-images.githubusercontent.com/3758704/39158754-bf4e9e66-4716-11e8-9dc3-90d06a5511f3.png)

If the table is wide enough to force scrolling, the table will scroll behind the options pane.