### PR TITLE
Change VS Code to SQL Ops Studio in screen reader dialog

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -1285,7 +1285,8 @@ class ScreenReaderDetectedExplanation {
 		}));
 		domNode.appendChild(closeBtn);
 
-		const question = $('p.question', {}, nls.localize('screenReaderDetectedExplanation.question', "Are you using a screen reader to operate VS Code?"));
+		// {{SQL CARBON EDIT}}
+		const question = $('p.question', {}, nls.localize('screenReaderDetectedExplanation.question', "Are you using a screen reader to operate SQL Operations Studio?"));
 		domNode.appendChild(question);
 
 		const buttonContainer = $('div.buttons');
@@ -1317,7 +1318,8 @@ class ScreenReaderDetectedExplanation {
 		const hr = $('hr');
 		domNode.appendChild(hr);
 
-		const explanation1 = $('p.body1', {}, nls.localize('screenReaderDetectedExplanation.body1', "VS Code is now optimized for usage with a screen reader."));
+		// {{SQL CARBON EDIT}}
+		const explanation1 = $('p.body1', {}, nls.localize('screenReaderDetectedExplanation.body1', "SQL Operations Studio is now optimized for usage with a screen reader."));
 		domNode.appendChild(explanation1);
 
 		const explanation2 = $('p.body2', {}, nls.localize('screenReaderDetectedExplanation.body2', "Some editor features will have different behaviour: e.g. word wrapping, folding, etc."));


### PR DESCRIPTION
Fixes the VS Code string in the below dialog.

![screen](https://user-images.githubusercontent.com/599935/40262650-d7150af2-5abd-11e8-8658-eb0a4a5e8a72.png)
