### PR TITLE
Fix bug where select box selection could not be changed by mouse

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -541,21 +541,22 @@ export class SelectBoxList implements ISelectBoxDelegate, IDelegate<ISelectOptio
 
 			this.selectList.setFocus([this.selected]);
 			this.selectList.reveal(this.selectList.getFocus()[0]);
+
+			// {{SQL CARBON EDIT}} - Update the selection before firing the handler instead of after
+			// Reset Selection Handler
+			this._currentSelection = -1;
+			this.hideSelectDropDown(true);
+
 			this._onDidSelect.fire({
 				index: this.selectElement.selectedIndex,
 				selected: this.selectElement.title
 			});
-
-			// Reset Selection Handler
-			this._currentSelection = -1;
-			this.hideSelectDropDown(true);
 		}
 		dom.EventHelper.stop(e);
 	}
 
 	// List Exit - passive - hide drop-down, fire onDidSelect
 	private onListBlur(): void {
-
 		if (this._currentSelection >= 0) {
 			this.select(this._currentSelection);
 		}


### PR DESCRIPTION
Fixes #1614 which happens because VS Code has new logic to reset the selection if the user hits escape while using the drop down box, but this logic gets fired by our selection handler. The fix is to make sure the drop down finishes updating the selection before firing the event handler.

There are some other things that broke in the backup/restore dialogs that I'll look into too.