### PR TITLE
Make Webview support official

### DIFF
--- a/src/vs/workbench/api/node/extHost.api.impl.ts
+++ b/src/vs/workbench/api/node/extHost.api.impl.ts
@@ -407,9 +407,10 @@ export function createApiFactory(
 			registerDecorationProvider: proposedApiFunction(extension, (provider: vscode.DecorationProvider) => {
 				return extHostDecorations.registerDecorationProvider(provider, extension.id);
 			}),
-			createWebview: proposedApiFunction(extension, (uri: vscode.Uri, title: string, column: vscode.ViewColumn, options: vscode.WebviewOptions) => {
+			// {{SQL CARBON EDIT}}
+			createWebview(uri: vscode.Uri, title: string, column: vscode.ViewColumn, options: vscode.WebviewOptions): vscode.Webview {
 				return extHostWebviews.createWebview(uri, title, column, options);
-			}),
+			},
 			onDidChangeActiveEditor: proposedApiFunction(extension, (listener, thisArg?, disposables?) => {
 				return extHostDocumentsAndEditors.onDidChangeActiveEditor(listener, thisArg, disposables);
 			})


### PR DESCRIPTION
This is needed to enable testing of webview-based experiences.

This was made an official API in the latest VSCode release, so on next VSCode merge this will be standard anyhow.