### PR TITLE
Add wizard navigation validator

### DIFF
--- a/src/sql/platform/dialog/dialogTypes.ts
+++ b/src/sql/platform/dialog/dialogTypes.ts
@@ -139,6 +139,7 @@ export class Wizard {
 	public readonly onPageAdded = this._pageAddedEmitter.event;
 	private _pageRemovedEmitter = new Emitter<WizardPage>();
 	public readonly onPageRemoved = this._pageRemovedEmitter.event;
+	private _navigationValidator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>;
 
 	constructor(public title: string) { }
 
@@ -190,5 +191,20 @@ export class Wizard {
 		let removedPage = this.pages[index];
 		this.pages.splice(index, 1);
 		this._pageRemovedEmitter.fire(removedPage);
+	}
+
+	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>): void {
+		this._navigationValidator = validator;
+	}
+
+	public validateNavigation(newPage: number): Thenable<boolean> {
+		if (this._navigationValidator) {
+			return Promise.resolve(this._navigationValidator({
+				lastPage: this._currentPage,
+				newPage: newPage
+			}));
+		} else {
+			return Promise.resolve(true);
+		}
 	}
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -580,7 +580,7 @@ declare module 'sqlops' {
 				lastPage: number,
 
 				/**
-				 * The new page number
+				 * The new page number or undefined if the user is closing the wizard
 				 */
 				newPage: number
 			}
@@ -693,6 +693,16 @@ declare module 'sqlops' {
 				 * Close the wizard. Does nothing if the wizard is not open.
 				 */
 				close(): Thenable<void>;
+
+				/**
+				 * Register a callback that will be called when the user tries to navigate by
+				 * changing pages or clicking done. Only one callback can be registered at once, so
+				 * each registration call will clear the previous registration.
+				 * @param validator The callback that gets executed when the user tries to
+				 * navigate. Return true to allow the navigation to proceed, or false to
+				 * cancel it.
+				 */
+				registerNavigationValidator(validator: (pageChangeInfo: WizardPageChangeInfo) => boolean | Thenable<boolean>): void;
 			}
 		}
 	}

--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -217,6 +217,7 @@ class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
 	public customButtons: sqlops.window.modelviewdialog.Button[];
 	private _pageChangedEmitter = new Emitter<sqlops.window.modelviewdialog.WizardPageChangeInfo>();
 	public readonly onPageChanged = this._pageChangedEmitter.event;
+	private _navigationValidator: (info: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>;
 
 	constructor(public title: string, private _extHostModelViewDialog: ExtHostModelViewDialog) {
 		this.doneButton = this._extHostModelViewDialog.createButton(DONE_LABEL);
@@ -225,6 +226,7 @@ class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
 		this.nextButton = this._extHostModelViewDialog.createButton(NEXT_LABEL);
 		this.backButton = this._extHostModelViewDialog.createButton(PREVIOUS_LABEL);
 		this._extHostModelViewDialog.registerWizardPageInfoChangedCallback(this, info => this.handlePageInfoChanged(info));
+		this._currentPage = 0;
 		this.onPageChanged(info => this._currentPage = info.newPage);
 	}
 
@@ -252,6 +254,18 @@ class WizardImpl implements sqlops.window.modelviewdialog.Wizard {
 
 	public close(): Thenable<void> {
 		return this._extHostModelViewDialog.closeWizard(this);
+	}
+
+	public registerNavigationValidator(validator: (pageChangeInfo: sqlops.window.modelviewdialog.WizardPageChangeInfo) => boolean | Thenable<boolean>): void {
+		this._navigationValidator = validator;
+	}
+
+	public validateNavigation(info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
+		if (this._navigationValidator) {
+			return Promise.resolve(this._navigationValidator(info));
+		} else {
+			return Promise.resolve(true);
+		}
 	}
 
 	private handlePageInfoChanged(info: WizardPageEventInfo): void {
@@ -333,6 +347,11 @@ export class ExtHostModelViewDialog implements ExtHostModelViewDialogShape {
 				pages: pages
 			});
 		}
+	}
+
+	public $validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
+		let wizard = this._objectsByHandle.get(handle) as WizardImpl;
+		return wizard.validateNavigation(info);
 	}
 
 	public openDialog(dialog: sqlops.window.modelviewdialog.Dialog): void {

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -157,6 +157,7 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 			wizard.onPageChanged(info => this._proxy.$onWizardPageChanged(handle, info));
 			wizard.onPageAdded(() => this.handleWizardPageAddedOrRemoved(handle));
 			wizard.onPageRemoved(() => this.handleWizardPageAddedOrRemoved(handle));
+			wizard.registerNavigationValidator(info => this.validateNavigation(handle, info));
 			this._wizards.set(handle, wizard);
 		}
 
