### PR TITLE
Fix custom UI validation bugs

### DIFF
--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -407,9 +407,9 @@ class ComponentWrapper implements sqlops.Component {
 	public onEvent(eventArgs: IComponentEventArgs) {
 		if (eventArgs && eventArgs.eventType === ComponentEventType.PropertiesChanged) {
 			this.properties = eventArgs.args;
-		}
-		else if (eventArgs && eventArgs.eventType === ComponentEventType.validityChanged) {
+		} else if (eventArgs && eventArgs.eventType === ComponentEventType.validityChanged) {
 			this._valid = eventArgs.args;
+			this._onValidityChangedEmitter.fire(this._valid);
 		} else if (eventArgs) {
 			let emitter = this._emitterMap.get(eventArgs.eventType);
 			if (emitter) {

--- a/src/sqltest/workbench/api/extHostModelView.test.ts
+++ b/src/sqltest/workbench/api/extHostModelView.test.ts
@@ -118,4 +118,14 @@ suite('ExtHostModelView Validation Tests', () => {
 		});
 		assert.equal(inputBox.valid, true, 'Input box did not update validity to true based on the validityChanged event');
 	});
+
+	test('Main thread validityChanged events cause component to fire validity changed events', () => {
+		let validityFromEvent: boolean = undefined;
+		inputBox.onValidityChanged(valid => validityFromEvent = valid);
+		extHostModelView.$handleEvent(handle, inputBox.id, {
+			eventType: ComponentEventType.validityChanged,
+			args: false
+		});
+		assert.equal(validityFromEvent, false, 'Main thread validityChanged event did not cause component to fire its own event');
+	});
 });

--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -364,7 +364,11 @@ export class InputBox extends Widget {
 				};
 			}
 
-			if (!errorMsg) {
+			if (errorMsg) {
+				this.inputElement.setAttribute('aria-invalid', 'true');
+				this.showMessage(errorMsg);
+			}
+			else if (this.inputElement.hasAttribute('aria-invalid')) {
 				this.inputElement.removeAttribute('aria-invalid');
 				this.hideMessage();
 			}


### PR DESCRIPTION
Fixes #1581 

There were 2 problems here. One was that input box validation broke because I resolved a merge conflict incorrectly when merging the VS Code release. The other was that my recent refactoring to how components handle events inadvertently stopped the `onValidityChanged` event from ever firing for any component.