### PR TITLE
Fire done/cancel click events when dialog is closed

### DIFF
--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -29,9 +29,6 @@ export class DialogModal extends Modal {
 	private _onDone = new Emitter<void>();
 	private _onCancel = new Emitter<void>();
 
-	// Wizard HTML elements
-	private _body: HTMLElement;
-
 	// Buttons
 	private _cancelButton: Button;
 	private _doneButton: Button;
@@ -97,12 +94,13 @@ export class DialogModal extends Modal {
 	}
 
 	protected renderBody(container: HTMLElement): void {
+		let body: HTMLElement;
 		new Builder(container).div({ class: 'dialogModal-body' }, (bodyBuilder) => {
-			this._body = bodyBuilder.getHTMLElement();
+			body = bodyBuilder.getHTMLElement();
 		});
 
 		this._dialogPane = new DialogPane(this._dialog, this._bootstrapService);
-		this._dialogPane.createBody(this._body);
+		this._dialogPane.createBody(body);
 	}
 
 	public open(): void {

--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -26,6 +26,8 @@ import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 
 export class DialogModal extends Modal {
 	private _dialogPane: DialogPane;
+	private _onDone = new Emitter<void>();
+	private _onCancel = new Emitter<void>();
 
 	// Wizard HTML elements
 	private _body: HTMLElement;
@@ -67,16 +69,20 @@ export class DialogModal extends Modal {
 			});
 		}
 
-		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel());
+		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel(), false);
 		this.updateButtonElement(this._cancelButton, this._dialog.cancelButton);
-		this._doneButton = this.addDialogButton(this._dialog.okButton, () => this.done());
+		this._dialog.cancelButton.registerClickEvent(this._onCancel.event);
+		this._doneButton = this.addDialogButton(this._dialog.okButton, () => this.done(), false);
 		this.updateButtonElement(this._doneButton, this._dialog.okButton);
+		this._dialog.okButton.registerClickEvent(this._onDone.event);
 	}
 
-	private addDialogButton(button: DialogButton, onSelect: () => void = () => undefined): Button {
+	private addDialogButton(button: DialogButton, onSelect: () => void = () => undefined, registerClickEvent: boolean = true): Button {
 		let buttonElement = this.addFooterButton(button.label, onSelect);
 		buttonElement.enabled = button.enabled;
-		button.registerClickEvent(buttonElement.onDidClick);
+		if (registerClickEvent) {
+			button.registerClickEvent(buttonElement.onDidClick);
+		}
 		button.onUpdate(() => {
 			this.updateButtonElement(buttonElement, button);
 		});
@@ -105,12 +111,14 @@ export class DialogModal extends Modal {
 
 	public done(): void {
 		if (this._dialog.okButton.enabled) {
+			this._onDone.fire();
 			this.dispose();
 			this.hide();
 		}
 	}
 
 	public cancel(): void {
+		this._onCancel.fire();
 		this.dispose();
 		this.hide();
 	}


### PR DESCRIPTION
The dialog API uses the dialog ok and cancel button click events to notify extension authors when the dialog has been completed or canceled, but these only fired when the buttons were actually clicked with the mouse instead of when the dialog was closed by hitting enter or escape.

Now any way of canceling or completing the dialog will cause the button events to fire