### PR TITLE
added libunwind8 to Debian dependencies

### DIFF
--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -1,7 +1,7 @@
 Package: @@NAME@@
 Version: @@VERSION@@
 Section: devel
-Depends: libnotify4, libnss3, gnupg, apt, libxkbfile1, libgconf-2-4, libsecret-1-0
+Depends: libnotify4, libnss3, gnupg, apt, libxkbfile1, libgconf-2-4, libsecret-1-0, libuwind8
 Priority: optional
 Architecture: @@ARCHITECTURE@@
 Maintainer: Microsoft Corporation

--- a/resources/linux/debian/control.template
+++ b/resources/linux/debian/control.template
@@ -1,7 +1,7 @@
 Package: @@NAME@@
 Version: @@VERSION@@
 Section: devel
-Depends: libnotify4, libnss3, gnupg, apt, libxkbfile1, libgconf-2-4, libsecret-1-0, libuwind8
+Depends: libnotify4, libnss3, gnupg, apt, libxkbfile1, libgconf-2-4, libsecret-1-0, libunwind8
 Priority: optional
 Architecture: @@ARCHITECTURE@@
 Maintainer: Microsoft Corporation


### PR DESCRIPTION
fixes #821

After installing .deb without my change I didn't see any specific issue. is this package required for making connection?  Anyway I added the package as one of the dependencies.
When I run the .deb in Debian, I see this warning now: 
_dependency problem prevent configuration of sqlops. sqlops depends on libunwind8"_

So running dpks -i doesn't install the dependencies.
Running the following command installed the dependencies and sqlops successfully: sudo apt-get -f install

Is that the correct behavior?  
