### PR TITLE
Add default model view input types and validation

### DIFF
--- a/src/sql/parts/modelComponents/componentBase.ts
+++ b/src/sql/parts/modelComponents/componentBase.ts
@@ -69,6 +69,7 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 		}
 		this.properties = properties;
 		this.layout();
+		this.validate();
 	}
 
 	protected getProperties<TPropertyBag>(): TPropertyBag {

--- a/src/sql/parts/modelComponents/componentBase.ts
+++ b/src/sql/parts/modelComponents/componentBase.ts
@@ -117,7 +117,7 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 		}
 	}
 
-	protected validate(): Thenable<boolean> {
+	public validate(): Thenable<boolean> {
 		let validations = this._validations.map(validation => Promise.resolve(validation()));
 		return Promise.all(validations).then(values => {
 			let isValid = values.every(value => value === true);

--- a/src/sql/parts/modelComponents/componentBase.ts
+++ b/src/sql/parts/modelComponents/componentBase.ts
@@ -117,9 +117,9 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 		}
 	}
 
-	protected validate(): void {
+	protected validate(): Thenable<boolean> {
 		let validations = this._validations.map(validation => Promise.resolve(validation()));
-		Promise.all(validations).then(values => {
+		return Promise.all(validations).then(values => {
 			let isValid = values.every(value => value === true);
 			if (this._valid !== isValid) {
 				this._valid = isValid;
@@ -128,6 +128,7 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 					args: this._valid
 				});
 			}
+			return isValid;
 		});
 	}
 }

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -72,12 +72,14 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 					args: e
 				});
 			}));
-			this._register(this._onEventEmitter.event(event => {
-				if (event.eventType === ComponentEventType.validityChanged) {
-					this._input.validate();
-				}
-			}));
 		}
+	}
+
+	protected validate(): Thenable<boolean> {
+		return super.validate().then(valid => {
+			this._input.validate();
+			return valid;
+		});
 	}
 
 	ngOnDestroy(): void {

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -110,6 +110,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 		if (this.width) {
 			this._input.width = this.width;
 		}
+		this._input.inputElement.required = this.required;
 		this.validate();
 	}
 
@@ -161,5 +162,13 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public set inputType(newValue: string) {
 		this.setPropertyFromUI<sqlops.InputBoxProperties, string>((props, value) => props.inputType = value, newValue);
+	}
+
+	public get required(): boolean {
+		return this.getPropertyOrDefault<sqlops.InputBoxProperties, boolean>((props) => props.required, false);
+	}
+
+	public set required(newValue: boolean) {
+		this.setPropertyFromUI<sqlops.InputBoxProperties, boolean>((props, value) => props.required = value, newValue);
 	}
 }

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -61,6 +61,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 			};
 
 			this._input = new InputBox(this._inputContainer.nativeElement, this._commonService.contextViewService, inputOptions);
+			this._validations.push(() => !this._input.inputElement.validationMessage);
 
 			this._register(this._input);
 			this._register(attachInputBoxStyler(this._input, this._commonService.themeService));
@@ -70,6 +71,11 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 					eventType: ComponentEventType.onDidChange,
 					args: e
 				});
+			}));
+			this._register(this._onEventEmitter.event(event => {
+				if (event.eventType === ComponentEventType.validityChanged) {
+					this._input.validate();
+				}
 			}));
 		}
 	}
@@ -102,11 +108,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 		if (this.width) {
 			this._input.width = this.width;
 		}
-	}
-
-	public setValid(valid: boolean): void {
-		super.setValid(valid);
-		this._input.validate();
+		this.validate();
 	}
 
 	// CSS-bound properties

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -91,6 +91,10 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public setProperties(properties: { [key: string]: any; }): void {
 		super.setProperties(properties);
+		this._input.inputElement.type = this.inputType;
+		if (this.inputType === 'number') {
+			this._input.inputElement.step = 'any';
+		}
 		this._input.value = this.value;
 		this._input.setAriaLabel(this.ariaLabel);
 		this._input.setPlaceHolder(this.placeHolder);
@@ -145,5 +149,13 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 
 	public set width(newValue: number) {
 		this.setPropertyFromUI<sqlops.InputBoxProperties, number>((props, value) => props.width = value, newValue);
+	}
+
+	public get inputType(): string {
+		return this.getPropertyOrDefault<sqlops.InputBoxProperties, string>((props) => props.inputType, 'text');
+	}
+
+	public set inputType(newValue: string) {
+		this.setPropertyFromUI<sqlops.InputBoxProperties, string>((props, value) => props.inputType = value, newValue);
 	}
 }

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -57,7 +57,8 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 							};
 						}
 					}
-				}
+				},
+				useDefaultValidation: true
 			};
 
 			this._input = new InputBox(this._inputContainer.nativeElement, this._commonService.contextViewService, inputOptions);

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -52,7 +52,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 							return undefined;
 						} else {
 							return {
-								content: nls.localize('invalidValueError', 'Invalid value'),
+								content: this._input.inputElement.validationMessage || nls.localize('invalidValueError', 'Invalid value'),
 								type: MessageType.ERROR
 							};
 						}
