### PR TITLE
run query shortcut key alt+x added

### DIFF
--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -118,6 +118,16 @@ actionRegistry.registerWorkbenchAction(
 
 actionRegistry.registerWorkbenchAction(
 	new SyncActionDescriptor(
+		RunCurrentQueryKeyboardAction,
+		RunCurrentQueryKeyboardAction.ID,
+		RunCurrentQueryKeyboardAction.LABEL,
+		{ primary: KeyMod.Alt | KeyCode.KEY_X }
+	),
+	RunCurrentQueryKeyboardAction.LABEL
+);
+
+actionRegistry.registerWorkbenchAction(
+	new SyncActionDescriptor(
 		RunCurrentQueryWithActualPlanKeyboardAction,
 		RunCurrentQueryWithActualPlanKeyboardAction.ID,
 		RunCurrentQueryWithActualPlanKeyboardAction.LABEL


### PR DESCRIPTION
in sql server management studio has shortcut key alt+x for run query. but there is no. i added that shortcut key