### PR TITLE
Add grid.viewAsChart and grid.goToNextGrid keyboard shortcuts for editor 

### DIFF
--- a/src/sql/parts/grid/common/gridContentEvents.ts
+++ b/src/sql/parts/grid/common/gridContentEvents.ts
@@ -17,4 +17,6 @@ export let SelectAllMessages = 'SelectAllMessages';
 export let SaveAsCsv = 'SaveAsCSV';
 export let SaveAsJSON = 'SaveAsJSON';
 export let SaveAsExcel = 'SaveAsExcel';
+export let ViewAsChart = 'ViewAsChart';
 export let GoToNextQueryOutputTab = 'GoToNextQueryOutputTab';
+export let GoToNextGrid = 'GoToNextGrid';

--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -22,7 +22,6 @@ import { GridParentComponent } from 'sql/parts/grid/views/gridParentComponent';
 import { EditDataGridActionProvider } from 'sql/parts/grid/views/editData/editDataGridActions';
 import { error } from 'sql/base/common/log';
 import { clone } from 'sql/base/common/objects';
-import * as GridContentEvents from 'sql/parts/grid/common/gridContentEvents';
 
 export const EDITDATA_SELECTOR: string = 'editdata-component';
 
@@ -111,18 +110,11 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			self._cd.detectChanges();
 		});
 
-		this.subscribeWithDispose(this.dataService.gridContentObserver, (type) => {
-			switch (type) {
-				case GridContentEvents.RefreshContents:
-					self.refreshResultsets();
-					break;
-				case GridContentEvents.ResizeContents:
-					self.resizeGrids();
-					break;
-			}
-		});
-
 		this.dataService.onAngularLoaded();
+	}
+
+	protected initShortcuts(shortcuts: { [name: string]: Function }): void {
+		// TODO add any Edit Data-specific shortcuts here
 	}
 
 	public ngOnDestroy(): void {

--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -22,6 +22,7 @@ import { GridParentComponent } from 'sql/parts/grid/views/gridParentComponent';
 import { EditDataGridActionProvider } from 'sql/parts/grid/views/editData/editDataGridActions';
 import { error } from 'sql/base/common/log';
 import { clone } from 'sql/base/common/objects';
+import * as GridContentEvents from 'sql/parts/grid/common/gridContentEvents';
 
 export const EDITDATA_SELECTOR: string = 'editdata-component';
 
@@ -110,11 +111,18 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			self._cd.detectChanges();
 		});
 
-		this.dataService.onAngularLoaded();
-	}
+		this.subscribeWithDispose(this.dataService.gridContentObserver, (type) => {
+			switch (type) {
+				case GridContentEvents.RefreshContents:
+					self.refreshResultsets();
+					break;
+				case GridContentEvents.ResizeContents:
+					self.resizeGrids();
+					break;
+			}
+		});
 
