### PR TITLE
Bump tools service for recent fixes

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.4.0-alpha.31",
+	"version": "1.4.0-alpha.34",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.1.zip",
 		"Windows_64": "win-x64-netcoreapp2.1.zip",


### PR DESCRIPTION
Brings in recent tools service changes including adding the `between` keyword (https://github.com/Microsoft/sqlopsstudio/issues/1372) and catching parser errors (https://github.com/Microsoft/sqlopsstudio/issues/1395)