### PR TITLE
Fix for double clicking column handle in results table

### DIFF
--- a/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/autoSizeColumns.plugin.ts
@@ -67,7 +67,7 @@ export class AutoColumnSize<T> implements Slick.Plugin<T> {
 		let rowEl = this.createRow(columnDef);
 		let data = this._grid.getData();
 		let viewPort = this._grid.getViewport();
-		let start = Math.max(0, viewPort.top + 1);
+		let start = Math.max(0, viewPort.top);
 		let end = Math.min(data.getLength(), viewPort.bottom);
 		for (let i = start; i < end; i++) {
 			texts.push(data.getItem(i)[columnDef.field]);


### PR DESCRIPTION
Where the column width would not update correctly when the longest row item is the top item in the viewPort.

This can be used to test this issue.
-- IF OBJECT_ID('tempdb..#tmp') IS NOT NULL BEGIN DROP TABLE #tmp END

CREATE TABLE #tmp (
    ColumnName VARCHAR(50)
)

INSERT INTO #tmp
(ColumnName)
VALUES
('S')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Short')
,('Longer')
,('This is the longest varchar')

SELECT *
FROM #tmp
ORDER BY LEN(ColumnName) DESC
-- ORDER BY LEN(ColumnName) ASC