### PR TITLE
Remove all ID fields from telemetry

### DIFF
--- a/src/vs/platform/telemetry/node/appInsightsAppender.ts
+++ b/src/vs/platform/telemetry/node/appInsightsAppender.ts
@@ -36,12 +36,6 @@ function getClient(aiKey: string): typeof appInsights.client {
 	// clear all ID fields from telemetry
 	client.context.tags[client.context.keys.deviceMachineName] = '';
 	client.context.tags[client.context.keys.cloudRoleInstance] = '';
-	client.context.tags['common.machineId'] = '';
-	client.context.tags['sessionID'] = '';
-	client.context.tags['common.instanceId'] = '';
-	client.context.tags['common.userId'] = '';
-	client.context.tags['common.firstSessionDate'] = '';
-	client.context.tags['common.lastSessionDate'] = '';
 
 	// set envelope flags to suppress Vortex ingest header
 	client.addTelemetryProcessor((envelope, contextObjects) => {

--- a/src/vs/platform/telemetry/node/appInsightsAppender.ts
+++ b/src/vs/platform/telemetry/node/appInsightsAppender.ts
@@ -33,8 +33,15 @@ function getClient(aiKey: string): typeof appInsights.client {
 	client.channel.setOfflineMode(true);
 
 	// {{SQL CARBON EDIT}}
-	client.context.tags[client.context.keys.deviceMachineName] = ''; //prevent App Insights from reporting machine name
-	client.context.tags[client.context.keys.cloudRoleInstance] = ''; //prevent App Insights from reporting machine name
+	// clear all ID fields from telemetry
+	client.context.tags[client.context.keys.deviceMachineName] = '';
+	client.context.tags[client.context.keys.cloudRoleInstance] = '';
+	client.context.tags['common.machineId'] = '';
+	client.context.tags['sessionID'] = '';
+	client.context.tags['common.instanceId'] = '';
+	client.context.tags['common.userId'] = '';
+	client.context.tags['common.firstSessionDate'] = '';
+	client.context.tags['common.lastSessionDate'] = '';
 
 	// set envelope flags to suppress Vortex ingest header
 	client.addTelemetryProcessor((envelope, contextObjects) => {

--- a/src/vs/platform/telemetry/node/commonProperties.ts
+++ b/src/vs/platform/telemetry/node/commonProperties.ts
@@ -14,10 +14,15 @@ import product from 'vs/platform/node/product';
 
 export function resolveCommonProperties(commit: string, version: string, machineId: string, installSourcePath: string): TPromise<{ [name: string]: string; }> {
 	const result: { [name: string]: string; } = Object.create(null);
+
+	// {{SQL CARBON EDIT}}
 	// __GDPR__COMMON__ "common.machineId" : { "endPoint": "MacAddressHash", "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
-	result['common.machineId'] = machineId;
-	// __GDPR__COMMON__ "sessionID" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-	result['sessionID'] = uuid.generateUuid() + Date.now();
+	// result['common.machineId'] = machineId;
+	result['common.machineId'] = '';
+	// // __GDPR__COMMON__ "sessionID" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+	// result['sessionID'] = uuid.generateUuid() + Date.now();
+	result['sessionID'] = '';
+
 	// __GDPR__COMMON__ "commitHash" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['commitHash'] = commit;
 	// __GDPR__COMMON__ "version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
@@ -32,7 +37,7 @@ export function resolveCommonProperties(commit: string, version: string, machine
 	result['common.nodePlatform'] = process.platform;
 	// __GDPR__COMMON__ "common.nodeArch" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['common.nodeArch'] = process.arch;
-	
+
 	// {{SQL CARBON EDIT}}
 	result['common.application.name'] = product.nameLong;
 

--- a/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
@@ -20,6 +20,8 @@ export function resolveWorkbenchCommonProperties(storageService: IStorageService
 		result['common.version.renderer'] = process.versions && (<any>process).versions['chrome'];
 		// {{SQL CARBON EDIT}}
 		result['common.application.name'] = product.nameLong;
+		// {{SQL CARBON EDIT}}
+		result['common.userId'] = '';
 
 		// {{SQL CARBON EDIT}}
 		// const lastSessionDate = storageService.get('telemetry.lastSessionDate');

--- a/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
@@ -34,16 +34,18 @@ export function resolveWorkbenchCommonProperties(storageService: IStorageService
 		// // __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 		// result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
 
+		// {{SQL CARBON EDIT}}
 		// __GDPR__COMMON__ "common.instanceId" : { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
 		// result['common.instanceId'] = getOrCreateInstanceId(storageService);
+		result['common.instanceId'] = '';
 
 		return result;
 	});
 }
 
-function getOrCreateInstanceId(storageService: IStorageService): string {
-	const result = storageService.get('telemetry.instanceId') || uuid.generateUuid();
-	storageService.store('telemetry.instanceId', result);
-
-	return result;
-}
+// {{SQL CARBON EDIT}}
+// function getOrCreateInstanceId(storageService: IStorageService): string {
+// 	const result = storageService.get('telemetry.instanceId') || uuid.generateUuid();
+// 	storageService.store('telemetry.instanceId', result);
+// 	return result;
+// }

--- a/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
+++ b/src/vs/platform/telemetry/node/workbenchCommonProperties.ts
@@ -20,21 +20,22 @@ export function resolveWorkbenchCommonProperties(storageService: IStorageService
 		result['common.version.renderer'] = process.versions && (<any>process).versions['chrome'];
 		// {{SQL CARBON EDIT}}
 		result['common.application.name'] = product.nameLong;
-		getUserId(storageService).then(value => result['common.userId'] = value);
 
-		const lastSessionDate = storageService.get('telemetry.lastSessionDate');
-		const firstSessionDate = storageService.get('telemetry.firstSessionDate') || new Date().toUTCString();
-		storageService.store('telemetry.firstSessionDate', firstSessionDate);
-		storageService.store('telemetry.lastSessionDate', new Date().toUTCString());
+		// {{SQL CARBON EDIT}}
+		// const lastSessionDate = storageService.get('telemetry.lastSessionDate');
+		// const firstSessionDate = storageService.get('telemetry.firstSessionDate') || new Date().toUTCString();
+		// storageService.store('telemetry.firstSessionDate', firstSessionDate);
+		// storageService.store('telemetry.lastSessionDate', new Date().toUTCString());
 
-		// __GDPR__COMMON__ "common.firstSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-		result['common.firstSessionDate'] = firstSessionDate;
-		// __GDPR__COMMON__ "common.lastSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-		result['common.lastSessionDate'] = lastSessionDate;
-		// __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
-		result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
+		// // __GDPR__COMMON__ "common.firstSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		// result['common.firstSessionDate'] = firstSessionDate;
+		// // __GDPR__COMMON__ "common.lastSessionDate" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		// result['common.lastSessionDate'] = lastSessionDate;
+		// // __GDPR__COMMON__ "common.isNewSession" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+		// result['common.isNewSession'] = !lastSessionDate ? '1' : '0';
+
 		// __GDPR__COMMON__ "common.instanceId" : { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
-		result['common.instanceId'] = getOrCreateInstanceId(storageService);
+		// result['common.instanceId'] = getOrCreateInstanceId(storageService);
 
 		return result;
 	});
@@ -45,23 +46,4 @@ function getOrCreateInstanceId(storageService: IStorageService): string {
 	storageService.store('telemetry.instanceId', result);
 
 	return result;
-}
-// {{SQL CARBON EDIT}}
-// Get the unique ID for the current user
-function getUserId(storageService: IStorageService): Promise<string> {
-	var userId = storageService.get('common.userId');
-	return new Promise<string>(resolve => {
-		// Generate the user id if it has not been created already
-		if (typeof userId === 'undefined') {
-			let id = Utils.generateUserId();
-			id.then( newId => {
-				userId = newId;
-				resolve(userId);
-				//store the user Id in the storage service
-				storageService.store('common.userId', userId);
-			});
-		} else {
-			resolve(userId);
-		}
-	});
 }

--- a/src/vs/platform/telemetry/test/electron-browser/commonProperties.test.ts
+++ b/src/vs/platform/telemetry/test/electron-browser/commonProperties.test.ts
@@ -32,58 +32,59 @@ suite('Telemetry - common properties', function () {
 		del(parentDir, os.tmpdir(), done);
 	});
 
-	test('default', function () {
-		return mkdirp(parentDir).then(() => {
-			fs.writeFileSync(installSource, 'my.install.source');
+	// {{SQL CARBON EDIT}}
+	// test('default', function () {
+	// 	return mkdirp(parentDir).then(() => {
+	// 		fs.writeFileSync(installSource, 'my.install.source');
 
-			return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {
-				assert.ok('commitHash' in props);
-				assert.ok('sessionID' in props);
-				assert.ok('timestamp' in props);
-				assert.ok('common.platform' in props);
-				assert.ok('common.nodePlatform' in props);
-				assert.ok('common.nodeArch' in props);
-				assert.ok('common.timesincesessionstart' in props);
-				assert.ok('common.sequence' in props);
+	// 		return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {
+	// 			assert.ok('commitHash' in props);
+	// 			assert.ok('sessionID' in props);
+	// 			assert.ok('timestamp' in props);
+	// 			assert.ok('common.platform' in props);
+	// 			assert.ok('common.nodePlatform' in props);
+	// 			assert.ok('common.nodeArch' in props);
+	// 			assert.ok('common.timesincesessionstart' in props);
+	// 			assert.ok('common.sequence' in props);
 
-				// assert.ok('common.version.shell' in first.data); // only when running on electron
-				// assert.ok('common.version.renderer' in first.data);
-				assert.ok('common.osVersion' in props, 'osVersion');
-				assert.ok('common.platformVersion' in props, 'platformVersion');
-				assert.ok('version' in props);
-				assert.equal(props['common.source'], 'my.install.source');
+	// 			// assert.ok('common.version.shell' in first.data); // only when running on electron
+	// 			// assert.ok('common.version.renderer' in first.data);
+	// 			assert.ok('common.osVersion' in props, 'osVersion');
+	// 			assert.ok('common.platformVersion' in props, 'platformVersion');
+	// 			assert.ok('version' in props);
+	// 			assert.equal(props['common.source'], 'my.install.source');
 
-			// {{SQL CARBON EDIT}}
-			assert.ok('common.application.name' in props);
+	// 		// {{SQL CARBON EDIT}}
+	// 		assert.ok('common.application.name' in props);
 
-				assert.ok('common.firstSessionDate' in props, 'firstSessionDate');
-				assert.ok('common.lastSessionDate' in props, 'lastSessionDate'); // conditional, see below, 'lastSessionDate'ow
-				assert.ok('common.isNewSession' in props, 'isNewSession');
+	// 			assert.ok('common.firstSessionDate' in props, 'firstSessionDate');
+	// 			assert.ok('common.lastSessionDate' in props, 'lastSessionDate'); // conditional, see below, 'lastSessionDate'ow
+	// 			assert.ok('common.isNewSession' in props, 'isNewSession');
 
-				// machine id et al
-				assert.ok('common.instanceId' in props, 'instanceId');
-				assert.ok('common.machineId' in props, 'machineId');
+	// 			// machine id et al
+	// 			assert.ok('common.instanceId' in props, 'instanceId');
+	// 			assert.ok('common.machineId' in props, 'machineId');
 
-				fs.unlinkSync(installSource);
+	// 			fs.unlinkSync(installSource);
 
-				return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {
-					assert.ok(!('common.source' in props));
-				});
-			});
-		});
-	});
+	// 			return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {
+	// 				assert.ok(!('common.source' in props));
+	// 			});
+	// 		});
+	// 	});
+	// });
 
-	test('lastSessionDate when aviablale', function () {
+	// test('lastSessionDate when aviablale', function () {
 
-		storageService.store('telemetry.lastSessionDate', new Date().toUTCString());
+	// 	storageService.store('telemetry.lastSessionDate', new Date().toUTCString());
 
-		return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {
+	// 	return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {
 
-			assert.ok('common.lastSessionDate' in props); // conditional, see below
-			assert.ok('common.isNewSession' in props);
-			assert.equal(props['common.isNewSession'], 0);
-		});
-	});
+	// 		assert.ok('common.lastSessionDate' in props); // conditional, see below
+	// 		assert.ok('common.isNewSession' in props);
+	// 		assert.equal(props['common.isNewSession'], 0);
+	// 	});
+	// });
 
 	test('values chance on ask', function () {
 		return resolveWorkbenchCommonProperties(storageService, commit, version, 'someMachineId', installSource).then(props => {


### PR DESCRIPTION
Remove all user, machine, instance, etc. ID fields from the telemetry to ensure data is "transient" under GDPR compliance guidelines.