### PR TITLE
Combine query messages to reduce rendering time when possible

### DIFF
--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -131,6 +131,7 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 	private messages: IMessage[] = [];
 	private messageStore: IMessage[] = [];
 	private messageTimeout: number;
+	private lastMessageHandleTime: number = 0;
 	private scrollTimeOut: number;
 	private resizing = false;
 	private resizeHandleTop: string = '0';
@@ -248,13 +249,28 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 
 	handleMessage(self: QueryComponent, event: any): void {
 		self.messageStore.push(event.data);
-		clearTimeout(self.messageTimeout);
+		// Ensure that messages are updated at least every 10 seconds during long-running queries
+		if (self.messageTimeout !== undefined && Date.now() - self.lastMessageHandleTime < 10000) {
+			clearTimeout(self.messageTimeout);
+		} else {
+			self.lastMessageHandleTime = Date.now();
+		}
 		self.messageTimeout = setTimeout(() => {
-			self.messages = self.messages.concat(self.messageStore);
-			self.messageStore = [];
+			while (self.messageStore.length > 0) {
+				let lastMessage = self.messages.length > 0 ? self.messages[self.messages.length - 1] : undefined;
+				let nextMessage = self.messageStore[0];
+				// If the next message has the same metadata as the previous one, just append its text to avoid rendering an entirely new message
+				if (lastMessage !== undefined && lastMessage.batchId === nextMessage.batchId && lastMessage.isError === nextMessage.isError
+					&& lastMessage.link === nextMessage.link && lastMessage.link === undefined) {
+					lastMessage.message += '\n' + nextMessage.message;
+				} else {
+					self.messages.push(nextMessage);
+				}
+				self.messageStore = self.messageStore.slice(1);
+			}
 			self._cd.detectChanges();
 			self.scrollMessages();
-		}, 10);
+		}, 100);
 	}
 
 	handleResultSet(self: QueryComponent, event: any): void {


### PR DESCRIPTION
The performance issue in #645 happens because when we run queries that produce lots of messages we build a DOM element for every single message. This makes performance better by combining incoming messages with previous messages if the messages' metadata is the same.

I've seen the spacing issue in #645 before but I can't reproduce it right now so I'll keep looking into it. We're still probably 100x or 1000x slower than SSMS on the user's query. The query is slow now because of our IPC calls instead of DOM rendering, but it doesn't freeze the whole app at least.

Going forward we might also want to look into coming up with a way to only render visible messages/result elements too