### PR TITLE
Fix error when calling layout on single-tab dialog

### DIFF
--- a/src/sql/platform/dialog/dialogPane.ts
+++ b/src/sql/platform/dialog/dialogPane.ts
@@ -20,7 +20,6 @@ import * as DOM from 'vs/base/browser/dom';
 import { Builder } from 'vs/base/browser/builder';
 import { IThemable } from 'vs/platform/theme/common/styler';
 import { Disposable } from 'vs/base/common/lifecycle';
-import { Event, Emitter } from 'vs/base/common/event';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 export class DialogPane extends Disposable implements IThemable {
@@ -82,7 +81,9 @@ export class DialogPane extends Disposable implements IThemable {
 	}
 
 	public layout(): void {
-		this._tabbedPanel.layout(new DOM.Dimension(DOM.getContentWidth(this._body), DOM.getContentHeight(this._body)));
+		if (this._tabbedPanel) {
+			this._tabbedPanel.layout(new DOM.Dimension(DOM.getContentWidth(this._body), DOM.getContentHeight(this._body)));
+		}
 	}
 
 	/**


### PR DESCRIPTION
We currently get an error when opening dialogs that only have 1 tab due to `this._tabbedPanel` being undefined when `layout()` gets called. It doesn't seem to impact functionality at all, but this change fixes it