### PR TITLE
change keyboard shortcut for focusOnCurrentQuery

### DIFF
--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -137,7 +137,7 @@ actionRegistry.registerWorkbenchAction(
 		FocusOnCurrentQueryKeyboardAction,
 		FocusOnCurrentQueryKeyboardAction.ID,
 		FocusOnCurrentQueryKeyboardAction.LABEL,
-		{ primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_Q }
+		{ primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_O }
 	),
 	FocusOnCurrentQueryKeyboardAction.LABEL
 );


### PR DESCRIPTION
Fix #1238: @ sign not working 

I tested with German keyboard and it works with both @ and KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_O