@@ -75,7 +75,7 @@ export default class InputBoxComponent extends ComponentBase implements ICompone
 		}
 	}
 
-	protected validate(): Thenable<boolean> {
+	public validate(): Thenable<boolean> {
 		return super.validate().then(valid => {
 			this._input.validate();
 			return valid;

--- a/src/sql/parts/modelComponents/interfaces.ts
+++ b/src/sql/parts/modelComponents/interfaces.ts
@@ -24,7 +24,6 @@ export interface IComponent {
 	setLayout?: (layout: any) => void;
 	setProperties?: (properties: { [key: string]: any; }) => void;
 	readonly valid?: boolean;
-	setValid(valid: boolean): void;
 }
 
 export const COMPONENT_CONFIG = new InjectionToken<IComponentConfig>('component_config');
@@ -88,4 +87,9 @@ export interface IModelStore {
 	 * @memberof IModelStore
 	 */
 	eventuallyRunOnComponent<T>(componentId: string, action: (component: IComponent) => T): Promise<T>;
+	/**
+	 * TOOD
+	 */
+	registerValidationCallback(callback: (componentId: string) => Thenable<boolean>): void;
+	validate(component: IComponent): Thenable<boolean>;
 }

--- a/src/sql/parts/modelComponents/interfaces.ts
+++ b/src/sql/parts/modelComponents/interfaces.ts
@@ -24,6 +24,7 @@ export interface IComponent {
 	setLayout?: (layout: any) => void;
 	setProperties?: (properties: { [key: string]: any; }) => void;
 	readonly valid?: boolean;
+	validate(): Thenable<boolean>;
 }
 
 export const COMPONENT_CONFIG = new InjectionToken<IComponentConfig>('component_config');

--- a/src/sql/parts/modelComponents/modelStore.ts
+++ b/src/sql/parts/modelComponents/modelStore.ts
@@ -27,6 +27,7 @@ export class ModelStore implements IModelStore {
 	private _descriptorMappings: { [x: string]: IComponentDescriptor } = {};
 	private _componentMappings: { [x: string]: IComponent } = {};
 	private _componentActions: { [x: string]: Deferred<IComponent> } = {};
+	private _validationCallbacks: ((componentId: string) => Thenable<boolean>)[] = [];
 	constructor() {
 	}
 
@@ -64,6 +65,15 @@ export class ModelStore implements IModelStore {
 		} else {
 			return this.addPendingAction(componentId, action);
 		}
+	}
+
+	registerValidationCallback(callback: (componentId: string) => Thenable<boolean>): void {
+		this._validationCallbacks.push(callback);
+	}
+
+	validate(component: IComponent): Thenable<boolean> {
+		let componentId = Object.entries(this._componentMappings).find(([id, mappedComponent]) => component === mappedComponent)[0];
+		return Promise.all(this._validationCallbacks.map(callback => callback(componentId))).then(validations => validations.every(validation => validation === true));
 	}
 
 	private addPendingAction<T>(componentId: string, action: (component: IComponent) => T): Promise<T> {

--- a/src/sql/parts/modelComponents/viewBase.ts
+++ b/src/sql/parts/modelComponents/viewBase.ts
@@ -39,9 +39,10 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 	private _onEventEmitter = new Emitter<any>();
 
 
-	initializeModel(rootComponent: IComponentShape): void {
+	initializeModel(rootComponent: IComponentShape, validationCallback: (componentId: string) => Thenable<boolean>): void {
 		let descriptor = this.defineComponent(rootComponent);
 		this.rootDescriptor = descriptor;
+		this.modelStore.registerValidationCallback(validationCallback);
 		// Kick off the build by detecting changes to the model
 		this.changeRef.detectChanges();
 	}
@@ -89,10 +90,6 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 			return;
 		}
 		this.queueAction(componentId, (component) => component.setProperties(properties));
-	}
-
-	setValid(componentId: string, valid: boolean): void {
-		this.queueAction(componentId, (component) => component.setValid(valid));
 	}
 
 	private queueAction<T>(componentId: string, action: (component: IComponent) => T): void {

--- a/src/sql/parts/modelComponents/viewBase.ts
+++ b/src/sql/parts/modelComponents/viewBase.ts
@@ -110,4 +110,8 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 	public get onEvent(): Event<IComponentEventArgs> {
 		return this._onEventEmitter.event;
 	}
+
+	public validate(componentId: string): Thenable<boolean> {
+		return new Promise(resolve => this.modelStore.eventuallyRunOnComponent(componentId, component => resolve(component.validate())));
+	}
 }

--- a/src/sql/services/model/modelViewService.ts
+++ b/src/sql/services/model/modelViewService.ts
@@ -22,4 +22,5 @@ export interface IModelView extends IView {
 	setProperties(componentId: string, properties: { [key: string]: any }): void;
 	registerEvent(componentId: string);
 	onEvent: Event<any>;
+	validate(componentId: string): Thenable<boolean>;
 }

--- a/src/sql/services/model/modelViewService.ts
+++ b/src/sql/services/model/modelViewService.ts
@@ -15,12 +15,11 @@ export interface IView {
 }
 
 export interface IModelView extends IView {
-	initializeModel(rootComponent: IComponentShape): void;
+	initializeModel(rootComponent: IComponentShape, validationCallback?: (componentId: string) => Thenable<boolean>): void;
 	clearContainer(componentId: string): void;
 	addToContainer(containerId: string, item: IItemConfig): void;
 	setLayout(componentId: string, layout: any): void;
 	setProperties(componentId: string, properties: { [key: string]: any }): void;
-	setValid(componentId: string, valid: boolean): void;
 	registerEvent(componentId: string);
 	onEvent: Event<any>;
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -204,12 +204,15 @@ declare module 'sqlops' {
 		actions?: ActionDescriptor[];
 	}
 
+	export type InputBoxInputType = 'color' | 'date' | 'datetime-local' | 'email' | 'month' | 'number' | 'password' | 'range' | 'search' | 'text' | 'time' | 'url' | 'week';
+
 	export interface InputBoxProperties {
 		value?: string;
 		ariaLabel?: string;
 		placeHolder?: string;
 		height: number;
 		width: number;
+		inputType?: InputBoxInputType;
 	}
 
 	export interface CheckBoxProperties {

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -213,6 +213,7 @@ declare module 'sqlops' {
 		height: number;
 		width: number;
 		inputType?: InputBoxInputType;
+		required?: boolean;
 	}
 
 	export interface CheckBoxProperties {

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -72,7 +72,7 @@ declare module 'sqlops' {
 		/**
 		 * Run the component's validations
 		 */
-		validate(): boolean;
+		validate(): Thenable<boolean>;
 	}
 
 	export interface FormComponent {
@@ -302,7 +302,7 @@ declare module 'sqlops' {
 		/**
 		 * Run the model view root component's validations
 		 */
-		validate(): void;
+		validate(): Thenable<boolean>;
 
 		/**
 		 * Initializes the model with a root component definition.

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -72,7 +72,7 @@ declare module 'sqlops' {
 		/**
 		 * Run the component's validations
 		 */
-		validate(): void;
+		validate(): boolean;
 	}
 
 	export interface FormComponent {

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -92,7 +92,8 @@ export interface IItemConfig {
 export enum ComponentEventType {
 	PropertiesChanged,
 	onDidChange,
-	onDidClick
+	onDidClick,
+	validityChanged
 }
 
 export interface IComponentEventArgs {

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -28,7 +28,7 @@ class ModelBuilderImpl implements sqlops.ModelBuilder {
 		let id = this.getNextComponentId();
 		let container: ContainerBuilderImpl<sqlops.NavContainer, any, any> = new ContainerBuilderImpl(this._proxy, this._handle, ModelComponentTypes.NavContainer, id);
 		this._eventHandlers.set(id, container);
-		this._components.set(id, container.component());
+		this._components.set(id, container.componentWrapper());
 		return container;
 	}
 
@@ -36,7 +36,7 @@ class ModelBuilderImpl implements sqlops.ModelBuilder {
 		let id = this.getNextComponentId();
 		let container: ContainerBuilderImpl<sqlops.FlexContainer, any, any> = new ContainerBuilderImpl<sqlops.FlexContainer, sqlops.FlexLayout, sqlops.FlexItemLayout>(this._proxy, this._handle, ModelComponentTypes.FlexContainer, id);
 		this._eventHandlers.set(id, container);
-		this._components.set(id, container.component());
+		this._components.set(id, container.componentWrapper());
 		return container;
 	}
 
@@ -44,60 +44,60 @@ class ModelBuilderImpl implements sqlops.ModelBuilder {
 		let id = this.getNextComponentId();
 		let container = new FormContainerBuilder(this._proxy, this._handle, ModelComponentTypes.Form, id);
 		this._eventHandlers.set(id, container);
-		this._components.set(id, container.component());
+		this._components.set(id, container.componentWrapper());
 		return container;
 	}
 
 	card(): sqlops.ComponentBuilder<sqlops.CardComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.CardComponent> = this.withEventHandler(new CardWrapper(this._proxy, this._handle, id), id);
-		this._components.set(id, builder.component());
+		let builder: ComponentBuilderImpl<sqlops.CardComponent> = this.withEventHandler(new CardWrapper(this._proxy, this._handle, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
 	inputBox(): sqlops.ComponentBuilder<sqlops.InputBoxComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.InputBoxComponent> = this.withEventHandler(new InputBoxWrapper(this._proxy, this._handle, id), id);
-		this._components.set(id, builder.component());
+		let builder: ComponentBuilderImpl<sqlops.InputBoxComponent> = this.withEventHandler(new InputBoxWrapper(this._proxy, this._handle, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
 	checkBox(): sqlops.ComponentBuilder<sqlops.CheckBoxComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.CheckBoxComponent> = this.withEventHandler(new CheckBoxWrapper(this._proxy, this._handle, id), id);
-		this._components.set(id, builder.component());
+		let builder: ComponentBuilderImpl<sqlops.CheckBoxComponent> = this.withEventHandler(new CheckBoxWrapper(this._proxy, this._handle, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
 	button(): sqlops.ComponentBuilder<sqlops.ButtonComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.ButtonComponent> = this.withEventHandler(new ButtonWrapper(this._proxy, this._handle, id), id);
-		this._components.set(id, builder.component());
+		let builder: ComponentBuilderImpl<sqlops.ButtonComponent> = this.withEventHandler(new ButtonWrapper(this._proxy, this._handle, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
 	dropDown(): sqlops.ComponentBuilder<sqlops.DropDownComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.DropDownComponent> = this.withEventHandler(new DropDownWrapper(this._proxy, this._handle, id), id);
-		this._components.set(id, builder.component());
+		let builder: ComponentBuilderImpl<sqlops.DropDownComponent> = this.withEventHandler(new DropDownWrapper(this._proxy, this._handle, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
 	dashboardWidget(widgetId: string): sqlops.ComponentBuilder<sqlops.WidgetComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.WidgetComponent> = this.withEventHandler<sqlops.WidgetComponent>(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWidget, id), id);
-		this._components.set(id, builder.component());
+		let builder = this.withEventHandler<sqlops.WidgetComponent>(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWidget, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
 	dashboardWebview(webviewId: string): sqlops.ComponentBuilder<sqlops.WebviewComponent> {
 		let id = this.getNextComponentId();
-		let builder: sqlops.ComponentBuilder<sqlops.WebviewComponent> = this.withEventHandler(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWebview, id), id);
-		this._components.set(id, builder.component());
+		let builder: ComponentBuilderImpl<sqlops.WebviewComponent> = this.withEventHandler(new ComponentWrapper(this._proxy, this._handle, ModelComponentTypes.DashboardWebview, id), id);
+		this._components.set(id, builder.componentWrapper());
 		return builder;
 	}
 
-	withEventHandler<T extends sqlops.Component>(component: ComponentWrapper, id: string): sqlops.ComponentBuilder<T> {
+	withEventHandler<T extends sqlops.Component>(component: ComponentWrapper, id: string): ComponentBuilderImpl<T> {
 		let componentBuilder: ComponentBuilderImpl<T> = new ComponentBuilderImpl<T>(component);
 		this._eventHandlers.set(id, componentBuilder);
 		return componentBuilder;
@@ -110,9 +110,9 @@ class ModelBuilderImpl implements sqlops.ModelBuilder {
 		}
 	}
 
-	public validateComponent(componentId: string): boolean {
+	public runCustomValidations(componentId: string): boolean {
 		let component = this._components.get(componentId);
-		return component.runExtensionValidations();
+		return component.runCustomValidations();
 	}
 
 	private getNextComponentId(): string {
@@ -134,13 +134,17 @@ class ComponentBuilderImpl<T extends sqlops.Component> implements sqlops.Compone
 		return <T><any>this._component;
 	}
 
+	componentWrapper(): ComponentWrapper {
+		return this._component;
+	}
+
 	withProperties<U>(properties: U): sqlops.ComponentBuilder<T> {
 		this._component.properties = properties;
 		return this;
 	}
 
 	withValidation(validation: (component: T) => boolean): sqlops.ComponentBuilder<T> {
-		this._component.extensionValidations.push(validation);
+		this._component.customValidations.push(validation);
 		return this;
 	}
 
@@ -228,7 +232,7 @@ class ComponentWrapper implements sqlops.Component {
 	public properties: { [key: string]: any } = {};
 	public layout: any;
 	public itemConfigs: InternalItemConfig[];
-	public extensionValidations: ((component: ThisType<ComponentWrapper>) => boolean)[] = [];
+	public customValidations: ((component: ThisType<ComponentWrapper>) => boolean)[] = [];
 	private _valid: boolean = true;
 	private _onValidityChangedEmitter = new Emitter<boolean>();
 	public readonly onValidityChanged = this._onValidityChangedEmitter.event;
@@ -340,10 +344,10 @@ class ComponentWrapper implements sqlops.Component {
 		this._onErrorEmitter.fire(err);
 	}
 
-	public runExtensionValidations(): boolean {
+	public runCustomValidations(): boolean {
 		let isValid = true;
 		try {
-			this.extensionValidations.forEach(validation => {
+			this.customValidations.forEach(validation => {
 				if (!validation(this)) {
 					isValid = false;
 				}
@@ -587,8 +591,8 @@ class ModelViewImpl implements sqlops.ModelView {
 		return this._proxy.$validate(this._handle, this._component.id);
 	}
 
-	public runExtensionValidations(componentId: string): boolean {
-		return this._modelBuilder.validateComponent(componentId);
+	public runCustomValidations(componentId: string): boolean {
+		return this._modelBuilder.runCustomValidations(componentId);
 	}
 }
 
@@ -628,8 +632,8 @@ export class ExtHostModelView implements ExtHostModelViewShape {
 		}
 	}
 
-	$runExtensionValidations(handle: number, componentId: string): Thenable<boolean> {
+	$runCustomValidations(handle: number, componentId: string): Thenable<boolean> {
 		const view = this._modelViews.get(handle);
-		return Promise.resolve(view.runExtensionValidations(componentId));
+		return Promise.resolve(view.runCustomValidations(componentId));
 	}
 }

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -303,6 +303,9 @@ class ComponentWrapper implements sqlops.Component {
 		if (eventArgs && eventArgs.eventType === ComponentEventType.PropertiesChanged) {
 			this.properties = eventArgs.args;
 			this.validate();
+		}
+		else if (eventArgs && eventArgs.eventType === ComponentEventType.validityChanged) {
+
 		} else if (eventArgs) {
 			let emitter = this._emitterMap.get(eventArgs.eventType);
 			if (emitter) {
@@ -425,6 +428,13 @@ class InputBoxWrapper extends ComponentWrapper implements sqlops.InputBoxCompone
 	}
 	public set width(v: number) {
 		this.setProperty('width', v);
+	}
+
+	public get inputType(): sqlops.InputBoxInputType {
+		return this.properties['inputType'];
+	}
+	public set inputType(v: sqlops.InputBoxInputType) {
+		this.setProperty('inputType', v);
 	}
 
 	public get onTextChanged(): vscode.Event<any> {

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -576,6 +576,10 @@ class ModelViewImpl implements sqlops.ModelView {
 	public validate(): void {
 		this._component.validate();
 	}
+
+	public validateComponent(componentId: string): boolean {
+		return this._modelBuilder.validateComponent(componentId);
+	}
 }
 
 export class ExtHostModelView implements ExtHostModelViewShape {
@@ -612,5 +616,9 @@ export class ExtHostModelView implements ExtHostModelViewShape {
 		if (view) {
 			view.handleEvent(componentId, eventArgs);
 		}
+	}
+
+	$validateWidget(handle: number, componentId: string): Thenable<boolean> {
+		const view = this._modelViews.get(handle);
 	}
 }

--- a/src/sql/workbench/api/node/mainThreadModelView.ts
+++ b/src/sql/workbench/api/node/mainThreadModelView.ts
@@ -46,7 +46,7 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 
 	$initializeModel(handle: number, rootComponent: IComponentShape): Thenable<void> {
 		return this.execModelViewAction(handle, (modelView) => {
-			modelView.initializeModel(rootComponent, (componentId) => this.validate(handle, componentId));
+			modelView.initializeModel(rootComponent, (componentId) => this.runExtensionHostValidation(handle, componentId));
 		});
 	}
 
@@ -82,7 +82,11 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 		return this.execModelViewAction(handle, (modelView) => modelView.setProperties(componentId, properties));
 	}
 
-	private validate(handle: number, componentId: string): Thenable<boolean> {
+	$validate(handle: number, componentId: string): Thenable<boolean> {
+		return new Promise(resolve => this.execModelViewAction(handle, (modelView) => resolve(modelView.validate(componentId))));
+	}
+
+	private runExtensionHostValidation(handle: number, componentId: string): Thenable<boolean> {
 		return this._proxy.$validateWidget(handle, componentId);
 	}
 

--- a/src/sql/workbench/api/node/mainThreadModelView.ts
+++ b/src/sql/workbench/api/node/mainThreadModelView.ts
@@ -46,7 +46,7 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 
 	$initializeModel(handle: number, rootComponent: IComponentShape): Thenable<void> {
 		return this.execModelViewAction(handle, (modelView) => {
-			modelView.initializeModel(rootComponent);
+			modelView.initializeModel(rootComponent, (componentId) => this.validate(handle, componentId));
 		});
 	}
 
@@ -82,8 +82,8 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 		return this.execModelViewAction(handle, (modelView) => modelView.setProperties(componentId, properties));
 	}
 
-	$notifyValidation(handle: number, componentId: string, valid: boolean): Thenable<void> {
-		return this.execModelViewAction(handle, (modelView) => modelView.setValid(componentId, valid));
+	private validate(handle: number, componentId: string): Thenable<boolean> {
+		return this._proxy.$validateWidget(handle, componentId);
 	}
 
 	private execModelViewAction<T>(handle: number, action: (m: IModelView) => T): Thenable<T> {

--- a/src/sql/workbench/api/node/mainThreadModelView.ts
+++ b/src/sql/workbench/api/node/mainThreadModelView.ts
@@ -46,7 +46,7 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 
 	$initializeModel(handle: number, rootComponent: IComponentShape): Thenable<void> {
 		return this.execModelViewAction(handle, (modelView) => {
-			modelView.initializeModel(rootComponent, (componentId) => this.runExtensionHostValidation(handle, componentId));
+			modelView.initializeModel(rootComponent, (componentId) => this.runCustomValidations(handle, componentId));
 		});
 	}
 
@@ -86,8 +86,8 @@ export class MainThreadModelView extends Disposable implements MainThreadModelVi
 		return new Promise(resolve => this.execModelViewAction(handle, (modelView) => resolve(modelView.validate(componentId))));
 	}
 
-	private runExtensionHostValidation(handle: number, componentId: string): Thenable<boolean> {
-		return this._proxy.$validateWidget(handle, componentId);
+	private runCustomValidations(handle: number, componentId: string): Thenable<boolean> {
+		return this._proxy.$runCustomValidations(handle, componentId);
 	}
 
 	private execModelViewAction<T>(handle: number, action: (m: IModelView) => T): Thenable<T> {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -520,7 +520,7 @@ export interface ExtHostModelViewShape {
 	$onClosed(handle: number): void;
 	$registerWidget(handle: number, id: string, connection: sqlops.connection.Connection, serverInfo: sqlops.ServerInfo): void;
 	$handleEvent(handle: number, id: string, eventArgs: any);
-	$validateWidget(handle: number, id: string): Thenable<boolean>;
+	$runExtensionValidations(handle: number, id: string): Thenable<boolean>;
 }
 
 export interface MainThreadModelViewShape extends IDisposable {
@@ -531,6 +531,7 @@ export interface MainThreadModelViewShape extends IDisposable {
 	$setLayout(handle: number, componentId: string, layout: any): Thenable<void>;
 	$setProperties(handle: number, componentId: string, properties: { [key: string]: any }): Thenable<void>;
 	$registerEvent(handle: number, componentId: string):  Thenable<void>;
+	$validate(handle: number, componentId: string): Thenable<boolean>;
 }
 
 export interface ExtHostObjectExplorerShape {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -520,7 +520,7 @@ export interface ExtHostModelViewShape {
 	$onClosed(handle: number): void;
 	$registerWidget(handle: number, id: string, connection: sqlops.connection.Connection, serverInfo: sqlops.ServerInfo): void;
 	$handleEvent(handle: number, id: string, eventArgs: any);
-	$runExtensionValidations(handle: number, id: string): Thenable<boolean>;
+	$runCustomValidations(handle: number, id: string): Thenable<boolean>;
 }
 
 export interface MainThreadModelViewShape extends IDisposable {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -520,6 +520,7 @@ export interface ExtHostModelViewShape {
 	$onClosed(handle: number): void;
 	$registerWidget(handle: number, id: string, connection: sqlops.connection.Connection, serverInfo: sqlops.ServerInfo): void;
 	$handleEvent(handle: number, id: string, eventArgs: any);
+	$validateWidget(handle: number, id: string): Thenable<boolean>;
 }
 
 export interface MainThreadModelViewShape extends IDisposable {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -531,7 +531,6 @@ export interface MainThreadModelViewShape extends IDisposable {
 	$setLayout(handle: number, componentId: string, layout: any): Thenable<void>;
 	$setProperties(handle: number, componentId: string, properties: { [key: string]: any }): Thenable<void>;
 	$registerEvent(handle: number, componentId: string):  Thenable<void>;
-	$notifyValidation(handle: number, componentId: string, valid: boolean): Thenable<void>;
 }
 
 export interface ExtHostObjectExplorerShape {

--- a/src/sqltest/parts/modelComponents/componentBase.test.ts
+++ b/src/sqltest/parts/modelComponents/componentBase.test.ts
@@ -1,0 +1,132 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Mock, It, Times, MockBehavior } from 'typemoq';
+import { ComponentBase, ContainerBase } from 'sql/parts/modelComponents/componentBase';
+import { IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/parts/modelComponents/interfaces';
+import { ModelStore } from 'sql/parts/modelComponents/modelStore';
+import { ChangeDetectorRef } from '@angular/core';
+
+'use strict';
+
+class TestComponent extends ComponentBase {
+	public descriptor: IComponentDescriptor;
+
+	constructor(public modelStore: IModelStore, id: string) {
+		super(undefined);
+		this.descriptor = modelStore.createComponentDescriptor('TestComponent', id);
+		this.baseInit();
+	}
+
+	ngOnInit() { }
+	setLayout() { }
+
+	public addValidation(validation: () => boolean | Thenable<boolean>) {
+		this._validations.push(validation);
+	}
+}
+
+class TestContainer extends ContainerBase<TestComponent> {
+	public descriptor: IComponentDescriptor;
+
+	constructor(public modelStore: IModelStore, id: string) {
+		super(undefined);
+		this.descriptor = modelStore.createComponentDescriptor('TestContainer', id);
+		this._changeRef = {
+			detectChanges: () => undefined
+		} as ChangeDetectorRef;
+		this.baseInit();
+	}
+
+	ngOnInit() { }
+	setLayout() { }
+
+	public addValidation(validation: () => boolean | Thenable<boolean>) {
+		this._validations.push(validation);
+	}
+}
+
+suite('ComponentBase Validation Tests', () => {
+	let testComponent: TestComponent;
+	let testContainer: TestContainer;
+	let modelStore: IModelStore;
+
+	setup(() => {
+		modelStore = new ModelStore();
+		testComponent = new TestComponent(modelStore, 'testComponent');
+		testContainer = new TestContainer(modelStore, 'testContainer');
+	});
+
+	test('Component validation runs external validations stored in the model store', done => {
+		assert.equal(testComponent.valid, true, 'Test component validity did not default to true');
+		let validationCalls = 0;
+		modelStore.registerValidationCallback(componentId => {
+			validationCalls += 1;
+			return Promise.resolve(false);
+		});
+
+		testComponent.validate().then(valid => {
+			try {
+				assert.equal(validationCalls, 1, 'External validation was not called once');
+				assert.equal(valid, false, 'Validate call did not return correct value from the external validation');
+				assert.equal(testComponent.valid, false, 'Validate call did not update the component valid property');
+				done();
+			} catch (err) {
+				done(err);
+			}
+		}, err => done(err));
+	});
+
+	test('Component validation runs default component validations', done => {
+		assert.equal(testComponent.valid, true, 'Test component validity did not default to true');
+		let validationCalls = 0;
+		testComponent.addValidation(() => {
+			validationCalls += 1;
+			return false;
+		});
+
+		testComponent.validate().then(valid => {
+			try {
+				assert.equal(validationCalls, 1, 'Default validation was not called once');
+				assert.equal(valid, false, 'Validate call did not return correct value from the default validation');
+				assert.equal(testComponent.valid, false, 'Validate call did not update the component valid property');
+				done();
+			} catch (err) {
+				done(err);
+			}
+		}, err => done(err));
+	});
+
+	test('Container validation reflects child component validity', done => {
+		assert.equal(testContainer.valid, true, 'Test container validity did not default to true');
+		testContainer.addToContainer(testComponent.descriptor, undefined);
+		testComponent.addValidation(() => false);
+		testComponent.validate().then(() => {
+			testContainer.validate().then(valid => {
+				assert.equal(valid, false, 'Validate call did not return correct value for container child validation');
+				assert.equal(testContainer.valid, false, 'Validate call did not update the container valid property');
+				done();
+			}, err => done(err));
+		}, err => done(err));
+	});
+
+	test('Container child validity changes cause the parent container validity to change', done => {
+		testContainer.registerEventHandler(event => {
+			try {
+				if (event.eventType === ComponentEventType.validityChanged) {
+					assert.equal(testContainer.valid, false, 'Test container validity did not change to false when child validity changed');
+					assert.equal(event.args, false, 'ValidityChanged event did not contain the updated container validity');
+					done();
+				}
+			} catch (err) {
+				done(err);
+			}
+		});
+		testComponent.addValidation(() => false);
+		testContainer.addToContainer(testComponent.descriptor, undefined);
+		testComponent.validate();
+	});
+});

--- a/src/sqltest/workbench/api/extHostModelView.test.ts
+++ b/src/sqltest/workbench/api/extHostModelView.test.ts
@@ -68,13 +68,9 @@ suite('ExtHostModelView Validation Tests', () => {
 		extHostModelView.$registerWidget(handle, widgetId, undefined, undefined);
 	});
 
-	test('The validity of a component and its containers gets set when it is initialized', done => {
+	test('The validity of a component gets set when it is initialized', done => {
 		try {
-			assert.equal(modelView.valid, false, 'modelView was not marked as invalid');
 			assert.equal(inputBox.valid, false, 'inputBox was not marked as invalid');
-			assert.equal(formContainer.valid, false, 'formContainer was not marked as invalid');
-			assert.equal(flexContainer.valid, false, 'flexContainer was not marked as invalid');
-			assert.equal(dropDownBox.valid, true, 'dropDownBox was marked as invalid');
 			done();
 		} catch (err) {
 			done(err);
@@ -84,10 +80,7 @@ suite('ExtHostModelView Validation Tests', () => {
 	test('Containers reflect validity changes of contained components', done => {
 		try {
 			inputBox.value = validText;
-			assert.equal(modelView.valid, true, 'modelView was not marked as valid');
 			assert.equal(inputBox.valid, true, 'inputBox was not marked as valid');
-			assert.equal(formContainer.valid, true, 'formContainer was not marked as valid');
-			assert.equal(flexContainer.valid, true, 'flexContainer was not marked as valid');
 			done();
 		} catch (err) {
 			done(err);

--- a/src/sqltest/workbench/api/extHostModelView.test.ts
+++ b/src/sqltest/workbench/api/extHostModelView.test.ts
@@ -38,7 +38,6 @@ suite('ExtHostModelView Validation Tests', () => {
 			$setLayout: (handle: number, componentId: string, layout: any) => undefined,
 			$setProperties: (handle: number, componentId: string, properties: { [key: string]: any }) => undefined,
 			$registerEvent: (handle: number, componentId: string) => undefined,
-			$notifyValidation: (handle: number, componentId: string, valid: boolean) => undefined,
 			dispose: () => undefined
 		}, MockBehavior.Loose);
 		let mainContext = <IMainContext>{
@@ -47,7 +46,6 @@ suite('ExtHostModelView Validation Tests', () => {
 		mockProxy.setup(x => x.$initializeModel(It.isAny(), It.isAny())).returns(() => Promise.resolve());
 		mockProxy.setup(x => x.$registerEvent(It.isAny(), It.isAny())).returns(() => Promise.resolve());
 		mockProxy.setup(x => x.$setProperties(It.isAny(), It.isAny(), It.isAny())).returns(() => Promise.resolve());
-		mockProxy.setup(x => x.$notifyValidation(It.isAny(), It.isAny(), It.isAny())).returns(() => Promise.resolve());
 
 		// Register a model view of an input box and drop down box inside a form container inside a flex container
 		extHostModelView = new ExtHostModelView(mainContext);

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -355,6 +355,14 @@ export class InputBox extends Widget {
 		if (this.validation) {
 			result = this.validation(this.value);
 
+			// {{SQL CARBON EDIT}}
+			if (!result && this.inputElement.validationMessage) {
+				result = {
+					content: this.inputElement.validationMessage,
+					type: MessageType.ERROR
+				};
+			}
+
 			if (!result) {
 				this.inputElement.removeAttribute('aria-invalid');
 				this.hideMessage();

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -32,6 +32,7 @@ export interface IInputOptions extends IInputBoxStyles {
 	// {{SQL CARBON EDIT}} Candidate for addition to vscode
 	min?: string;
 	max?: string;
+	useDefaultValidation?: boolean;
 }
 
 export interface IInputBoxStyles {
@@ -356,7 +357,7 @@ export class InputBox extends Widget {
 			result = this.validation(this.value);
 
 			// {{SQL CARBON EDIT}}
-			if (!result && this.inputElement.validationMessage) {
+			if (!result && this.options.useDefaultValidation && this.inputElement.validationMessage) {
 				result = {
 					content: this.inputElement.validationMessage,
 					type: MessageType.ERROR


### PR DESCRIPTION
This PR adds default validations for model view input boxes by allowing the user to set whether the input box is required and set the detailed type of the input box if desired.

The code moves all responsibility for validating model view components to the main thread model view code from the extension host, with the main thread calling out to the extension host to run extension-provided validations when needed.

Here's a screenshot of a dialog created using these features as well as the code below (note that the password field is marked invalid because it is required):

<img width="483" alt="Dialog containing various form components including a number component that has an invalid value and is showing an error message, and a password component that is required but has no value" src="https://user-images.githubusercontent.com/3758704/39946301-866acfd8-5522-11e8-90d4-212ae83ee7f8.png">

```
sqlops.ui.registerModelViewProvider('dialogContent1', async view => {
	let inputBox1 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'color' })
		.component();
	let inputBox2 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'date' })
		.component();
	let inputBox3 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'datetime-local' })
		.component();
	let inputBox4 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'email' })
		.component();
	let inputBox5 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'month' })
		.component();
	let inputBox6 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'number' })
		.component();
	let inputBox7 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'password', required: true })
		.component();
	let inputBox8 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'range' })
		.component();
	let inputBox9 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'search' })
		.component();
	let inputBox10 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'text' })
		.component();
	let inputBox11 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'time' })
		.component();
	let inputBox12 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'url' })
		.component();
	let inputBox13 = view.modelBuilder.inputBox()
		.withProperties({ inputType: 'week' })
		.component();
	let formModel = view.modelBuilder.formContainer()
		.withFormItems([{
			component: inputBox1,
			title: 'Color'
		},
		{
			component: inputBox2,
			title: 'Date'
		},
		{
			component: inputBox3,
			title: 'Datetime-local'
		},
		{
			component: inputBox4,
			title: 'Email'
		},
		{
			component: inputBox5,
			title: 'Month'
		},
		{
			component: inputBox6,
			title: 'Number'
		},
		{
			component: inputBox7,
			title: 'Password'
		},
		{
			component: inputBox8,
			title: 'Range'
		},
		{
			component: inputBox9,
			title: 'Search'
		},
		{
			component: inputBox10,
			title: 'Text'
		},
		{
			component: inputBox11,
			title: 'Time'
		},
		{
			component: inputBox12,
			title: 'Url'
		},
		{
			component: inputBox13,
			title: 'Week'
		},
	]).component();
	await view.initializeModel(formModel);
});

sqlops.ui.registerModelViewProvider('dialogContent2', async view => {
	let inputBox = view.modelBuilder.inputBox()
		.withValidation(component => component.value === 'valid')
		.component();
	let formModel = view.modelBuilder.formContainer()
		.withFormItems([{
			component: inputBox,
			title: 'Enter "valid"'
		}]).component();
	await view.initializeModel(formModel);
});

vscode.commands.registerCommand('mssql.openTestDialog', () => {
	let dialog = sqlops.window.modelviewdialog.createDialog('Test dialog');
	let tab1 = sqlops.window.modelviewdialog.createTab('Tab 1');
	tab1.content = 'dialogContent1';
	let tab2 = sqlops.window.modelviewdialog.createTab('Tab 2');
	tab2.content = 'dialogContent2';
	dialog.content = [tab1, tab2];
	dialog.onValidityChanged(valid => {
		console.log('dialog is ' + dialog.valid + ', validity is ' + valid);
		dialog.okButton.enabled = valid;
	});
	sqlops.window.modelviewdialog.openDialog(dialog);
});
```