### PR TITLE
Prevent components from being defined multiple times

### DIFF
--- a/src/sql/parts/modelComponents/viewBase.ts
+++ b/src/sql/parts/modelComponents/viewBase.ts
@@ -40,7 +40,6 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 	abstract serverInfo: sqlops.ServerInfo;
 	private _onEventEmitter = new Emitter<any>();
 
-
 	initializeModel(rootComponent: IComponentShape, validationCallback: (componentId: string) => Thenable<boolean>): void {
 		let descriptor = this.defineComponent(rootComponent);
 		this.rootDescriptor = descriptor;
@@ -50,6 +49,10 @@ export abstract class ViewBase extends AngularDisposable implements IModelView {
 	}
 
 	private defineComponent(component: IComponentShape): IComponentDescriptor {
+		let existingDescriptor = this.modelStore.getComponentDescriptor(component.id);
+		if (existingDescriptor) {
+			return existingDescriptor;
+		}
 		let typeId = componentRegistry.getIdForTypeMapping(component.type);
 		if (!typeId) {
 			// failure case


### PR DESCRIPTION
Due to the way the extension host sets up certain containers, like forms, child objects could often get defined multiple times. This could cause, for example, button click handlers to fire twice on every click. This new code fixes the bug by returning the already-registered component when trying to define the same component again.