### PR TITLE
Fix app name in Report Issue dialog

### DIFF
--- a/src/vs/code/electron-browser/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterMain.ts
@@ -462,11 +462,12 @@ export class IssueReporter extends Disposable {
 			response.json().then(result => {
 				this.clearSearchResults();
 
-				if (result && result.candidates) {
-					this.displaySearchResults(result.candidates);
-				} else {
-					throw new Error('Unexpected response, no candidates property');
-				}
+				// {{SQL CARBON EDIT}}
+				// if (result && result.candidates) {
+				// 	this.displaySearchResults(result.candidates);
+				// } else {
+				// 	throw new Error('Unexpected response, no candidates property');
+				// }
 			}).catch((error) => {
 				this.logSearchError(error);
 			});

--- a/src/vs/code/electron-browser/issue/issueReporterModel.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterModel.ts
@@ -59,13 +59,14 @@ export class IssueReporterModel {
 		assign(this._data, newData);
 	}
 
+	// {{SQL CARBON EDIT}}
 	serialize(): string {
 		return `
 Issue Type: <b>${this.getIssueTypeTitle()}</b>
 
 ${this._data.issueDescription}
 
-VS Code version: ${this._data.versionInfo && this._data.versionInfo.vscodeVersion}
+SQL Operations Studio version: ${this._data.versionInfo && this._data.versionInfo.vscodeVersion}
 OS version: ${this._data.versionInfo && this._data.versionInfo.os}
 
 ${this.getInfos()}

--- a/src/vs/code/electron-browser/issue/test/testReporterModel.test.ts
+++ b/src/vs/code/electron-browser/issue/test/testReporterModel.test.ts
@@ -23,6 +23,7 @@ suite('IssueReporter', () => {
 		});
 	});
 
+	// {{SQL CARBON EDIT}}
 	test('serializes model skeleton when no data is provided', () => {
 		const issueReporterModel = new IssueReporterModel();
 		assert.equal(issueReporterModel.serialize(),
@@ -31,7 +32,7 @@ Issue Type: <b>Feature Request</b>
 
 undefined
 
-VS Code version: undefined
+SQL Operations Studio version: undefined
 OS version: undefined
 
 


### PR DESCRIPTION
This fixes the app name in the `Report Issue` dialog to `SQL Operations Studio`.  It also removes the suggested duplicate issues section since the web service is returning VS Code issues.

The string updated is shown below.

![screen shot 2018-04-27 at 10 36 17 pm](https://user-images.githubusercontent.com/599935/39392490-8db32478-4a6b-11e8-9373-0b43adf94565.png)
