### PR TITLE
Fix a null ref exception in dashboard layout

### DIFF
--- a/src/sql/parts/dashboard/containers/dashboardHomeContainer.component.ts
+++ b/src/sql/parts/dashboard/containers/dashboardHomeContainer.component.ts
@@ -63,6 +63,8 @@ export class DashboardHomeContainer extends DashboardWidgetContainer {
 
 	public layout() {
 		super.layout();
-		this._scrollable.layout();
+		if (this._scrollable) {
+			this._scrollable.layout();
+		}
 	}
 }


### PR DESCRIPTION
I'm hitting the below exception in some cases, so adding a null check around the layout call.

```
/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules/zone.js/dist/zone-node.js:388 ERROR TypeError: Cannot read property 'layout' of undefined
    at DashboardHomeContainer.layout (file:///Applications/SQL Operations Studio.app/Contents/Resources/app/out/vs/workbench/workbench.main.js:224389:29)
    at DatabaseDashboardPage.DashboardPage.handleTabChange (file:///Applications/SQL Operations Studio.app/Contents/Resources/app/out/vs/workbench/workbench.main.js:170490:22)
    at Object.eval [as handleEvent] (ng:///DashboardModule/DatabaseDashboardPage.ngfactory.js:397:24)
    at Object.handleEvent (/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/@angular/core/bundles/core.umd.js:11921:138)
    at Object.handleEvent (/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/@angular/core/bundles/core.umd.js:12624:85)
    at dispatchEvent (/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/@angular/core/bundles/core.umd.js:8821:21)
    at /Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/@angular/core/bundles/core.umd.js:10749:20
    at SafeSubscriber.schedulerFn [as _next] (/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/@angular/core/bundles/core.umd.js:3870:36)
    at SafeSubscriber.__tryOrUnsub (/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/rxjs/Subscriber.js:238:16)
    at SafeSubscriber.next (/Applications/SQL Operations Studio.app/Contents/Resources/app/node_modules.asar/rxjs/Subscriber.js:185:22)
```