### PR TITLE
Fix form layout spacing

### DIFF
--- a/src/sql/parts/modelComponents/formContainer.component.ts
+++ b/src/sql/parts/modelComponents/formContainer.component.ts
@@ -37,30 +37,34 @@ class FormItem {
 				<ng-container *ngIf="isFormComponent(item)">
 					<ng-container *ngIf="isHorizontal(item)">
 						<div class="form-cell">{{getItemTitle(item)}}</div>
-						<div class="form-cell" [style.width]="getComponentWidth(item)">
-							<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore">
-							</model-component-wrapper>
-						</div>
-						<div *ngIf="itemHasActions(item)" class="form-cell">
-								<ng-container *ngFor="let actionItem of getActionComponents(item)">
-									<model-component-wrapper  [descriptor]="actionItem.descriptor" [modelStore]="modelStore" >
+						<div class="form-cell">
+							<div class="form-component-container">
+								<div [style.width]="getComponentWidth(item)" [ngClass]="{'form-input-flex': !getComponentWidth(item)}">
+									<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore">
 									</model-component-wrapper>
-								</ng-container>
+								</div>
+								<div *ngIf="itemHasActions(item)" class="form-component-actions">
+										<ng-container *ngFor="let actionItem of getActionComponents(item)">
+											<model-component-wrapper  [descriptor]="actionItem.descriptor" [modelStore]="modelStore" >
+											</model-component-wrapper>
+										</ng-container>
+								</div>
+							</div>
 						</div>
 					</ng-container>
-					<ng-container *ngIf="isVertical(item)">
-						<div class="form-item-row form-item-title">{{getItemTitle(item)}}</div>
+					<div class="form-vertical-container" *ngIf="isVertical(item)">
+						<div class="form-item-row">{{getItemTitle(item)}}</div>
 						<div class="form-item-row" [style.width]="getComponentWidth(item)">
 							<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore" [style.width]="getComponentWidth(item)">
 							</model-component-wrapper>
-							<div *ngIf="itemHasActions(item)" class="form-actions-table">
+						</div>
+						<div *ngIf="itemHasActions(item)" class="form-item-row form-actions-table form-item-last-row">
 								<div *ngFor="let actionItem of getActionComponents(item)" class="form-actions-cell" >
 									<model-component-wrapper  [descriptor]="actionItem.descriptor" [modelStore]="modelStore">
 									</model-component-wrapper>
 								</div>
 							</div>
-						</div>
-					</ng-container>
+					</div>
 				</ng-container>
 			</div>
 			</ng-container>
@@ -114,12 +118,12 @@ export default class FormContainer extends ContainerBase<FormItemLayout> impleme
 
 	private getFormWidth(item: FormItem): string {
 		let itemConfig = item.config;
-		return itemConfig && itemConfig.width ? +itemConfig.width + 'px' : '400px';
+		return itemConfig && itemConfig.width ? +itemConfig.width + 'px' : '100%';
 	}
 
 	private getComponentWidth(item: FormItem): string {
 		let itemConfig = item.config;
-		return itemConfig ? itemConfig.componentWidth + 'px' : '';
+		return (itemConfig && itemConfig.componentWidth) ? itemConfig.componentWidth + 'px' : '';
 	}
 
 	private getItemTitle(item: FormItem): string {

--- a/src/sql/parts/modelComponents/formContainer.component.ts
+++ b/src/sql/parts/modelComponents/formContainer.component.ts
@@ -42,12 +42,10 @@ class FormItem {
 							</model-component-wrapper>
 						</div>
 						<div *ngIf="itemHasActions(item)" class="form-cell">
-							<div class="form-actions-table">
-								<div *ngFor="let actionItem of getActionComponents(item)" class="form-cell" >
+								<ng-container *ngFor="let actionItem of getActionComponents(item)">
 									<model-component-wrapper  [descriptor]="actionItem.descriptor" [modelStore]="modelStore" >
 									</model-component-wrapper>
-								</div>
-							</div>
+								</ng-container>
 						</div>
 					</ng-container>
 					<ng-container *ngIf="isVertical(item)">
@@ -55,14 +53,12 @@ class FormItem {
 						<div class="form-item-row" [style.width]="getComponentWidth(item)">
 							<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore" [style.width]="getComponentWidth(item)">
 							</model-component-wrapper>
-						</div>
-						<div *ngIf="itemHasActions(item)" class="form-actions-table">
-
-							<div *ngFor="let actionItem of getActionComponents(item)" class="form-actions-cell" >
-								<model-component-wrapper  [descriptor]="actionItem.descriptor" [modelStore]="modelStore">
-								</model-component-wrapper>
+							<div *ngIf="itemHasActions(item)" class="form-actions-table">
+								<div *ngFor="let actionItem of getActionComponents(item)" class="form-actions-cell" >
+									<model-component-wrapper  [descriptor]="actionItem.descriptor" [modelStore]="modelStore">
+									</model-component-wrapper>
+								</div>
 							</div>
-
 						</div>
 					</ng-container>
 				</ng-container>

--- a/src/sql/parts/modelComponents/formLayout.css
+++ b/src/sql/parts/modelComponents/formLayout.css
@@ -12,22 +12,34 @@
 
 .form-row {
 	display: table-row;
-	width: 100px;
 }
 
 .form-item-row {
-	padding-bottom: 20px;
-	width: 300px;
+	padding-bottom: 5px;
 }
 
-.form-item-row.form-item-title {
-	padding-bottom: 5px;
+.form-vertical-container {
+	padding-bottom: 15px;
+	width: 100%;
 }
 
 .form-cell {
 	padding-bottom: 20px;
 	padding-right: 5px;
 	display: table-cell;
+}
+
+.form-component-container {
+	display: flex;
+	flex-direction: row;
+}
+
+.form-input-flex {
+	flex: 1;
+}
+
+.form-component-actions {
+	padding-left: 5px;
 }
 
 .form-actions-cell {

--- a/src/sql/parts/modelComponents/formLayout.css
+++ b/src/sql/parts/modelComponents/formLayout.css
@@ -1,32 +1,31 @@
 
 .form-table {
-	width:400px;
-	display:table;
-	padding: 30px;
+	width: 100%;
+	display: table;
+	padding: 10px 30px 0px 30px;
+	box-sizing: border-box;
 }
 
 .form-actions-table {
-	display:table;
+	display: table;
 }
 
 .form-row {
 	display: table-row;
 	width: 100px;
-	padding-bottom: 10px;
 }
 
 .form-item-row {
-	padding-bottom: 5px;
+	padding-bottom: 20px;
 	width: 300px;
 }
 
-.form-item-title {
-
-	padding-top: 20px;
+.form-item-row.form-item-title {
+	padding-bottom: 5px;
 }
 
 .form-cell {
-	padding-top: 20px;
+	padding-bottom: 20px;
 	padding-right: 5px;
 	display: table-cell;
 }


### PR DESCRIPTION
Fixes #1396 

Also changed the layout so that having buttons on one form input don't cause all the other inputs to get smaller, and so that inputs will take up 100% of the available space by default instead of 400px (since the user can set a width if desired).

**Before:**
Horizontal
![Old horizontal form layout with blank space at the top and inputs that don't extend all the way to the edge of the dialog](https://user-images.githubusercontent.com/3758704/39951105-a5a94e6a-553b-11e8-83ee-3408874dfdf6.png)

Vertical
![Old vertical form layout with blank space at the top and inputs that don't extend all the way to the edge of the dialog](https://user-images.githubusercontent.com/3758704/39951114-bf650fba-553b-11e8-9e20-5dda0be672ae.png)

**After:**
Horizontal
![New horizontal form layout with no blank space at the top and inputs that extend all the way to the edge of the dialog](https://user-images.githubusercontent.com/3758704/39951126-da70b1f6-553b-11e8-880c-a8c055cd872e.png)

Vertical
![New vertical form layout with no blank space at the top and inputs that extend all the way to the edge of the dialog](https://user-images.githubusercontent.com/3758704/39951130-e8913828-553b-11e8-8d0e-498a7acdf507.png)
