### PR TITLE
Initial improvement in sp_whoisactive

### DIFF
--- a/samples/sp_whoIsActive/.vscode/launch.json
+++ b/samples/sp_whoIsActive/.vscode/launch.json
@@ -1,28 +1,57 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+
+// To debug the extension:
+// 1. please install the "SQL Operations Studio Debug" extension into VSCode
+// 2. Ensure sqlops is added to your path:
+//    - open SQL Operations Studio
+//    - run the command "Install 'sqlops' command in PATH"
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
+	"version": "0.2.0",
     "configurations": [
+
         {
-            "type": "node",
+            "name": "Debug in SqlOps install",
+            "type": "sqlopsExtensionHost",
             "request": "launch",
-            "name": "Launch Program",
-            "program": "${workspaceFolder}\\out\\src\\extension"
+            "runtimeExecutable": "sqlops",
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ]
         },
-        {
-            "type": "node",
-            "request": "attach",
-            "name": "Attach to Ops Studio",
-            "protocol": "inspector",
-            "port": 5870,
-            "restart": true,
+		{
+			"type": "node",
+			"request": "attach",
+			"name": "Attach to Ops Studio",
+			"protocol": "inspector",
+			"port": 5870,
+			"restart": true,
             "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/out/**/*.js"
-            ],
+			"outFiles": [
+				"${workspaceRoot}/out/**/*.js"
+			],
             "preLaunchTask": "",
             "timeout": 25000
-        },
+		},
+        {
+            "name": "Debug in enlistment",
+            "type": "sqlopsExtensionHost",
+            "request": "launch",
+			"windows": {
+				"runtimeExecutable": "${workspaceFolder}/../../scripts/sql.bat"
+			},
+			"osx": {
+				"runtimeExecutable": "${workspaceFolder}/../../scripts/sql.sh"
+			},
+			"linux": {
+				"runtimeExecutable": "${workspaceFolder}/../../scripts/sql.sh"
+			},
+            "args": [
+                "--extensionDevelopmentPath=${workspaceFolder}"
+            ],
+            "timeout": 20000
+        }
     ]
 }

--- a/samples/sp_whoIsActive/package-lock.json
+++ b/samples/sp_whoIsActive/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "whoisactive",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/samples/sp_whoIsActive/package.json
+++ b/samples/sp_whoIsActive/package.json
@@ -24,7 +24,7 @@
         "commands": [
             {
                 "command": "sp_whoisactive.install",
-                "title": "Install sp_whoisactive",
+                "title": "Whoisactive: Install sp_whoisactive",
                 "icon": {
                     "light": "./out/src/media/download.svg",
                     "dark": "./out/src/media/download_inverse.svg"
@@ -32,7 +32,7 @@
             },
             {
                 "command": "sp_whoisactive.findBlockLeaders",
-                "title": "Find leader of block",
+                "title": "Whoisactive: Find leader of block",
                 "icon": {
                     "light": "./out/src/media/blocker.svg",
                     "dark": "./out/src/media/blocker_inverse.svg"
@@ -40,7 +40,7 @@
             },
             {
                 "command": "sp_whoisactive.getPlans",
-                "title": "Get plans",
+                "title": "Whoisactive: Get plans",
                 "icon": {
                     "light": "./out/src/media/monitor.svg",
                     "dark": "./out/src/media/monitor_inverse.svg"
@@ -48,7 +48,7 @@
             },
             {
                 "command": "sp_whoisactive.documentation",
-                "title": "Documentation",
+                "title": "Whoisactive: Documentation",
                 "icon": {
                     "light": "./out/src/media/documentation.svg",
                     "dark": "./out/src/media/documentation_inverse.svg"

--- a/samples/sp_whoIsActive/package.json
+++ b/samples/sp_whoIsActive/package.json
@@ -2,7 +2,7 @@
     "name": "whoisactive",
     "displayName": "whoisactive",
     "description": "sp_whoisactive for SQL Operations Studio",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "publisher": "Microsoft",
     "preview": true,
     "engines": {
@@ -45,6 +45,14 @@
                     "light": "./out/src/media/monitor.svg",
                     "dark": "./out/src/media/monitor_inverse.svg"
                 }
+            },
+            {
+                "command": "sp_whoisactive.documentation",
+                "title": "Documentation",
+                "icon": {
+                    "light": "./out/src/media/documentation.svg",
+                    "dark": "./out/src/media/documentation_inverse.svg"
+                }
             }
         ],
         "views": {},
@@ -55,30 +63,7 @@
                 "title": "sp_whoisactive",
                 "description": "Extension for checking who is active.",
                 "container": {
-                    "nav-section": [
-                        {
-                            "id": "sp_whoisactive_insights",
-                            "title": "Insights",
-                            "icon": {
-                                "light": "./out/src/media/insights.svg",
-                                "dark": "./out/src/media/insights_inverse.svg"
-                            },
-                            "container": {
-                                "sp_whoisactive-insights": {}
-                            }
-                        },
-                        {
-                            "id": "sp_whoisactive_documentation",
-                            "title": "Documentation",
-                            "icon": {
-                                "light": "./out/src/media/documentation.svg",
-                                "dark": "./out/src/media/documentation_inverse.svg"
-                            },
-                            "container": {
-                                "webview-container": null
-                            }
-                        }
-                    ]
+                    "sp_whoisactive-insights": {}
                 }
             }
         ],
@@ -92,7 +77,8 @@
                             "dataType": "number",
                             "legendPosition": "none",
                             "labelFirstColumn": false,
-                            "columnsAsLabels": true
+                            "columnsAsLabels": true,
+                            "showTopNData": 5
                         }
                     },
                     "queryFile": "./out/src/sql/cpuUsage.sql"
