### PR TITLE
Pick up Electron 1.7.12

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "1.7.11"
+target "1.7.12"
 runtime "electron"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "1.7.13"
+target "1.7.12"
 runtime "electron"

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,3 +1,3 @@
 disturl "https://atom.io/download/electron"
-target "1.7.12"
+target "1.7.13"
 runtime "electron"


### PR DESCRIPTION
~~VS Code already updated to 1.7.12 in `master`.  We might as well pick this up since we may not merge their code again for another month or so.~~

I noticed 1.7.13 is already out so might as go to that version.  The delta with 1.7.12 looks minimal.