### PR TITLE
Update Server Reports extension version

### DIFF
--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -64,14 +64,14 @@
 				},
 				"versions": [
 					{
-						"version": "0.1.1",
-						"lastUpdated": "4/24/2018",
+						"version": "0.1.0",
+						"lastUpdated": "1/1/2018",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
 								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.1.1.vsix"
+								"source": "https://sqlopsextensions.blob.core.windows.net/march-extensions/whoisactive/whoisactive-0.1.0.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",
@@ -115,14 +115,14 @@
 				},
 				"versions": [
 					{
-						"version": "0.1.0",
-						"lastUpdated": "1/1/2018",
+						"version": "0.1.1",
+						"lastUpdated": "4/24/2018",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
 								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://sqlopsextensions.blob.core.windows.net/march-extensions/serverreports/server-report-0.1.0.vsix"
+								"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.1.1.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery-insider.json
+++ b/extensionsGallery-insider.json
@@ -64,14 +64,14 @@
 				},
 				"versions": [
 					{
-						"version": "0.1.0",
-						"lastUpdated": "1/1/2018",
+						"version": "0.1.1",
+						"lastUpdated": "4/24/2018",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
 								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://sqlopsextensions.blob.core.windows.net/march-extensions/whoisactive/whoisactive-0.1.0.vsix"
+								"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.1.1.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -13,14 +13,14 @@
 				},
 				"versions": [
 					{
-						"version": "0.1.0",
-						"lastUpdated": "1/1/2018",
+						"version": "0.1.1",
+						"lastUpdated": "4/24/2018",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
 								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://sqlopsextensions.blob.core.windows.net/march-extensions/whoisactive/whoisactive-0.1.0.vsix"
+								"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.1.1.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",

--- a/extensionsGallery.json
+++ b/extensionsGallery.json
@@ -13,14 +13,14 @@
 				},
 				"versions": [
 					{
-						"version": "0.1.1",
-						"lastUpdated": "4/24/2018",
+						"version": "0.1.0",
+						"lastUpdated": "1/1/2018",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
 								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.1.1.vsix"
+								"source": "https://sqlopsextensions.blob.core.windows.net/march-extensions/whoisactive/whoisactive-0.1.0.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",
@@ -64,14 +64,14 @@
 				},
 				"versions": [
 					{
-						"version": "0.1.0",
-						"lastUpdated": "1/1/2018",
+						"version": "0.1.1",
+						"lastUpdated": "4/24/2018",
 						"assetUri": "",
 						"fallbackAssetUri": "fallbackAssetUri",
 							"files": [
 							{
 								"assetType": "Microsoft.VisualStudio.Services.VSIXPackage",
-								"source": "https://sqlopsextensions.blob.core.windows.net/march-extensions/serverreports/server-report-0.1.0.vsix"
+								"source": "https://sqlopsextensions.blob.core.windows.net/extensions/ServerReports/server-report-0.1.1.vsix"
 							},
 							{
 								"assetType": "Microsoft.VisualStudio.Services.Links.Source",


### PR DESCRIPTION
Update Server Reports extensions to version 1.1.  I'll publish the updated extension as part of the April Public Preview release process tonight.