### PR TITLE
Open inactive editors as sql editors when needed

### DIFF
--- a/src/vs/workbench/common/editor/editorStacksModel.ts
+++ b/src/vs/workbench/common/editor/editorStacksModel.ts
@@ -225,6 +225,10 @@ export class EditorGroup implements IEditorGroup {
 	}
 
 	public openEditor(editor: EditorInput, options?: IEditorOpenOptions): void {
+		// {{SQL CARBON EDIT}}
+		// Convert input into custom type if it's one of the ones we support
+		editor = CustomInputConverter.convertEditorInput(editor, options, this.instantiationService);
+
 		const index = this.indexOf(editor);
 
 		const makePinned = options && options.pinned;


### PR DESCRIPTION
See #1175 for issue details

This fixes the issue where SQL editors show doubled tabs when you open multiple files. The code path for opening the active editor properly opened a `QueryInput` editor, but the path to open inactive editors did not. 