### PR TITLE
fixed extension viewlet issues

### DIFF
--- a/src/vs/code/electron-browser/issue/issueReporterMain.ts
+++ b/src/vs/code/electron-browser/issue/issueReporterMain.ts
@@ -771,7 +771,8 @@ export class IssueReporter extends Disposable {
 			}
 		}
 
-		const queryStringPrefix = product.reportIssueUrl.indexOf('?') === -1 ? '?' : '&';
+		// {{SQL CARBON EDIT}}
+		const queryStringPrefix = repositoryUrl.indexOf('?') === -1 ? '?' : '&';
 		return `${repositoryUrl}${queryStringPrefix}title=${encodeURIComponent(issueTitle)}`;
 	}
 

--- a/src/vs/workbench/parts/extensions/browser/extensionsList.ts
+++ b/src/vs/workbench/parts/extensions/browser/extensionsList.ts
@@ -28,8 +28,9 @@ export interface ITemplateData {
 	element: HTMLElement;
 	icon: HTMLImageElement;
 	name: HTMLElement;
-	installCount: HTMLElement;
-	ratings: HTMLElement;
+	// {{SQL CARBON EDIT}}
+	//installCount: HTMLElement;
+	//ratings: HTMLElement;
 	author: HTMLElement;
 	description: HTMLElement;
 	extension: IExtension;
@@ -103,16 +104,19 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		const reloadAction = this.instantiationService.createInstance(ReloadAction);
 		const manageAction = this.instantiationService.createInstance(ManageExtensionAction);
 
+		// {{SQL CARBON EDIT}}
 		actionbar.push([updateAction, reloadAction, installAction, disabledStatusAction, maliciousStatusAction, manageAction], actionOptions);
-		const disposables = [versionWidget, installCountWidget, ratingsWidget, maliciousStatusAction, disabledStatusAction, updateAction, reloadAction, manageAction, actionbar, bookmarkStyler];
+		const disposables = [versionWidget, /*installCountWidget, ratingsWidget*/, maliciousStatusAction, disabledStatusAction, updateAction, reloadAction, manageAction, actionbar, bookmarkStyler];
 
 		return {
-			root, element, icon, name, installCount, ratings, author, description, disposables,
+			// {{SQL CARBON EDIT}}
+			root, element, icon, name, /*installCount, ratings,*/ author, description, disposables,
 			extensionDisposables: [],
 			set extension(extension: IExtension) {
 				versionWidget.extension = extension;
-				installCountWidget.extension = extension;
-				ratingsWidget.extension = extension;
+				// {{SQL CARBON EDIT}}
+				//installCountWidget.extension = extension;
+				//ratingsWidget.extension = extension;
 				maliciousStatusAction.extension = extension;
 				disabledStatusAction.extension = extension;
 				installAction.extension = extension;
@@ -132,8 +136,8 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		data.name.textContent = '';
 		data.author.textContent = '';
 		data.description.textContent = '';
-		data.installCount.style.display = 'none';
-		data.ratings.style.display = 'none';
+		//data.installCount.style.display = 'none';
+		//data.ratings.style.display = 'none';
 		data.extension = null;
 	}
 
@@ -173,8 +177,9 @@ export class Renderer implements IPagedRenderer<IExtension, ITemplateData> {
 		data.name.textContent = extension.displayName;
 		data.author.textContent = extension.publisherDisplayName;
 		data.description.textContent = extension.description;
-		data.installCount.style.display = '';
-		data.ratings.style.display = '';
+		// {{SQL CARBON EDIT}}
+		//data.installCount.style.display = '';
+		//data.ratings.style.display = '';
 		data.extension = extension;
 	}
 

--- a/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionEditor.ts
@@ -327,17 +327,20 @@ export class ExtensionEditor extends BaseEditor {
 					.done(viewlet => viewlet.search(`publisher:"${extension.publisherDisplayName}"`));
 			});
 
-			if (extension.licenseUrl) {
-				this.license.onclick = finalHandler(() => window.open(extension.licenseUrl));
-				this.license.style.display = 'initial';
-			} else {
-				this.license.onclick = null;
-				this.license.style.display = 'none';
-			}
+
 		} else {
 			this.name.onclick = null;
 			this.rating.onclick = null;
 			this.publisher.onclick = null;
+		}
+
+		// {{SQL CARBON EDIT}}
+		if (extension.licenseUrl) {
+			this.license.onclick = finalHandler(() => window.open(extension.licenseUrl));
+			this.license.style.display = 'initial';
+		} else {
+			this.license.onclick = null;
+			this.license.style.display = 'none';
 		}
 
 		if (extension.repository) {


### PR DESCRIPTION
Fixed couple of issues in the extension viewlet:

1. The license and repository was not displayed for extensions
2. Removed the small "rating" and "install count" icons 
fixes #1167
3. Issue tracker now works for extension and it's possible to create issue for extension but the url used to create github was returning 404. the reason was a bug in vs code which doesn't add "?" to the url. Had to fix the issue in vs code but for now fixing it in sqlops

![image](https://user-images.githubusercontent.com/17187348/41262589-92002ce4-6d96-11e8-8276-3977dfc36edc.png)
