### PR TITLE
Add SQL CARBON EDIT tag in product class

### DIFF
--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -49,9 +49,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.7":
-  version "0.1.7"
-  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/d50285b03d0d5073c086362c5c96afb279320607"
+"dataprotocol-client@github:Microsoft/sqlops-dataprotocolclient#0.1.9":
+  version "0.1.9"
+  resolved "https://codeload.github.com/Microsoft/sqlops-dataprotocolclient/tar.gz/a1a79895cb79658b75d78aa5cfd745855019148d"
   dependencies:
     vscode-languageclient "3.5.0"
 

--- a/src/vs/platform/node/product.ts
+++ b/src/vs/platform/node/product.ts
@@ -52,6 +52,7 @@ export interface IProductConfiguration {
 	};
 	documentationUrl: string;
 	releaseNotesUrl: string;
+	// {SQL CARBON EDIT}
 	gettingStartedUrl: string;
 	keyboardShortcutsUrlMac: string;
 	keyboardShortcutsUrlLinux: string;


### PR DESCRIPTION
I forgot to add the edit tag on a previous edit.  Also, it looks like the yarn lock file didn't get updated when the DMP client was previously bumped.