@@ -107,7 +93,8 @@
                             "dataType": "number",
                             "legendPosition": "none",
                             "labelFirstColumn": false,
-                            "columnsAsLabels": true
+                            "columnsAsLabels": true,
+                            "showTopNData": 5
                         }
                     },
                     "queryFile": "./out/src/sql/cpuDelta.sql"
@@ -122,7 +109,8 @@
                             "dataType": "number",
                             "legendPosition": "none",
                             "labelFirstColumn": false,
-                            "columnsAsLabels": true
+                            "columnsAsLabels": true,
+                            "showTopNData": 5
                         }
                     },
                     "queryFile": "./out/src/sql/memoryUsage.sql"
@@ -137,10 +125,20 @@
                             "dataType": "number",
                             "legendPosition": "none",
                             "labelFirstColumn": false,
-                            "columnsAsLabels": true
+                            "columnsAsLabels": true,
+                            "showTopNData": 5
                         }
                     },
                     "queryFile": "./out/src/sql/memoryDelta.sql"
+                }
+            },
+            {
+                "id": "sp_whoisactive-blocking_sessions",
+                "contrib": {
+                    "type": {
+                        "table": null
+                    },
+                    "queryFile": "./out/src/sql/blockingSessions.sql"
                 }
             }
         ],
@@ -155,12 +153,13 @@
                                 "tasks-widget": [
                                     "sp_whoisactive.getPlans",
                                     "sp_whoisactive.findBlockLeaders",
+                                    "sp_whoisactive.documentation",
                                     "sp_whoisactive.install"
                                 ]
                             }
                         },
                         {
-                            "name": "CPU Usage",
+                            "name": "Top 5 CPU Usage",
                             "gridItemConfig": {
                                 "sizex": 2,
                                 "sizey": 1
@@ -170,7 +169,7 @@
                             }
                         },
                         {
-                            "name": "CPU Delta",
+                            "name": "Top 5 CPU Delta",
                             "gridItemConfig": {
                                 "sizex": 2,
                                 "sizey": 1
@@ -180,7 +179,7 @@
                             }
                         },
                         {
-                            "name": "Memory Usage",
+                            "name": "Top 5 Memory Usage",
                             "gridItemConfig": {
                                 "sizex": 2,
                                 "sizey": 1
@@ -190,13 +189,23 @@
                             }
                         },
                         {
-                            "name": "Memory Delta",
+                            "name": "Top 5 Memory Delta",
                             "gridItemConfig": {
                                 "sizex": 2,
                                 "sizey": 1
                             },
                             "widget": {
                                 "sp_whoisactive-memory-delta": {}
+                            }
+                        },
+                        {
+                            "name": "Blocking Sessions",
+                            "gridItemConfig": {
+                                "sizex": 2,
+                                "sizey": 1
+                            },
+                            "widget": {
+                                "sp_whoisactive-blocking_sessions": {}
                             }
                         }
                     ]

--- a/samples/sp_whoIsActive/src/controllers/mainController.ts
+++ b/samples/sp_whoIsActive/src/controllers/mainController.ts
@@ -29,23 +29,16 @@ export default class MainController extends ControllerBase {
     }
 
     public activate(): Promise<boolean> {
-        sqlops.dashboard.registerWebviewProvider('sp_whoisactive_documentation', webview => {
-            let templateValues = {url: 'http://whoisactive.com/docs/'};
-            Utils.renderTemplateHtml(path.join(__dirname, '..'), 'templateTab.html', templateValues)
-            .then(html => {
-                webview.html = html;
-            });
-        });
-
-        sqlops.tasks.registerTask('sp_whoisactive.install', e => this.onInstall(e));
+        sqlops.tasks.registerTask('sp_whoisactive.install', e => this.openurl('http://whoisactive.com/downloads/'));
+        sqlops.tasks.registerTask('sp_whoisactive.documentation', e => this.openurl('http://whoisactive.com/docs/'));
         sqlops.tasks.registerTask('sp_whoisactive.findBlockLeaders', e => this.onExecute(e, 'findBlockLeaders.sql'));
         sqlops.tasks.registerTask('sp_whoisactive.getPlans', e => this.onExecute(e, 'getPlans.sql'));
 
         return Promise.resolve(true);
     }
 
-    private onInstall(connection: sqlops.IConnectionProfile): void {
-        openurl.open('http://whoisactive.com/downloads/');
+    private openurl(link: string): void {
+        openurl.open(link);
     }
 
     private onExecute(connection: sqlops.IConnectionProfile, fileName: string): void {

--- a/samples/sp_whoIsActive/src/controllers/mainController.ts
+++ b/samples/sp_whoIsActive/src/controllers/mainController.ts
@@ -47,7 +47,7 @@ export default class MainController extends ControllerBase {
     }
 
     private openSQLFileWithContent(content: string): void {
-        vscode.workspace.openTextDocument({language: 'sql', content: content}).then(doc => {
+        vscode.workspace.openTextDocument({ language: 'sql', content: content }).then(doc => {
             vscode.window.showTextDocument(doc, vscode.ViewColumn.Active, false);
         });
     }

--- a/samples/sp_whoIsActive/src/sql/blockingSessions.sql
+++ b/samples/sp_whoIsActive/src/sql/blockingSessions.sql
@@ -1,0 +1,4 @@
+SELECT blocking_session_id
+FROM sys.dm_os_waiting_tasks
+WHERE 
+    blocking_session_id IS NOT NULL


### PR DESCRIPTION
- Fix #1231: Extension commands should use a grouping prefix 
- Remove document tab that host's Adam website
- Add documentation task to open SP_Whoisactive documentation link
- Show only TOP 5 data for all charts
- Add Blocking Sessions table in the dashboard

(Still in working progress.)