@@ -253,5 +254,9 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 	private handleWizardPageAddedOrRemoved(handle: number): void {
 		let wizard = this._wizards.get(handle);
 		this._proxy.$updateWizardPageInfo(handle, wizard.pages.map(page => this._wizardPageHandles.get(page)), wizard.currentPage);
+	}
+
+	private validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
+		return this._proxy.$validateNavigation(handle, info);
 	}
 }

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -556,6 +556,7 @@ export interface ExtHostModelViewDialogShape {
 	$onPanelValidityChanged(handle: number, valid: boolean): void;
 	$onWizardPageChanged(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): void;
 	$updateWizardPageInfo(handle: number, pageHandles: number[], currentPageIndex: number): void;
+	$validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean>;
 }
 
 export interface MainThreadModelViewDialogShape extends IDisposable {

--- a/src/sqltest/workbench/api/mainThreadModelViewDialog.test.ts
+++ b/src/sqltest/workbench/api/mainThreadModelViewDialog.test.ts
@@ -59,7 +59,8 @@ suite('MainThreadModelViewDialog Tests', () => {
 			$onButtonClick: handle => undefined,
 			$onPanelValidityChanged: (handle, valid) => undefined,
 			$onWizardPageChanged: (handle, info) => undefined,
-			$updateWizardPageInfo: (wizardHandle, pageHandles, currentPageIndex) => undefined
+			$updateWizardPageInfo: (wizardHandle, pageHandles, currentPageIndex) => undefined,
+			$validateNavigation: (handle, info) => undefined
 		});
 		let extHostContext = <IExtHostContext>{
 			getProxy: proxyType => mockExtHostModelViewDialog.object
@@ -315,5 +316,16 @@ suite('MainThreadModelViewDialog Tests', () => {
 			It.is(handle => handle === wizardHandle),
 			It.is(pageHandles => pageHandles.length === 1 && pageHandles[0] === page2Handle),
 			It.is(currentPage => currentPage === 0)), Times.once());
+	});
+
+	test('Creating a wizard adds a navigation validation that calls the extension host', () => {
+		mockExtHostModelViewDialog.setup(x => x.$validateNavigation(It.isAny(), It.isAny()));
+
+		// If I call validateNavigation on the wizard that gets created
+		let wizard: Wizard = (mainThreadModelViewDialog as any).getWizard(wizardHandle);
+		wizard.validateNavigation(1);
+
+		// Then the call gets forwarded to the extension host
+		mockExtHostModelViewDialog.verify(x => x.$validateNavigation(It.is(handle => handle === wizardHandle), It.is(info => info.newPage === 1)), Times.once());
 	});
 });


### PR DESCRIPTION
Adds a wizard navigation callback that gets called when the user tries to navigate to a new page or click the done button. The wizard developer can cancel the navigation by returning `false` from the callback. Here's a simple example that blocks the navigation every other time:

```
let shouldNavigate = true;
wizard.registerNavigationValidator(info => {
	shouldNavigate = !shouldNavigate;
	console.log('Attempting page change from ' + info.lastPage + ' to ' + info.newPage + '. Returning ' + shouldNavigate);
	return shouldNavigate;
});
```

Closes #1584 
