### PR TITLE
Fix edit data revert row bugs

### DIFF
--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -220,17 +220,20 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 		};
 	}
 
-	onRevertRow(): (index: number) => void {
+	onRevertRow(): () => void {
 		const self = this;
-		return (index: number): void => {
-			// Force focus to the first cell (completing any active edit operation)
-			self.focusCell(index, 0, false);
-			this.currentEditCellValue = null;
-			// Perform a revert row operation
-			self.dataService.revertRow(index)
-				.then(() => {
-					self.refreshResultsets();
-				});
+		return async (): Promise<void> => {
+			try {
+				// Perform a revert row operation
+				if (self.currentCell) {
+					await self.dataService.revertRow(self.currentCell.row);
+				}
+			} finally {
+				// The operation may fail if there were no changes sent to the service to revert,
+				// so clear any existing client-side edit and refresh the table regardless
+				this.currentEditCellValue = null;
+				self.refreshResultsets();
+			}
 		};
 	}
 
@@ -444,7 +447,7 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			handled = true;
 		} else if (e.keyCode === KeyCode.Escape) {
 			this.currentEditCellValue = null;
-			this.onRevertRow()(this.currentCell.row);
+			this.onRevertRow()();
 			handled = true;
 		}
 		return handled;

--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -214,9 +214,14 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 	onDeleteRow(): (index: number) => void {
 		const self = this;
 		return (index: number): void => {
-			self.dataService.deleteRow(index)
-				.then(() => self.dataService.commitEdit())
-				.then(() => self.removeRow(index));
+			// If the user is deleting a new row that hasn't been committed yet then use the revert code
+			if (self.newRowVisible && index === self.dataSet.dataRows.getLength() - 2) {
+				self.revertCurrentRow();
+			} else {
+				self.dataService.deleteRow(index)
+					.then(() => self.dataService.commitEdit())
+					.then(() => self.removeRow(index));
+			}
 		};
 	}
 

--- a/src/sql/parts/grid/views/editData/editDataGridActions.ts
+++ b/src/sql/parts/grid/views/editData/editDataGridActions.ts
@@ -19,7 +19,7 @@ export class EditDataGridActionProvider extends GridActionProvider {
 		dataService: DataService,
 		selectAllCallback: (index: number) => void,
 		private _deleteRowCallback: (index: number) => void,
-		private _revertRowCallback: (index: number) => void,
+		private _revertRowCallback: () => void,
 		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super(dataService, selectAllCallback, instantiationService);
@@ -56,18 +56,18 @@ export class DeleteRowAction extends Action {
 
 export class RevertRowAction extends Action {
 	public static ID = 'grid.revertRow';
-	public static LABEL = localize('revertRow', 'Revert Row');
+	public static LABEL = localize('revertRow', 'Revert Current Row');
 
 	constructor(
 		id: string,
 		label: string,
-		private callback: (index: number) => void
+		private callback: () => void
 	) {
 		super(id, label);
 	}
 
 	public run(gridInfo: IGridInfo): TPromise<boolean> {
-		this.callback(gridInfo.rowIndex);
+		this.callback();
 		return TPromise.as(true);
 	}
 }


### PR DESCRIPTION
This fixes #1498 and #1502 by updating the revert row logic so that it does not try to send the current edit to the service before calling revert (which caused problems when the current edit was not valid) and by unifying the "revert row" context menu logic with the escape key handler logic to revert the current row, since there is no way to have active changes for any other row.

Also fixes #1501 by adding logic to delete a new row instead of committing it when clicking off of it onto an existing row if there are no changes. The user can still commit a new blank row by clicking to add another new row.