### PR TITLE
Fix edit data limit dropdown position

### DIFF
--- a/src/sql/parts/grid/views/editData/media/editData.css
+++ b/src/sql/parts/grid/views/editData/media/editData.css
@@ -6,3 +6,8 @@
 .editdata-component * {
 	box-sizing: border-box;
 }
+
+#workbench\.editor\.editDataEditor .monaco-toolbar .monaco-select-box {
+	margin-top: 4px;
+	margin-bottom: 4px;
+}


### PR DESCRIPTION
Fixes #1654 

Before:
![Edit data dialog with the max rows dropdown aligned at the bottom of the toolbar](https://user-images.githubusercontent.com/3758704/41567798-f35fc29e-7316-11e8-9347-c72cd84a1a67.png)

After:
![Edit data dialog with the max rows dropdown aligned in the vertical center of the toolbar](https://user-images.githubusercontent.com/3758704/41567806-febb2bc4-7316-11e8-8fe2-0c27f0544275.png)