### PR TITLE
Update sqlservices example for new webview messages API

### DIFF
--- a/samples/sqlservices/README.md
+++ b/samples/sqlservices/README.md
@@ -1,1 +1,7 @@
 This is a sample extension that will show some basic model-backed UI scenarios. The long-term goal is to use SQL Service querying (e.g. see if Agent and other services are running) and visualize in interesting ways. Additional suggestions for improving this sample are welcome.
+
+## Useful development commands
+- Download `sqlops` API typings for local development: `gulp copytypings`
+- Install dependencies: `npm install`
+- Compile: `gulp compile` or `gulp watch` to automatically recompile changes
+- Package: `gulp package`. The packaged .vsix will be placed at `out/sqlservices.vsix`.

--- a/samples/sqlservices/package.json
+++ b/samples/sqlservices/package.json
@@ -99,5 +99,9 @@
         "vscode": "^1.1.14",
         "@types/handlebars": "^4.0.11",
         "vsce": "1.36.2"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Microsoft/sqlopsstudio/tree/master/samples/sqlservices"
     }
 }

--- a/samples/sqlservices/src/controllers/button.html
+++ b/samples/sqlservices/src/controllers/button.html
@@ -10,8 +10,9 @@
     <body>
         <button onclick="count()">Count</button>
         <script>
+            const vscode = acquireVsCodeApi();
             function count() {
-                parent.postMessage('count', '*');
+                vscode.postMessage('count', '*');
             }
         </script>
     </body>

--- a/samples/sqlservices/tasks/packagetasks.js
+++ b/samples/sqlservices/tasks/packagetasks.js
@@ -34,3 +34,7 @@ let buildPackage = function(packageName) {
     console.log(command);
     return exec(command);
 };
+
+gulp.task('package', async () => {
+    await buildPackage('out/sqlservices.vsix');
+});


### PR DESCRIPTION
Our code for web view message passing is still fine but VS Code's API updated to that you have to call `acquireVsCodeAPI()` in the web view's HTML instead of accessing the API directly through `parent`.

I also updated the sqlservices extension a bit to add some info to the readme and a gulp task to generate the .vsix

Fixes #1566 