### PR TITLE
Profiler toolbar fixes + creating connections

### DIFF
--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -42,7 +42,6 @@ CommandsRegistry.registerCommand({
 		let objectExplorerService: IObjectExplorerService = accessor.get(IObjectExplorerService);
 
 		let connectionProfile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionService, editorService);
-
 		let profilerInput = instantiationService.createInstance(ProfilerInput, connectionProfile);
 		return editorService.openEditor(profilerInput, { pinned: true }, false).then(() => TPromise.as(true));
 	}

--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -19,8 +19,10 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
+import { IObjectExplorerService } from '../../objectExplorer/common/objectExplorerService';
 import { ProfilerInput } from 'sql/parts/profiler/editor/profilerInput';
 import { TPromise } from 'vs/base/common/winjs.base';
+import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
 
 // Contribute Global Actions
 const category = nls.localize('profilerCategory', "Profiler");
@@ -37,19 +39,9 @@ CommandsRegistry.registerCommand({
 		let editorService: IWorkbenchEditorService = accessor.get(IWorkbenchEditorService);
 		let instantiationService: IInstantiationService = accessor.get(IInstantiationService);
 		let connectionService: IConnectionManagementService = accessor.get(IConnectionManagementService);
+		let objectExplorerService: IObjectExplorerService = accessor.get(IObjectExplorerService);
 
-		// TODO: for test-only, grab the first MSSQL active connection for the profiler session
-		// TODO: when finishing the feature the connection should come from the launch context
-		let connectionProfile: IConnectionProfile;
-		let activeConnections = connectionService.getActiveConnections();
-		if (activeConnections) {
-			for (let i = 0; i < activeConnections.length; ++i) {
-				if (activeConnections[i].providerName === 'MSSQL') {
-					connectionProfile = activeConnections[i];
-					break;
-				}
-			}
-		}
+		let connectionProfile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionService, editorService);
 
 		let profilerInput = instantiationService.createInstance(ProfilerInput, connectionProfile);
 		return editorService.openEditor(profilerInput, { pinned: true }, false).then(() => TPromise.as(true));

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -202,8 +202,6 @@ export class ProfilerEditor extends BaseEditor {
 		this._register(attachSelectBoxStyler(this._sessionTemplateSelector, this.themeService));
 
 		this._actionBar.setContent([
-			{ action: this._connectAction },
-			{ element: Taskbar.createTaskbarSeparator() },
 			{ action: this._startAction },
 			{ action: this._stopAction },
 			{ element: dropdownContainer },
@@ -386,21 +384,20 @@ export class ProfilerEditor extends BaseEditor {
 
 		if (e.isConnected) {
 			this._connectAction.connected = this.input.state.isConnected;
-			this._startAction.enabled = this.input.state.isConnected;
-			this._stopAction.enabled = false;
-			this._pauseAction.enabled = false;
-
 			if (this.input.state.isConnected) {
 				this._sessionTemplateSelector.disable();
 			} else {
 				this._sessionTemplateSelector.enable();
+				this._startAction.enabled = this.input.state.isConnected;
+				this._stopAction.enabled = false;
+				this._pauseAction.enabled = false;
+				return;
 			}
-
-			return;
 		}
 
 		if (e.isPaused){
 			this._pauseAction.paused = this.input.state.isPaused;
+			this._pauseAction.enabled = !this.input.state.isStopped && (this.input.state.isRunning || this.input.state.isPaused);
 		}
 
 		if (e.isStopped || e.isRunning) {

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -44,7 +44,7 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 		// set inital state
 		this.state.change({
 			isConnected: true,
-			isStopped: false,
+			isStopped: true,
 			isPaused: false,
 			isRunning: false,
 			autoscroll: true


### PR DESCRIPTION
UI changes to remove the connect/disconnect button from the toolbar (since it won't be supported for the June release) and make sure buttons are updated correctly when switching between profiler windows. Also fixing connections to take the current global connection instead of the first active connection.