### PR TITLE
Only allow model view components to be added once

### DIFF
--- a/src/sql/parts/modelComponents/componentBase.ts
+++ b/src/sql/parts/modelComponents/componentBase.ts
@@ -156,6 +156,9 @@ export abstract class ContainerBase<T> extends ComponentBase {
 
 	/// IComponent container-related implementation
 	public addToContainer(componentDescriptor: IComponentDescriptor, config: any): void {
+		if (this.items.some(item => item.descriptor.id === componentDescriptor.id && item.descriptor.type === componentDescriptor.type)) {
+			return;
+		}
 		this.items.push(new ItemDescriptor(componentDescriptor, config));
 		this.modelStore.eventuallyRunOnComponent(componentDescriptor.id, component => component.registerEventHandler(event => {
 			if (event.eventType === ComponentEventType.validityChanged) {


### PR DESCRIPTION
Right now model view components can be added to a container more than once, which creates a bug if you call `addItem` on a container and then later initialize a model view with that container as its root container.

The fix is to only allow each unique component to be added to a container once, based on the component ID and type.

Fixes #1410 