### PR TITLE
add a check for when the task is not valid

### DIFF
--- a/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
@@ -86,7 +86,7 @@ export class TasksWidget extends DashboardWidget implements IDashboardWidget, On
 			}).filter(i => !!i);
 		}
 
-		this._tasks = tasks.map(i => MenuRegistry.getCommand(i));
+		this._tasks = tasks.map(i => MenuRegistry.getCommand(i)).filter(v => !!v);
 	}
 
 	ngOnInit() {


### PR DESCRIPTION
Apparently it's possible for there to be a invalid task passed to the tasks widget. This clears those out.