### PR TITLE
Show all available extensions in Extension Manager 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlops",
-  "version": "0.28.6",
+  "version": "0.29.1",
   "distro": "8c3e97e3425cc9814496472ab73e076de2ba99ee",
   "author": {
     "name": "Microsoft Corporation"

--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -435,7 +435,9 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 
 		return this.queryGallery(query).then(({ galleryExtensions, total }) => {
 			const extensions = galleryExtensions.map((e, index) => toExtension(e, this.extensionsGalleryUrl, index, query, options.source));
-			const pageSize = query.pageSize;
+
+			// {{SQL CARBON EDIT}}
+			const pageSize = extensions.length;
 			const getPage = (pageIndex: number) => {
 				const nextPageQuery = query.withPage(pageIndex + 1);
 				return this.queryGallery(nextPageQuery)

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViewlet.ts
@@ -177,7 +177,8 @@ export class ExtensionsViewlet extends PersistentViewsViewlet implements IExtens
 	private createDefaultRecommendedExtensionsListViewDescriptor(): IViewDescriptor {
 		return {
 			id: 'extensions.recommendedList',
-			name: localize('recommendedExtensions', "Recommended"),
+			// {{ SQL CARBON EDIT}}
+			name: localize('recommendedExtensions', "Marketplace"),
 			location: ViewLocation.Extensions,
 			ctor: RecommendedExtensionsView,
 			when: ContextKeyExpr.and(ContextKeyExpr.not('searchExtensions'), ContextKeyExpr.has('defaultRecommendedExtensions')),

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -235,8 +235,8 @@ export class ExtensionsListView extends ViewsViewletPanel {
 		} else if (ExtensionsListView.isRecommendedExtensionsQuery(query.value)) {
 			return this.getRecommendationsModel(query, options);
 		// {{SQL CARBON EDIT}}
-		} else if (ExtensionsListView.isAllUninstalledExtensionsQuery(query.value)) {
-			return this.getAllUninstalledModel(query, options);
+		} else if (ExtensionsListView.isAllMarketplaceExtensionsQuery(query.value)) {
+			return this.getAllMarketplaceModel(query, options);
 		}
 
 		let text = query.value;
@@ -367,7 +367,7 @@ export class ExtensionsListView extends ViewsViewletPanel {
 	}
 
 	// {{SQL CARBON EDIT}}
-	private getAllUninstalledModel(query: Query, options: IQueryOptions): TPromise<IPagedModel<IExtension>> {
+	private getAllMarketplaceModel(query: Query, options: IQueryOptions): TPromise<IPagedModel<IExtension>> {
 		const value = query.value.trim().toLowerCase();
 		return this.extensionsWorkbenchService.queryLocal()
 			.then(result => result.filter(e => e.type === LocalExtensionType.User))
@@ -567,8 +567,8 @@ export class ExtensionsListView extends ViewsViewletPanel {
 	}
 
 	// {{SQL CARBON EDIT}}
-	static isAllUninstalledExtensionsQuery(query: string): boolean {
-		return /@alluninstalled/i.test(query);
+	static isAllMarketplaceExtensionsQuery(query: string): boolean {
+		return /@allmarketplace/i.test(query);
 	}
 }
 
@@ -607,7 +607,7 @@ export class RecommendedExtensionsView extends ExtensionsListView {
 
 	async show(query: string): TPromise<IPagedModel<IExtension>> {
 		// {{SQL CARBON EDIT}}
-		return super.show('@alluninstalled');
+		return super.show('@allmarketplace');
 	}
 }
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -383,10 +383,8 @@ export class ExtensionsListView extends ViewsViewletPanel {
 
 						// sort the marketplace extensions
 						pager.firstPage.sort((a, b) => {
-							let extNameA: string = `${a.publisher}.${a.name}`;
-							let extNameB: string = `${b.publisher}.${b.name}`;
-							let isRecommendedA: boolean = recommmended.indexOf(extNameA) > -1;
-							let isRecommendedB: boolean = recommmended.indexOf(extNameB) > -1;
+							let isRecommendedA: boolean = recommmended.indexOf(`${a.publisher}.${a.name}`) > -1;
+							let isRecommendedB: boolean = recommmended.indexOf(`${b.publisher}.${b.name}`) > -1;
 
 							// sort recommeded extensions before other extensions
 							if (isRecommendedA !== isRecommendedB) {

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionsViews.ts
@@ -234,6 +234,9 @@ export class ExtensionsListView extends ViewsViewletPanel {
 			return this.getAllRecommendationsModel(query, options);
 		} else if (ExtensionsListView.isRecommendedExtensionsQuery(query.value)) {
 			return this.getRecommendationsModel(query, options);
+		// {{SQL CARBON EDIT}}
+		} else if (ExtensionsListView.isAllUninstalledExtensionsQuery(query.value)) {
+			return this.getAllUninstalledModel(query, options);
 		}
 
 		let text = query.value;
@@ -360,6 +363,44 @@ export class ExtensionsListView extends ViewsViewletPanel {
 								return new PagedModel(pager || []);
 							});
 					});
+			});
+	}
+
+	// {{SQL CARBON EDIT}}
+	private getAllUninstalledModel(query: Query, options: IQueryOptions): TPromise<IPagedModel<IExtension>> {
+		const value = query.value.trim().toLowerCase();
+		return this.extensionsWorkbenchService.queryLocal()
+			.then(result => result.filter(e => e.type === LocalExtensionType.User))
+			.then(local => {
+				return this.tipsService.getOtherRecommendations().then((recommmended) => {
+					const installedExtensions = local.map(x => `${x.publisher}.${x.name}`);
+					options = assign(options, { text: value, source: 'searchText' });
+					return TPromise.as(this.extensionsWorkbenchService.queryGallery(options).then((pager) => {
+						// filter out installed extensions
+						pager.firstPage = pager.firstPage.filter((p) => {
+							return installedExtensions.indexOf(`${p.publisher}.${p.name}`) === -1;
+						});
+
+						// sort the marketplace extensions
+						pager.firstPage.sort((a, b) => {
+							let extNameA: string = `${a.publisher}.${a.name}`;
+							let extNameB: string = `${b.publisher}.${b.name}`;
+							let isRecommendedA: boolean = recommmended.indexOf(extNameA) > -1;
+							let isRecommendedB: boolean = recommmended.indexOf(extNameB) > -1;
+
+							// sort recommeded extensions before other extensions
+							if (isRecommendedA !== isRecommendedB) {
+								return (isRecommendedA && !isRecommendedB) ? -1 : 1;
+							}
+
+							// otherwise sort by name
+							return a.displayName.toLowerCase() < b.displayName.toLowerCase() ? -1 : 1;
+						});
+						pager.total = pager.firstPage.length;
+						pager.pageSize = pager.firstPage.length;
+						return new PagedModel(pager || []);
+					}));
+				});
 			});
 	}
 
@@ -524,6 +565,11 @@ export class ExtensionsListView extends ViewsViewletPanel {
 	static isKeymapsRecommendedExtensionsQuery(query: string): boolean {
 		return /@recommended:keymaps/i.test(query);
 	}
+
+	// {{SQL CARBON EDIT}}
+	static isAllUninstalledExtensionsQuery(query: string): boolean {
+		return /@alluninstalled/i.test(query);
+	}
 }
 
 export class InstalledExtensionsView extends ExtensionsListView {
@@ -560,7 +606,8 @@ export class BuiltInExtensionsView extends ExtensionsListView {
 export class RecommendedExtensionsView extends ExtensionsListView {
 
 	async show(query: string): TPromise<IPagedModel<IExtension>> {
-		return super.show(!query.trim() ? '@recommended:all' : '@recommended');
+		// {{SQL CARBON EDIT}}
+		return super.show('@alluninstalled');
 	}
 }
 


### PR DESCRIPTION
Show all available extensions in the default Extension Manager view.  Recommended extensions will be sorted above other extensions in the "Marketplace" section.  We can review this design later once we have a enough extensions that the list is difficult to work with (~50?).

Fixes https://github.com/Microsoft/sqlopsstudio/issues/1166.

![screen](https://user-images.githubusercontent.com/599935/39291856-28f339a2-48e9-11e8-90a3-e79f0bd02c1d.png)
