### PR TITLE
Fixed error when tab is closed

### DIFF
--- a/src/sql/parts/dashboard/common/dashboardPage.component.ts
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.ts
@@ -332,7 +332,6 @@ export abstract class DashboardPage extends AngularDisposable {
 	public handleTabClose(tab: TabComponent): void {
 		let index = this.tabs.findIndex(i => i.id === tab.identifier);
 		this.tabs.splice(index, 1);
-		this._cd.detectChanges();
 		this.angularEventingService.sendAngularEvent(this.dashboardService.getUnderlyingUri(), AngularEventType.CLOSE_TAB, { id: tab.identifier });
 	}
 }


### PR DESCRIPTION
Fixed a bug reported by @alanrenmsft. If a tab was open and then closed, then SQL Operations quietly threw an error in the background - 
```
C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\zone.js\dist\zone-node.js:2251 ERROR Error: ViewDestroyedError: Attempt to use a destroyed view: detectChanges
    at viewDestroyedError (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:8665:12)
    at Object.debugUpdateDirectives [as updateDirectives] (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:12810:15)
    at checkAndUpdateView (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:12151:14)
    at callWithDebugContext (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:13213:42)
    at Object.debugCheckAndUpdateView [as checkAndUpdateView] (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:12753:12)
    at ViewRef_.detectChanges (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:10225:63)
    at TabComponent.set [as active] (file:///C:/Users/adbist/Desktop/SQL_Tools/sqlopsstudio/out/sql/base/browser/ui/panel/tab.component.js:35:26)
    at file:///C:/Users/adbist/Desktop/SQL_Tools/sqlopsstudio/out/sql/base/browser/ui/panel/panel.component.js:122:49
    at ZoneDelegate.invoke (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\zone.js\dist\zone-node.js:388:26)
    at Object.onInvoke (C:\Users\adbist\Desktop\SQL_Tools\sqlopsstudio\node_modules\@angular\core\bundles\core.umd.js:4156:37)
```
It was because `this._cd.detectChanges()` was getting called twice - once in the `DashboardPage` and once in `TabComponent`. This is now fixed.