### PR TITLE
Close insights dialog properly when escape is pressed

### DIFF
--- a/src/sql/parts/insights/browser/insightsDialogView.ts
+++ b/src/sql/parts/insights/browser/insightsDialogView.ts
@@ -332,6 +332,10 @@ export class InsightsDialogView extends Modal {
 		this._taskButtonDisposables = [];
 	}
 
+	protected onClose(e: StandardKeyboardEvent) {
+		this.close();
+	}
+
 	private hasActions(): boolean {
 		return !!(this._insight && this._insight.actions && this._insight.actions.types
 			&& this._insight.actions.types.length > 0);


### PR DESCRIPTION
Fixes #1311 by calling close on insights dialogs when the escape button is pressed instead of just calling hide (the default behavior)