-	protected initShortcuts(shortcuts: { [name: string]: Function }): void {
-		// TODO add any Edit Data-specific shortcuts here
+		this.dataService.onAngularLoaded();
 	}
 
 	public ngOnDestroy(): void {

--- a/src/sql/parts/grid/views/gridActions.ts
+++ b/src/sql/parts/grid/views/gridActions.ts
@@ -25,7 +25,8 @@ export const MESSAGES_COPY_ID = 'grid.messages.copy';
 export const TOGGLERESULTS_ID = 'grid.toggleResultPane';
 export const TOGGLEMESSAGES_ID = 'grid.toggleMessagePane';
 export const GOTONEXTQUERYOUTPUTTAB_ID = 'query.goToNextQueryOutputTab';
-
+export const GRID_VIEWASCHART_ID = 'grid.viewAsChart';
+export const GRID_GOTONEXTGRID_ID = 'grid.goToNextGrid';
 
 export class GridActionProvider {
 

--- a/src/sql/parts/grid/views/gridCommands.ts
+++ b/src/sql/parts/grid/views/gridCommands.ts
@@ -77,4 +77,11 @@ export const selectAllMessages = (accessor: ServicesAccessor) => {
 	runActionOnActiveResultsEditor(accessor, GridContentEvents.SelectAllMessages);
 };
 
+export const viewAsChart = (accessor: ServicesAccessor) => {
+	runActionOnActiveResultsEditor(accessor, GridContentEvents.ViewAsChart);
+};
+
+export const goToNextGrid = (accessor: ServicesAccessor) => {
+	runActionOnActiveResultsEditor(accessor, GridContentEvents.GoToNextGrid);
+};
 

--- a/src/sql/parts/grid/views/gridParentComponent.ts
+++ b/src/sql/parts/grid/views/gridParentComponent.ts
@@ -168,6 +168,12 @@ export abstract class GridParentComponent {
 				case GridContentEvents.GoToNextQueryOutputTab:
 					self.goToNextQueryOutputTab();
 					break;
+				case GridContentEvents.ViewAsChart:
+					self.showChartForGrid(self.activeGrid);
+					break;
+				case GridContentEvents.GoToNextGrid:
+					self.goToNextGrid();
+					break;
 				default:
 					error('Unexpected grid content event type "' + type + '" sent');
 					break;
@@ -276,6 +282,22 @@ export abstract class GridParentComponent {
 	}
 
 	protected goToNextQueryOutputTab(): void {
+	}
+
+	protected showChartForGrid(index: number) {
+	}
+
+	protected goToNextGrid() {
+		if (this.renderedDataSets.length > 0) {
+			let next  = this.activeGrid + 1;
+			if (next >= this.renderedDataSets.length) {
+				next = 0;
+			}
+			this.navigateToGrid(next);
+		}
+	}
+
+	protected navigateToGrid(index: number) {
 	}
 
 	private initShortcutsBase(): void {

--- a/src/sql/parts/grid/views/gridParentComponent.ts
+++ b/src/sql/parts/grid/views/gridParentComponent.ts
@@ -22,7 +22,6 @@ import * as Utils from 'sql/parts/connection/common/utils';
 import { DataService } from 'sql/parts/grid/services/dataService';
 import * as actions from 'sql/parts/grid/views/gridActions';
 import * as Services from 'sql/parts/grid/services/sharedServices';
-import * as GridContentEvents from 'sql/parts/grid/common/gridContentEvents';
 import { ResultsVisibleContext, ResultsGridFocussedContext, ResultsMessagesFocussedContext, QueryEditorVisibleContext } from 'sql/parts/query/common/queryContext';
 import { IBootstrapService } from 'sql/services/bootstrap/bootstrapService';
 import { error } from 'sql/base/common/log';
@@ -120,69 +119,14 @@ export abstract class GridParentComponent {
 
 	protected baseInit(): void {
 		const self = this;
-		this.initShortcutsBase();
 		if (this._bootstrapService.configurationService) {
 			let sqlConfig = this._bootstrapService.configurationService.getValue('sql');
 			if (sqlConfig) {
 				this._messageActive = sqlConfig['messagesDefaultOpen'];
 			}
 		}
-		this.subscribeWithDispose(this.dataService.gridContentObserver, (type) => {
-			switch (type) {
-				case GridContentEvents.RefreshContents:
-					self.refreshResultsets();
-					break;
-				case GridContentEvents.ResizeContents:
-					self.resizeGrids();
-					break;
-				case GridContentEvents.CopySelection:
-					self.copySelection();
-					break;
-				case GridContentEvents.CopyWithHeaders:
-					self.copyWithHeaders();
-					break;
-				case GridContentEvents.CopyMessagesSelection:
-					self.copyMessagesSelection();
-					break;
-				case GridContentEvents.ToggleResultPane:
-					self.toggleResultPane();
-					break;
-				case GridContentEvents.ToggleMessagePane:
-					self.toggleMessagePane();
-					break;
-				case GridContentEvents.SelectAll:
-					self.onSelectAllForActiveGrid();
-					break;
-				case GridContentEvents.SelectAllMessages:
-					self.selectAllMessages();
-					break;
-				case GridContentEvents.SaveAsCsv:
-					self.sendSaveRequest(SaveFormat.CSV);
-					break;
-				case GridContentEvents.SaveAsJSON:
-					self.sendSaveRequest(SaveFormat.JSON);
-					break;
-				case GridContentEvents.SaveAsExcel:
-					self.sendSaveRequest(SaveFormat.EXCEL);
-					break;
-				case GridContentEvents.GoToNextQueryOutputTab:
-					self.goToNextQueryOutputTab();
-					break;
-				case GridContentEvents.ViewAsChart:
-					self.showChartForGrid(self.activeGrid);
-					break;
-				case GridContentEvents.GoToNextGrid:
-					self.goToNextGrid();
-					break;
-				default:
-					error('Unexpected grid content event type "' + type + '" sent');
-					break;
-			}
-		});
-
 		this.contextMenuService = this._bootstrapService.contextMenuService;
 		this.keybindingService = this._bootstrapService.keybindingService;
-
 		this.bindKeys(this._bootstrapService.contextKeyService);
 	}
 
@@ -214,17 +158,6 @@ export abstract class GridParentComponent {
 		this.toDispose = dispose(this.toDispose);
 	}
 
-	protected toggleResultPane(): void {
-		this.resultActive = !this.resultActive;
-		if (this.resultActive) {
-			this.resizeGrids();
-		}
-		this._cd.detectChanges();
-	}
-
-	protected toggleMessagePane(): void {
-		this.messageActive = !this.messageActive;
-	}
 
 	protected onGridFocus() {
 		this.gridFocussedContextKey.set(true);
@@ -242,137 +175,7 @@ export abstract class GridParentComponent {
 		this.messagesFocussedContextKey.set(false);
 	}
 
-	private copySelection(): void {
-		let messageText = this.getMessageText();
-		if (messageText.length > 0) {
-			this._bootstrapService.clipboardService.writeText(messageText);
-		} else {
-			let activeGrid = this.activeGrid;
-			let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-			this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId, this.renderedDataSets[activeGrid].resultId);
-		}
-	}
 
-	private copyWithHeaders(): void {
-		let activeGrid = this.activeGrid;
-		let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-		this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId,
-			this.renderedDataSets[activeGrid].resultId, true);
-	}
-
-	private copyMessagesSelection(): void {
-		let messageText = this.getMessageText();
-		if (messageText.length === 0) {
-			// Since we know we're specifically copying messages, do a select all if nothing is selected
-			this.selectAllMessages();
-			messageText = this.getMessageText();
-		}
-		if (messageText.length > 0) {
-			this._bootstrapService.clipboardService.writeText(messageText);
-		}
-	}
-
-	private getMessageText(): string {
-		if (document.activeElement === this.getMessagesElement()) {
-			if (window.getSelection()) {
-				return window.getSelection().toString();
-			}
-		}
-		return '';
-	}
-
-	protected goToNextQueryOutputTab(): void {
-	}
-
-	protected showChartForGrid(index: number) {
-	}
-
-	protected goToNextGrid() {
-		if (this.renderedDataSets.length > 0) {
-			let next  = this.activeGrid + 1;
-			if (next >= this.renderedDataSets.length) {
-				next = 0;
-			}
-			this.navigateToGrid(next);
-		}
-	}
-
-	protected navigateToGrid(index: number) {
-	}
-
-	private initShortcutsBase(): void {
-		let shortcuts = {
-			'ToggleResultPane': () => {
-				this.toggleResultPane();
-			},
-			'ToggleMessagePane': () => {
-				this.toggleMessagePane();
-			},
-			'CopySelection': () => {
-				this.copySelection();
-			},
-			'CopyWithHeaders': () => {
-				this.copyWithHeaders();
-			},
-			'SelectAll': () => {
-				this.onSelectAllForActiveGrid();
-			},
-			'SaveAsCSV': () => {
-				this.sendSaveRequest(SaveFormat.CSV);
-			},
-			'SaveAsJSON': () => {
-				this.sendSaveRequest(SaveFormat.JSON);
-			},
-			'SaveAsExcel': () => {
-				this.sendSaveRequest(SaveFormat.EXCEL);
-			},
-			'GoToNextQueryOutputTab': () => {
-				this.goToNextQueryOutputTab();
-			}
-		};
-
-		this.initShortcuts(shortcuts);
-		this.shortcutfunc = shortcuts;
-	}
-
-	protected abstract initShortcuts(shortcuts: { [name: string]: Function }): void;
-
-	/**
-	 * Send save result set request to service
-	 */
-	handleContextClick(event: { type: string, batchId: number, resultId: number, index: number, selection: ISlickRange[] }): void {
-		switch (event.type) {
-			case 'savecsv':
-				this.dataService.sendSaveRequest({ batchIndex: event.batchId, resultSetNumber: event.resultId, format: SaveFormat.CSV, selection: event.selection });
-				break;
-			case 'savejson':
-				this.dataService.sendSaveRequest({ batchIndex: event.batchId, resultSetNumber: event.resultId, format: SaveFormat.JSON, selection: event.selection });
-				break;
-			case 'saveexcel':
-				this.dataService.sendSaveRequest({ batchIndex: event.batchId, resultSetNumber: event.resultId, format: SaveFormat.EXCEL, selection: event.selection });
-				break;
-			case 'selectall':
-				this.activeGrid = event.index;
-				this.onSelectAllForActiveGrid();
-				break;
-			case 'copySelection':
-				this.dataService.copyResults(event.selection, event.batchId, event.resultId);
-				break;
-			case 'copyWithHeaders':
-				this.dataService.copyResults(event.selection, event.batchId, event.resultId, true);
-				break;
-			default:
-				break;
-		}
-	}
-
-	private sendSaveRequest(format: SaveFormat) {
-		let activeGrid = this.activeGrid;
-		let batchId = this.renderedDataSets[activeGrid].batchId;
-		let resultId = this.renderedDataSets[activeGrid].resultId;
-		let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-		this.dataService.sendSaveRequest({ batchIndex: batchId, resultSetNumber: resultId, format: format, selection: selection });
-	}
 
 	protected _keybindingFor(action: IAction): ResolvedKeybinding {
 		var [kb] = this.keybindingService.lookupKeybindings(action.id);
@@ -423,12 +226,6 @@ export abstract class GridParentComponent {
 			self.activeGrid = gridIndex;
 			self.slickgrids.toArray()[this.activeGrid].selection = true;
 		};
-	}
-
-	private onSelectAllForActiveGrid(): void {
-		if (this.activeGrid >= 0 && this.slickgrids.length > this.activeGrid) {
-			this.slickgrids.toArray()[this.activeGrid].selection = true;
-		}
 	}
 
 	/**

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -589,7 +589,7 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 		});
 	}
 
-	private showChartForGrid(index: number) {
+	protected showChartForGrid(index: number) {
 		if (this.renderedDataSets.length > index) {
 			this.showChartRequested.emit(this.renderedDataSets[index]);
 		}

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -15,11 +15,11 @@ import {
 	ElementRef, QueryList, ChangeDetectorRef, OnInit, OnDestroy, Component, Inject,
 	ViewChildren, forwardRef, EventEmitter, Input, ViewChild
 } from '@angular/core';
-import { IGridDataRow, SlickGrid, VirtualizedCollection, ISlickRange } from 'angular2-slickgrid';
+import { IGridDataRow, SlickGrid, VirtualizedCollection } from 'angular2-slickgrid';
 
 import * as LocalizedConstants from 'sql/parts/query/common/localizedConstants';
 import * as Services from 'sql/parts/grid/services/sharedServices';
-import { IGridIcon, IMessage, IGridDataSet, SaveFormat } from 'sql/parts/grid/common/interfaces';
+import { IGridIcon, IMessage, IGridDataSet } from 'sql/parts/grid/common/interfaces';
 import { GridParentComponent } from 'sql/parts/grid/views/gridParentComponent';
 import { GridActionProvider } from 'sql/parts/grid/views/gridActions';
 import { IBootstrapService, BOOTSTRAP_SERVICE_ID } from 'sql/services/bootstrap/bootstrapService';
@@ -27,7 +27,6 @@ import { QueryComponentParams } from 'sql/services/bootstrap/bootstrapParams';
 import { error } from 'sql/base/common/log';
 import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
 import { clone } from 'sql/base/common/objects';
-import * as GridContentEvents from 'sql/parts/grid/common/gridContentEvents';
 
 import * as strings from 'vs/base/common/strings';
 import * as DOM from 'vs/base/browser/dom';
@@ -208,193 +207,14 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 			}
 			self._cd.detectChanges();
 		});
-
-		this.subscribeWithDispose(this.dataService.gridContentObserver, (type) => {
-			switch (type) {
-				case GridContentEvents.RefreshContents:
-					self.refreshResultsets();
-					break;
-				case GridContentEvents.ResizeContents:
-					self.resizeGrids();
-					break;
-				case GridContentEvents.CopySelection:
-					self.copySelection();
-					break;
-				case GridContentEvents.CopyWithHeaders:
-					self.copyWithHeaders();
-					break;
-				case GridContentEvents.CopyMessagesSelection:
-					self.copyMessagesSelection();
-					break;
-				case GridContentEvents.ToggleResultPane:
-					self.toggleResultPane();
-					break;
-				case GridContentEvents.ToggleMessagePane:
-					self.toggleMessagePane();
-					break;
-				case GridContentEvents.SelectAll:
-					self.onSelectAllForActiveGrid();
-					break;
-				case GridContentEvents.SelectAllMessages:
-					self.selectAllMessages();
-					break;
-				case GridContentEvents.SaveAsCsv:
-					self.sendSaveRequest(SaveFormat.CSV);
-					break;
-				case GridContentEvents.SaveAsJSON:
-					self.sendSaveRequest(SaveFormat.JSON);
-					break;
-				case GridContentEvents.SaveAsExcel:
-					self.sendSaveRequest(SaveFormat.EXCEL);
-					break;
-				case GridContentEvents.GoToNextQueryOutputTab:
-					self.goToNextQueryOutputTab();
-					break;
-				case GridContentEvents.ViewAsChart:
-					self.showChartForGrid(self.activeGrid);
-					break;
-				case GridContentEvents.GoToNextGrid:
-					self.goToNextGrid();
-					break;
-				default:
-					error('Unexpected grid content event type "' + type + '" sent');
-					break;
-			}
-		});
-
-		this.initShortcutsBase();
 		this.dataService.onAngularLoaded();
-	}
-
-	private goToNextGrid() {
-		if (this.renderedDataSets.length > 0) {
-			let next  = this.activeGrid + 1;
-			if (next >= this.renderedDataSets.length) {
-				next = 0;
-			}
-			this.navigateToGrid(next);
-		}
-	}
-
-	private initShortcutsBase(): void {
-		let shortcuts = {
-			'ToggleResultPane': () => {
-				this.toggleResultPane();
-			},
-			'ToggleMessagePane': () => {
-				this.toggleMessagePane();
-			},
-			'CopySelection': () => {
-				this.copySelection();
-			},
-			'CopyWithHeaders': () => {
-				this.copyWithHeaders();
-			},
-			'SelectAll': () => {
-				this.onSelectAllForActiveGrid();
-			},
-			'SaveAsCSV': () => {
-				this.sendSaveRequest(SaveFormat.CSV);
-			},
-			'SaveAsJSON': () => {
-				this.sendSaveRequest(SaveFormat.JSON);
-			},
-			'SaveAsExcel': () => {
-				this.sendSaveRequest(SaveFormat.EXCEL);
-			}
-		};
-
-		this.initShortcuts(shortcuts);
-		this.shortcutfunc = shortcuts;
-	}
-
-	private copySelection(): void {
-		let messageText = this.getMessageText();
-		if (messageText.length > 0) {
-			this._bootstrapService.clipboardService.writeText(messageText);
-		} else {
-			let activeGrid = this.activeGrid;
-			let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-			this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId, this.renderedDataSets[activeGrid].resultId);
-		}
-	}
-
-	private getMessageText(): string {
-		if (document.activeElement === this.getMessagesElement()) {
-			if (window.getSelection()) {
-				return window.getSelection().toString();
-			}
-		}
-		return '';
-	}
-
-	private copyWithHeaders(): void {
-		let activeGrid = this.activeGrid;
-		let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-		this.dataService.copyResults(selection, this.renderedDataSets[activeGrid].batchId,
-			this.renderedDataSets[activeGrid].resultId, true);
-	}
-
-	private copyMessagesSelection(): void {
-		let messageText = this.getMessageText();
-		if (messageText.length === 0) {
-			// Since we know we're specifically copying messages, do a select all if nothing is selected
-			this.selectAllMessages();
-			messageText = this.getMessageText();
-		}
-		if (messageText.length > 0) {
-			this._bootstrapService.clipboardService.writeText(messageText);
-		}
-	}
-
-	private onSelectAllForActiveGrid(): void {
-		if (this.activeGrid >= 0 && this.slickgrids.length > this.activeGrid) {
-			this.slickgrids.toArray()[this.activeGrid].selection = true;
-		}
-	}
-
-	private sendSaveRequest(format: SaveFormat) {
-		let activeGrid = this.activeGrid;
-		let batchId = this.renderedDataSets[activeGrid].batchId;
-		let resultId = this.renderedDataSets[activeGrid].resultId;
-		let selection = this.slickgrids.toArray()[activeGrid].getSelectedRanges();
-		this.dataService.sendSaveRequest({ batchIndex: batchId, resultSetNumber: resultId, format: format, selection: selection });
-	}
-
-	/**
-	 * Send save result set request to service
-	 */
-	private handleContextClick(event: { type: string, batchId: number, resultId: number, index: number, selection: ISlickRange[] }): void {
-		switch (event.type) {
-			case 'savecsv':
-				this.dataService.sendSaveRequest({ batchIndex: event.batchId, resultSetNumber: event.resultId, format: SaveFormat.CSV, selection: event.selection });
-				break;
-			case 'savejson':
-				this.dataService.sendSaveRequest({ batchIndex: event.batchId, resultSetNumber: event.resultId, format: SaveFormat.JSON, selection: event.selection });
-				break;
-			case 'saveexcel':
-				this.dataService.sendSaveRequest({ batchIndex: event.batchId, resultSetNumber: event.resultId, format: SaveFormat.EXCEL, selection: event.selection });
-				break;
-			case 'selectall':
-				this.activeGrid = event.index;
-				this.onSelectAllForActiveGrid();
-				break;
-			case 'copySelection':
-				this.dataService.copyResults(event.selection, event.batchId, event.resultId);
-				break;
-			case 'copyWithHeaders':
-				this.dataService.copyResults(event.selection, event.batchId, event.resultId, true);
-				break;
-			default:
-				break;
-		}
 	}
 
 	public ngOnDestroy(): void {
 		this.baseDestroy();
 	}
 
-	private initShortcuts(shortcuts: { [name: string]: Function }): void {
+	protected initShortcuts(shortcuts: { [name: string]: Function }): void {
 		shortcuts['event.nextGrid'] = () => {
 			this.navigateToGrid(this.activeGrid + 1);
 		};
@@ -769,17 +589,17 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 		});
 	}
 
-	private showChartForGrid(index: number) {
+	protected showChartForGrid(index: number) {
 		if (this.renderedDataSets.length > index) {
 			this.showChartRequested.emit(this.renderedDataSets[index]);
 		}
 	}
 
-	private goToNextQueryOutputTab(): void {
+	protected goToNextQueryOutputTab(): void {
 		this.goToNextQueryOutputTabRequested.emit();
 	}
 
-	private toggleResultPane(): void {
+	protected toggleResultPane(): void {
 		this.resultActive = !this.resultActive;
 		this._cd.detectChanges();
 		if (this.resultActive) {
@@ -788,7 +608,7 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 		}
 	}
 
-	private toggleMessagePane(): void {
+	protected toggleMessagePane(): void {
 		this.messageActive = !this.messageActive;
 		this._cd.detectChanges();
 		if (this.messageActive && this._messagesContainer) {

--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -212,6 +212,22 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: gridActions.GRID_VIEWASCHART_ID,
+	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(gridCommandsWeightBonus),
+	when: ResultsGridFocusCondition,
+	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_R, KeyMod.CtrlCmd | KeyCode.KEY_V),
+	handler: gridCommands.viewAsChart
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: gridActions.GRID_GOTONEXTGRID_ID,
+	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(gridCommandsWeightBonus),
+	when: ResultsGridFocusCondition,
+	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_R, KeyMod.CtrlCmd | KeyCode.KEY_N),
+	handler: gridCommands.goToNextGrid
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: gridActions.TOGGLERESULTS_ID,
 	weight: KeybindingsRegistry.WEIGHT.workbenchContrib(gridCommandsWeightBonus),
 	when: QueryEditorVisibleCondition,

--- a/src/sql/parts/query/views/queryOutput.component.ts
+++ b/src/sql/parts/query/views/queryOutput.component.ts
@@ -104,7 +104,6 @@ export class QueryOutputComponent implements OnInit, OnDestroy {
 		})));
 
 		this._disposables.push(toDisposableSubscription(this.queryComponent.goToNextQueryOutputTabRequested.subscribe(() => {
-			let activeTab = this._panel.getActiveTab;
 			this._panel.selectOnNextTab();
 		})));
 	}


### PR DESCRIPTION
We already have shortcuts for save as CVS, Json, and excel in the grid when ResultsGridFocusCondition. I have added 2 more shortcuts which are view as chart and go to next grid (in the case where we have multilple result set)

grid.viewAsChart - CtrlCmd + KEY_R, CtrlCmd + KEY_V
grid.goToNextGrid - CtrlCmd | KEY_R,  CtrlCmd + KEY_N