### PR TITLE
Trim server name

### DIFF
--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -109,6 +109,8 @@ export class ConnectionDialogService implements IConnectionDialogService {
 				}
 				profile = result.connection;
 
+				profile.serverName = trim(profile.serverName);
+
 				// append the port to the server name for SQL Server connections
 				if (this.getCurrentProviderName() === Constants.mssqlProviderName) {
 					let portPropertyName: string = 'port';
@@ -126,6 +128,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 
 				this.handleDefaultOnConnect(params, profile);
 			} else {
+				profile.serverName = trim(profile.serverName);
 				this._connectionManagementService.addSavedPassword(profile).then(connectionWithPassword => {
 					this.handleDefaultOnConnect(params, connectionWithPassword);
 				});
@@ -152,7 +155,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	}
 
 	private handleDefaultOnConnect(params: INewConnectionParams, connection: IConnectionProfile): Thenable<void> {
-		connection.serverName = trim(connection.serverName);
 		let fromEditor = params && params.connectionType === ConnectionType.editor;
 		let uri: string = undefined;
 		if (fromEditor && params.input) {

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -17,6 +17,7 @@ import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
 import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile';
 import { localize } from 'vs/nls';
+import { entries } from 'sql/base/common/objects';
 
 import * as sqlops from 'sqlops';
 
@@ -32,7 +33,7 @@ import { IWindowsService } from 'vs/platform/windows/common/windows';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import * as types from 'vs/base/common/types';
-import { entries } from 'sql/base/common/objects';
+import { trim } from 'vs/base/common/strings';
 
 export interface IConnectionValidateResult {
 	isValid: boolean;
@@ -107,6 +108,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 					return;
 				}
 				profile = result.connection;
+				profile.serverName = trim(profile.serverName);
 
 				// append the port to the server name for SQL Server connections
 				if (this.getCurrentProviderName() === Constants.mssqlProviderName) {

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -108,7 +108,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 					return;
 				}
 				profile = result.connection;
-				profile.serverName = trim(profile.serverName);
 
 				// append the port to the server name for SQL Server connections
 				if (this.getCurrentProviderName() === Constants.mssqlProviderName) {
@@ -153,6 +152,7 @@ export class ConnectionDialogService implements IConnectionDialogService {
 	}
 
 	private handleDefaultOnConnect(params: INewConnectionParams, connection: IConnectionProfile): Thenable<void> {
+		connection.serverName = trim(connection.serverName);
 		let fromEditor = params && params.connectionType === ConnectionType.editor;
 		let uri: string = undefined;
 		if (fromEditor && params.input) {

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -358,7 +358,8 @@ export class InputBox extends Widget {
 			}
 		}
 
-		return !result;
+		// {{SQL CARBON EDIT}} Canidate for addition to vscode
+		return result ? result.type !== MessageType.ERROR : true;
 	}
 
 	private stylesForType(type: MessageType): { border: Color; background: Color } {


### PR DESCRIPTION
- trims the server name from the connection dialog before making the connection
- warns the user that the server name will be trimmed
- modifies vscode's input box to not fail validation on warnings (makes sense to me)

fixes #790

![image](https://user-images.githubusercontent.com/4324725/39493020-3edeb258-4d46-11e8-9f18-7a58a077ce81.png)
![image](https://user-images.githubusercontent.com/4324725/39493038-470d6a3c-4d46-11e8-9cec-294ac439b23e.png)

