### PR TITLE
Rearrange done and cancel buttons and dispose dialogs correctly

### DIFF
--- a/src/sql/parts/modelComponents/componentBase.ts
+++ b/src/sql/parts/modelComponents/componentBase.ts
@@ -55,6 +55,7 @@ export abstract class ComponentBase extends Disposable implements IComponent, On
 		if (this.modelStore) {
 			this.modelStore.unregisterComponent(this);
 		}
+		this.dispose();
 	}
 
 	ngOnDestroy(): void {

--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -66,12 +66,12 @@ export class DialogModal extends Modal {
 			});
 		}
 
-		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel(), false);
-		this.updateButtonElement(this._cancelButton, this._dialog.cancelButton);
-		this._dialog.cancelButton.registerClickEvent(this._onCancel.event);
 		this._doneButton = this.addDialogButton(this._dialog.okButton, () => this.done(), false);
 		this.updateButtonElement(this._doneButton, this._dialog.okButton);
 		this._dialog.okButton.registerClickEvent(this._onDone.event);
+		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel(), false);
+		this.updateButtonElement(this._cancelButton, this._dialog.cancelButton);
+		this._dialog.cancelButton.registerClickEvent(this._onCancel.event);
 	}
 
 	private addDialogButton(button: DialogButton, onSelect: () => void = () => undefined, registerClickEvent: boolean = true): Button {

--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -67,10 +67,8 @@ export class DialogModal extends Modal {
 		}
 
 		this._doneButton = this.addDialogButton(this._dialog.okButton, () => this.done(), false);
-		this.updateButtonElement(this._doneButton, this._dialog.okButton);
 		this._dialog.okButton.registerClickEvent(this._onDone.event);
 		this._cancelButton = this.addDialogButton(this._dialog.cancelButton, () => this.cancel(), false);
-		this.updateButtonElement(this._cancelButton, this._dialog.cancelButton);
 		this._dialog.cancelButton.registerClickEvent(this._onCancel.event);
 	}
 
@@ -84,6 +82,7 @@ export class DialogModal extends Modal {
 			this.updateButtonElement(buttonElement, button);
 		});
 		attachButtonStyler(buttonElement, this._themeService);
+		this.updateButtonElement(buttonElement, button);
 		return buttonElement;
 	}
 

--- a/src/sql/platform/dialog/dialogPane.ts
+++ b/src/sql/platform/dialog/dialogPane.ts
@@ -19,9 +19,8 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import Event, { Emitter } from 'vs/base/common/event';
 
 export class DialogPane extends Disposable implements IThemable {
-	private _activeTabIndex: number;
 	private _tabbedPanel: TabbedPanel;
-	private _moduleRef: NgModuleRef<{}>;
+	private _moduleRefs: NgModuleRef<{}>[] = [];
 
 	// Validation
 	private _modelViewValidityMap = new Map<string, boolean>();
@@ -72,7 +71,6 @@ export class DialogPane extends Disposable implements IThemable {
 			}
 		});
 
-		this._activeTabIndex = 0;
 		return this._body;
 	}
 
@@ -89,7 +87,7 @@ export class DialogPane extends Disposable implements IThemable {
 				validityChangedCallback: (valid: boolean) => this._setValidity(modelViewId, valid)
 			} as DialogComponentParams,
 			undefined,
-			(moduleRef) => this._moduleRef = moduleRef);
+			(moduleRef) => this._moduleRefs.push(moduleRef));
 	}
 
 	public show(): void {
@@ -125,6 +123,6 @@ export class DialogPane extends Disposable implements IThemable {
 
 	public dispose() {
 		super.dispose();
-		this._moduleRef.destroy();
+		this._moduleRefs.forEach(moduleRef => moduleRef.destroy());
 	}
 }


### PR DESCRIPTION
This PR fixes 2 small issues with model view dialogs:
- The done and cancel buttons were in the wrong order compared to the rest of our UI (e.g. the connection dialog) - fixes #1416
- Dialogs with multiple tabs only destroyed one of the tabs when closed - part of #1414 but we still need to call close on each model view