### PR TITLE
Modifying angular bootstrap to add injection at the module level 

### DIFF
--- a/src/sql/parts/admin/security/createLogin.module.ts
+++ b/src/sql/parts/admin/security/createLogin.module.ts
@@ -6,12 +6,14 @@
 import { NgModule, Inject, forwardRef, ApplicationRef, ComponentFactoryResolver, Type } from '@angular/core';
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
 
-import { CreateLoginComponent, CREATELOGIN_SELECTOR } from 'sql/parts/admin/security/createLogin.component';
+import { IBootstrapParams, providerIterator } from 'sql/services/bootstrap/bootstrapService';
+import { CreateLoginComponent } from 'sql/parts/admin/security/createLogin.component';
+
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 // Connection Dashboard main angular module
-export const CreateLoginModule = (params: IBootstrapParams, selector: string): Type<any> => {
+export const CreateLoginModule = (params: IBootstrapParams, selector: string, instantiationService: IInstantiationService): Type<any> => {
 
 	@NgModule({
 		declarations: [
@@ -24,7 +26,8 @@ export const CreateLoginModule = (params: IBootstrapParams, selector: string): T
 		],
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/dashboard/dashboard.module.ts
+++ b/src/sql/parts/dashboard/dashboard.module.ts
@@ -154,7 +154,6 @@ export const DashboardModule = (params, selector: string, instantiationService: 
 			@Inject(ITelemetryService) private telemetryService: ITelemetryService,
 			@Inject(ISelector) private selector: string
 		) {
-			console.log(selector);
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {

--- a/src/sql/parts/dashboard/dashboard.module.ts
+++ b/src/sql/parts/dashboard/dashboard.module.ts
@@ -14,7 +14,7 @@ import { ChartsModule } from 'ng2-charts/ng2-charts';
 import CustomUrlSerializer from 'sql/common/urlSerializer';
 import { Extensions, IInsightRegistry } from 'sql/platform/dashboard/common/insightRegistry';
 import { Extensions as ComponentExtensions, IComponentRegistry } from 'sql/platform/dashboard/common/modelComponentRegistry';
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 
@@ -81,6 +81,7 @@ import { TasksWidget } from 'sql/parts/dashboard/widgets/tasks/tasksWidget.compo
 import { InsightsWidget } from 'sql/parts/dashboard/widgets/insights/insightsWidget.component';
 import { WebviewWidget } from 'sql/parts/dashboard/widgets/webview/webviewWidget.component';
 import { JobStepsViewComponent } from 'sql/parts/jobManagement/views/jobStepsView.component';
+import { IInstantiationService, _util } from 'vs/platform/instantiation/common/instantiation';
 
 let widgetComponents = [
 	PropertiesWidgetComponent,
@@ -109,7 +110,7 @@ const appRoutes: Routes = [
 ];
 
 // Connection Dashboard main angular module
-export const DashboardModule = (params, selector: string): any => {
+export const DashboardModule = (params, selector: string, instantiationService: IInstantiationService): any => {
 	@NgModule({
 		declarations: [
 			...baseComponents,
@@ -141,7 +142,8 @@ export const DashboardModule = (params, selector: string): any => {
 			{ provide: CommonServiceInterface, useClass: DashboardServiceInterface },
 			{ provide: UrlSerializer, useClass: CustomUrlSerializer },
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/dashboard/services/dashboardServiceInterface.service.ts
+++ b/src/sql/parts/dashboard/services/dashboardServiceInterface.service.ts
@@ -75,8 +75,11 @@ export class DashboardServiceInterface extends CommonServiceInterface {
 		@Inject(IConfigurationService) private _configService: IConfigurationService
 	) {
 		super(params, metadataService, connectionManagementService, adminService, queryManagementService);
-		this.dashboardContextKey = this._dashboardContextKey.bindTo(this.scopedContextKeyService);
-		this._register(toDisposableSubscription(this.angularEventingService.onAngularEvent(this._uri, (event) => this.handleDashboardEvent(event))));
+		// during testing there may not be params
+		if (this._params) {
+			this.dashboardContextKey = this._dashboardContextKey.bindTo(this.scopedContextKeyService);
+			this._register(toDisposableSubscription(this.angularEventingService.onAngularEvent(this._uri, (event) => this.handleDashboardEvent(event))));
+		}
 	}
 
 	/**

--- a/src/sql/parts/dashboard/services/dashboardServiceInterface.service.ts
+++ b/src/sql/parts/dashboard/services/dashboardServiceInterface.service.ts
@@ -64,33 +64,18 @@ export class DashboardServiceInterface extends CommonServiceInterface {
 	private _numberOfPageNavigations = 0;
 
 	constructor(
-		@Inject(forwardRef(() => Router)) private _router: Router,
-		@Inject(INotificationService) private _notificationService: INotificationService,
 		@Inject(IMetadataService) metadataService: IMetadataService,
 		@Inject(IConnectionManagementService) connectionManagementService: IConnectionManagementService,
 		@Inject(IAdminService) adminService: IAdminService,
 		@Inject(IQueryManagementService) queryManagementService: IQueryManagementService,
+		@Inject(IBootstrapParams) params: IDashboardComponentParams,
+		@Inject(forwardRef(() => Router)) private _router: Router,
+		@Inject(INotificationService) private _notificationService: INotificationService,
 		@Inject(IAngularEventingService) private angularEventingService: IAngularEventingService,
-		@Inject(IConfigurationService) private _configService: IConfigurationService,
-		@Inject(IBootstrapParams) _params: IDashboardComponentParams
+		@Inject(IConfigurationService) private _configService: IConfigurationService
 	) {
-		super(_params, metadataService, connectionManagementService, adminService, queryManagementService);
-		this.scopedContextKeyService = this.params.scopedContextService;
-		this._connectionContextKey = this.params.connectionContextKey;
+		super(params, metadataService, connectionManagementService, adminService, queryManagementService);
 		this.dashboardContextKey = this._dashboardContextKey.bindTo(this.scopedContextKeyService);
-		this.uri = this.params.ownerUri;
-	}
-
-	private get params(): IDashboardComponentParams {
-		return this._params;
-	}
-
-	/**
-	 * Set the uri for this dashboard instance, should only be set once
-	 * Inits all the services that depend on knowing a uri
-	 */
-	protected set uri(uri: string) {
-		super.setUri(uri);
 		this._register(toDisposableSubscription(this.angularEventingService.onAngularEvent(this._uri, (event) => this.handleDashboardEvent(event))));
 	}
 

--- a/src/sql/parts/dashboard/services/dashboardServiceInterface.service.ts
+++ b/src/sql/parts/dashboard/services/dashboardServiceInterface.service.ts
@@ -4,50 +4,29 @@
  *--------------------------------------------------------------------------------------------*/
 
 /* Node Modules */
-import { Injectable, Inject, forwardRef, OnDestroy } from '@angular/core';
+import { Injectable, Inject, forwardRef } from '@angular/core';
 import { Router } from '@angular/router';
-import { Observable } from 'rxjs/Observable';
 
 /* SQL imports */
 import { IDashboardComponentParams } from 'sql/services/bootstrap/bootstrapParams';
 import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
 import { IMetadataService } from 'sql/services/metadata/metadataService';
 import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
-import { ConnectionManagementInfo } from 'sql/parts/connection/common/connectionManagementInfo';
 import { IAdminService } from 'sql/parts/admin/common/adminService';
 import { IQueryManagementService } from 'sql/parts/query/common/queryManagement';
 import { toDisposableSubscription } from 'sql/parts/common/rxjsUtils';
-import { IInsightsDialogService } from 'sql/parts/insights/common/interfaces';
-import { ICapabilitiesService } from 'sql/services/capabilities/capabilitiesService';
-import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { AngularEventType, IAngularEvent, IAngularEventingService } from 'sql/services/angularEventing/angularEventingService';
 import { IDashboardTab } from 'sql/platform/dashboard/common/dashboardRegistry';
 import { TabSettingConfig } from 'sql/parts/dashboard/common/dashboardWidget';
-import { IDashboardViewService } from 'sql/services/dashboard/common/dashboardViewService';
-import { AngularDisposable } from 'sql/base/common/lifecycle';
-import { ConnectionContextkey } from 'sql/parts/connection/common/connectionContextKey';
-import { SingleConnectionMetadataService, SingleConnectionManagementService, SingleAdminService, SingleQueryManagementService, CommonServiceInterface }
-from 'sql/services/common/commonServiceInterface.service';
-
-import { ProviderMetadata, DatabaseInfo, SimpleExecuteResult } from 'sqlops';
+import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
 
 /* VS imports */
-import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IDisposable } from 'vs/base/common/lifecycle';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
-import { ConfigurationEditingService, IConfigurationValue } from 'vs/workbench/services/configuration/node/configurationEditingService';
-import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { IStorageService } from 'vs/platform/storage/common/storage';
 import { Event, Emitter } from 'vs/base/common/event';
 import Severity from 'vs/base/common/severity';
 import * as nls from 'vs/nls';
-import { IPartService } from 'vs/workbench/services/part/common/partService';
 import { deepClone } from 'vs/base/common/objects';
-import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IContextKeyService, RawContextKey, IContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { RawContextKey, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
 const DASHBOARD_SETTINGS = 'dashboard';
@@ -96,25 +75,14 @@ export class DashboardServiceInterface extends CommonServiceInterface {
 		@Inject(IBootstrapParams) _params: IDashboardComponentParams
 	) {
 		super(_params, metadataService, connectionManagementService, adminService, queryManagementService);
-	}
-
-	private get params(): IDashboardComponentParams {
-		return this._params;
-	}
-
-	/**
-	 * Set the selector for this dashboard instance, should only be set once
-	 */
-	public set selector(selector: string) {
-		this._uniqueSelector = selector;
-		this._getbootstrapParams();
-	}
-
-	protected _getbootstrapParams(): void {
 		this.scopedContextKeyService = this.params.scopedContextService;
 		this._connectionContextKey = this.params.connectionContextKey;
 		this.dashboardContextKey = this._dashboardContextKey.bindTo(this.scopedContextKeyService);
 		this.uri = this.params.ownerUri;
+	}
+
+	private get params(): IDashboardComponentParams {
+		return this._params;
 	}
 
 	/**

--- a/src/sql/parts/disasterRecovery/backup/backup.module.ts
+++ b/src/sql/parts/disasterRecovery/backup/backup.module.ts
@@ -4,14 +4,14 @@
 *--------------------------------------------------------------------------------------------*/
 
 import {
-	ApplicationRef, ComponentFactoryResolver, ModuleWithProviders, NgModule,
+	ApplicationRef, ComponentFactoryResolver, NgModule,
 	Inject, forwardRef, Type
 } from '@angular/core';
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
-import { BackupComponent, BACKUP_SELECTOR } from 'sql/parts/disasterRecovery/backup/backup.component';
+import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { BackupComponent } from 'sql/parts/disasterRecovery/backup/backup.component';
 
 // work around
 const BrowserAnimationsModule = (<any>require.__$__nodeRequire('@angular/platform-browser/animations')).BrowserAnimationsModule;
@@ -31,19 +31,21 @@ export const BackupModule = (params: IBootstrapParams, selector: string): Type<a
 		],
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			{ provide: ISelector, useValue: selector }
 		]
 	})
 	class ModuleClass {
 
 		constructor(
-			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver
+			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver,
+			@Inject(ISelector) private selector: string
 		) {
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {
 			const factory = this._resolver.resolveComponentFactory(BackupComponent);
-			(<any>factory).factory.selector = selector;
+			(<any>factory).factory.selector = this.selector;
 			appRef.bootstrap(factory);
 		}
 	}

--- a/src/sql/parts/disasterRecovery/backup/backup.module.ts
+++ b/src/sql/parts/disasterRecovery/backup/backup.module.ts
@@ -10,14 +10,17 @@ import {
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 import { BackupComponent } from 'sql/parts/disasterRecovery/backup/backup.component';
+
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 // work around
 const BrowserAnimationsModule = (<any>require.__$__nodeRequire('@angular/platform-browser/animations')).BrowserAnimationsModule;
 
 // Backup wizard main angular module
-export const BackupModule = (params: IBootstrapParams, selector: string): Type<any> => {
+export const BackupModule = (params: IBootstrapParams, selector: string, instantiationService: IInstantiationService): Type<any> => {
 	@NgModule({
 		declarations: [
 			BackupComponent
@@ -32,7 +35,8 @@ export const BackupModule = (params: IBootstrapParams, selector: string): Type<a
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/grid/views/editData/editData.module.ts
+++ b/src/sql/parts/grid/views/editData/editData.module.ts
@@ -8,9 +8,9 @@ import { ApplicationRef, ComponentFactoryResolver, NgModule, Inject, forwardRef,
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { EditDataComponent, EDITDATA_SELECTOR } from 'sql/parts/grid/views/editData/editData.component';
+import { EditDataComponent } from 'sql/parts/grid/views/editData/editData.component';
 import { SlickGrid } from 'angular2-slickgrid';
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
 
 export const EditDataModule = (params: IBootstrapParams, selector: string): Type<any> => {
 
@@ -30,19 +30,21 @@ export const EditDataModule = (params: IBootstrapParams, selector: string): Type
 			EditDataComponent
 		],
 		providers: [
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			{ provide: ISelector, useValue: selector }
 		]
 	})
 	class ModuleClass {
 
 		constructor(
-			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver
+			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver,
+			@Inject(ISelector) private selector: string
 		) {
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {
 			const factory = this._resolver.resolveComponentFactory(EditDataComponent);
-			(<any>factory).factory.selector = selector;
+			(<any>factory).factory.selector = this.selector;
 			appRef.bootstrap(factory);
 		}
 	}

--- a/src/sql/parts/grid/views/editData/editData.module.ts
+++ b/src/sql/parts/grid/views/editData/editData.module.ts
@@ -7,12 +7,14 @@
 import { ApplicationRef, ComponentFactoryResolver, NgModule, Inject, forwardRef, Type } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
+import { SlickGrid } from 'angular2-slickgrid';
 
 import { EditDataComponent } from 'sql/parts/grid/views/editData/editData.component';
-import { SlickGrid } from 'angular2-slickgrid';
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 
-export const EditDataModule = (params: IBootstrapParams, selector: string): Type<any> => {
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+
+export const EditDataModule = (params: IBootstrapParams, selector: string, instantiationService: IInstantiationService): Type<any> => {
 
 	@NgModule({
 
@@ -31,7 +33,8 @@ export const EditDataModule = (params: IBootstrapParams, selector: string): Type
 		],
 		providers: [
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/query/views/queryOutput.module.ts
+++ b/src/sql/parts/query/views/queryOutput.module.ts
@@ -13,13 +13,13 @@ import { ChartsModule } from 'ng2-charts/ng2-charts';
 
 const BrowserAnimationsModule = (<any>require.__$__nodeRequire('@angular/platform-browser/animations')).BrowserAnimationsModule;
 
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
 import { Extensions, IInsightRegistry } from 'sql/platform/dashboard/common/insightRegistry';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 
 
-import { QueryOutputComponent, QUERY_OUTPUT_SELECTOR } from 'sql/parts/query/views/queryOutput.component';
+import { QueryOutputComponent } from 'sql/parts/query/views/queryOutput.component';
 import { QueryPlanComponent, } from 'sql/parts/queryPlan/queryPlan.component';
 import { QueryComponent } from 'sql/parts/grid/views/query/query.component';
 import { TopOperationsComponent } from 'sql/parts/queryPlan/topOperations.component';
@@ -67,19 +67,21 @@ export const QueryOutputModule = (params: IBootstrapParams, selector: string): T
 			...insightComponents
 		],
 		providers: [
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			{ provide: ISelector, useValue: selector }
 		]
 	})
 	class ModuleClass {
 
 		constructor(
-			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver
+			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver,
+			@Inject(ISelector) private selector: string
 		) {
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {
 			const factory = this._resolver.resolveComponentFactory(QueryOutputComponent);
-			(<any>factory).factory.selector = selector;
+			(<any>factory).factory.selector = this.selector;
 			appRef.bootstrap(factory);
 		}
 	}

--- a/src/sql/parts/query/views/queryOutput.module.ts
+++ b/src/sql/parts/query/views/queryOutput.module.ts
@@ -13,10 +13,11 @@ import { ChartsModule } from 'ng2-charts/ng2-charts';
 
 const BrowserAnimationsModule = (<any>require.__$__nodeRequire('@angular/platform-browser/animations')).BrowserAnimationsModule;
 
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 import { Extensions, IInsightRegistry } from 'sql/platform/dashboard/common/insightRegistry';
 
 import { Registry } from 'vs/platform/registry/common/platform';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 
 import { QueryOutputComponent } from 'sql/parts/query/views/queryOutput.component';
@@ -41,7 +42,7 @@ let baseComponents = [QueryComponent, ComponentHostDirective, QueryOutputCompone
 /* Insights */
 let insightComponents = Registry.as<IInsightRegistry>(Extensions.InsightContribution).getAllCtors();
 
-export const QueryOutputModule = (params: IBootstrapParams, selector: string): Type<any> => {
+export const QueryOutputModule = (params: IBootstrapParams, selector: string, instantiationService: IInstantiationService): Type<any> => {
 
 	@NgModule({
 		imports: [
@@ -68,7 +69,8 @@ export const QueryOutputModule = (params: IBootstrapParams, selector: string): T
 		],
 		providers: [
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/queryPlan/queryPlan.module.ts
+++ b/src/sql/parts/queryPlan/queryPlan.module.ts
@@ -6,8 +6,8 @@
 import { NgModule, Inject, forwardRef, ApplicationRef, ComponentFactoryResolver, Type } from '@angular/core';
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
-import { QueryPlanComponent, QUERYPLAN_SELECTOR } from 'sql/parts/queryPlan/queryPlan.component';
+import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { QueryPlanComponent } from 'sql/parts/queryPlan/queryPlan.component';
 
 // Connection Dashboard main angular module
 export const QueryPlanModule = (params: IBootstrapParams, selector: string): Type<any> => {
@@ -23,19 +23,21 @@ export const QueryPlanModule = (params: IBootstrapParams, selector: string): Typ
 		],
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			{ provide: ISelector, useValue: selector }
 		]
 	})
 	class ModuleClass {
 
 		constructor(
-			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver
+			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver,
+			@Inject(ISelector) private selector: string
 		) {
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {
 			const factory = this._resolver.resolveComponentFactory(QueryPlanComponent);
-			(<any>factory).factory.selector = selector;
+			(<any>factory).factory.selector = this.selector;
 			appRef.bootstrap(factory);
 		}
 	}

--- a/src/sql/parts/queryPlan/queryPlan.module.ts
+++ b/src/sql/parts/queryPlan/queryPlan.module.ts
@@ -6,11 +6,14 @@
 import { NgModule, Inject, forwardRef, ApplicationRef, ComponentFactoryResolver, Type } from '@angular/core';
 import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 import { QueryPlanComponent } from 'sql/parts/queryPlan/queryPlan.component';
 
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+
 // Connection Dashboard main angular module
-export const QueryPlanModule = (params: IBootstrapParams, selector: string): Type<any> => {
+export const QueryPlanModule = (params: IBootstrapParams, selector: string, instantiationService: IInstantiationService): Type<any> => {
 
 	@NgModule({
 		declarations: [
@@ -24,7 +27,8 @@ export const QueryPlanModule = (params: IBootstrapParams, selector: string): Typ
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/tasks/dialog/taskDialog.module.ts
+++ b/src/sql/parts/tasks/dialog/taskDialog.module.ts
@@ -12,9 +12,11 @@ import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+
 import { TaskDialogComponent } from 'sql/parts/tasks/dialog/taskDialog.component';
 import { CreateDatabaseComponent } from 'sql/parts/admin/database/create/createDatabase.component';
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 
 // Setup routes for various child components
 const appRoutes: Routes = [
@@ -27,7 +29,7 @@ const appRoutes: Routes = [
 	{ path: '**', component: CreateDatabaseComponent }
 ];
 
-export const TaskDialogModule = (params: IBootstrapParams, selector: string): Type<any> => {
+export const TaskDialogModule = (params: IBootstrapParams, selector: string, instantiationService: IInstantiationService): Type<any> => {
 	@NgModule({
 		declarations: [
 			TaskDialogComponent,
@@ -43,7 +45,8 @@ export const TaskDialogModule = (params: IBootstrapParams, selector: string): Ty
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/parts/tasks/dialog/taskDialog.module.ts
+++ b/src/sql/parts/tasks/dialog/taskDialog.module.ts
@@ -12,9 +12,9 @@ import { APP_BASE_HREF, CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
-import { TaskDialogComponent, TASKDIALOG_SELECTOR } from 'sql/parts/tasks/dialog/taskDialog.component';
+import { TaskDialogComponent } from 'sql/parts/tasks/dialog/taskDialog.component';
 import { CreateDatabaseComponent } from 'sql/parts/admin/database/create/createDatabase.component';
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
 
 // Setup routes for various child components
 const appRoutes: Routes = [
@@ -42,19 +42,21 @@ export const TaskDialogModule = (params: IBootstrapParams, selector: string): Ty
 		],
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			{ provide: ISelector, useValue: selector }
 		]
 	})
 	class ModuleClass {
 
 		constructor(
-			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver
+			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver,
+			@Inject(ISelector) private selector: string
 		) {
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {
 			const factory = this._resolver.resolveComponentFactory(TaskDialogComponent);
-			(<any>factory).factory.selector = selector;
+			(<any>factory).factory.selector = this.selector;
 			appRef.bootstrap(factory);
 		}
 	}

--- a/src/sql/platform/dialog/dialog.module.ts
+++ b/src/sql/platform/dialog/dialog.module.ts
@@ -11,22 +11,25 @@ import { forwardRef, NgModule, ComponentFactoryResolver, Inject, ApplicationRef 
 import { FormsModule } from '@angular/forms';
 import { CommonModule, APP_BASE_HREF } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
+
 import { DialogContainer } from 'sql/platform/dialog/dialogContainer.component';
 import { Extensions, IComponentRegistry } from 'sql/platform/dashboard/common/modelComponentRegistry';
 import { ModelViewContent } from 'sql/parts/modelComponents/modelViewContent.component';
 import { ModelComponentWrapper } from 'sql/parts/modelComponents/modelComponentWrapper.component';
 import { ComponentHostDirective } from 'sql/parts/dashboard/common/componentHost.directive';
-import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector, providerIterator } from 'sql/services/bootstrap/bootstrapService';
 import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
-import { Registry } from 'vs/platform/registry/common/platform';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox.component';
 import { SelectBox } from 'sql/base/browser/ui/selectBox/selectBox.component';
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox.component';
 
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { Registry } from 'vs/platform/registry/common/platform';
+
 /* Model-backed components */
 let extensionComponents = Registry.as<IComponentRegistry>(Extensions.ComponentContribution).getAllCtors();
 
-export const DialogModule = (params, selector: string): any => {
+export const DialogModule = (params, selector: string, instantiationService: IInstantiationService): any => {
 	@NgModule({
 		declarations: [
 			Checkbox,
@@ -48,7 +51,8 @@ export const DialogModule = (params, selector: string): any => {
 			{ provide: APP_BASE_HREF, useValue: '/' },
 			CommonServiceInterface,
 			{ provide: IBootstrapParams, useValue: params },
-			{ provide: ISelector, useValue: selector }
+			{ provide: ISelector, useValue: selector },
+			...providerIterator(instantiationService)
 		]
 	})
 	class ModuleClass {

--- a/src/sql/platform/dialog/dialog.module.ts
+++ b/src/sql/platform/dialog/dialog.module.ts
@@ -16,7 +16,7 @@ import { Extensions, IComponentRegistry } from 'sql/platform/dashboard/common/mo
 import { ModelViewContent } from 'sql/parts/modelComponents/modelViewContent.component';
 import { ModelComponentWrapper } from 'sql/parts/modelComponents/modelComponentWrapper.component';
 import { ComponentHostDirective } from 'sql/parts/dashboard/common/componentHost.directive';
-import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
+import { IBootstrapParams, ISelector } from 'sql/services/bootstrap/bootstrapService';
 import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox.component';
@@ -47,20 +47,21 @@ export const DialogModule = (params, selector: string): any => {
 		providers: [
 			{ provide: APP_BASE_HREF, useValue: '/' },
 			CommonServiceInterface,
-			{ provide: IBootstrapParams, useValue: params }
+			{ provide: IBootstrapParams, useValue: params },
+			{ provide: ISelector, useValue: selector }
 		]
 	})
 	class ModuleClass {
 
 		constructor(
 			@Inject(forwardRef(() => ComponentFactoryResolver)) private _resolver: ComponentFactoryResolver,
-			@Inject(forwardRef(() => CommonServiceInterface)) bootstrap: CommonServiceInterface,
+			@Inject(ISelector) private selector: string
 		) {
 		}
 
 		ngDoBootstrap(appRef: ApplicationRef) {
 			const factoryWrapper: any = this._resolver.resolveComponentFactory(DialogContainer);
-			factoryWrapper.factory.selector = selector;
+			factoryWrapper.factory.selector = this.selector;
 			appRef.bootstrap(factoryWrapper);
 		}
 	}

--- a/src/sql/services/bootstrap/bootstrapService.ts
+++ b/src/sql/services/bootstrap/bootstrapService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { NgModuleRef, enableProdMode, InjectionToken, ReflectiveInjector, Type, PlatformRef, Provider } from '@angular/core';
+import { NgModuleRef, enableProdMode, InjectionToken, Type, PlatformRef, Provider, Injector } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { IEditorInput } from 'vs/platform/editor/common/editor';
@@ -12,7 +12,9 @@ import { IInstantiationService, _util } from 'vs/platform/instantiation/common/i
 const selectorCounter = new Map<string, number>();
 const serviceMap = new Map<string, IInstantiationService>();
 
-export const IBootstrapParams = new InjectionToken('bootstrap_params');
+export const ISelector = new InjectionToken<string>('selector');
+
+export const IBootstrapParams = new InjectionToken<IBootstrapParams>('bootstrap_params');
 export interface IBootstrapParams {
 }
 
@@ -59,10 +61,10 @@ export function bootstrapAngular<T>(service: IInstantiationService, moduleType: 
 		if (input) {
 			input.onDispose(() => {
 				serviceMap.delete(uniqueSelectorString);
-				moduleRef.onDestroy(() => {
-					serviceMap.delete(uniqueSelectorString);
-				});
 				moduleRef.destroy();
+			});
+			moduleRef.onDestroy(() => {
+				serviceMap.delete(uniqueSelectorString);
 			});
 		}
 		if (callbackSetModule) {

--- a/src/sql/services/bootstrap/bootstrapService.ts
+++ b/src/sql/services/bootstrap/bootstrapService.ts
@@ -3,14 +3,23 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { NgModuleRef, enableProdMode, InjectionToken, Type, PlatformRef, Provider, Injector } from '@angular/core';
+import { NgModuleRef, enableProdMode, InjectionToken, Type, PlatformRef, Provider, Injector, Optional, Inject, ComponentFactoryResolver } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { IEditorInput } from 'vs/platform/editor/common/editor';
 import { IInstantiationService, _util } from 'vs/platform/instantiation/common/instantiation';
 
 const selectorCounter = new Map<string, number>();
-const serviceMap = new Map<string, IInstantiationService>();
+
+export function providerIterator(service: IInstantiationService): Provider[] {
+	return Array.from(_util.serviceIds.values()).map(v => {
+		return {
+			provide: v, useFactory: () => {
+				return (<any>service)._getOrCreateServiceInstance(v);
+			}
+		};
+	});
+}
 
 export const ISelector = new InjectionToken<string>('selector');
 
@@ -18,7 +27,7 @@ export const IBootstrapParams = new InjectionToken<IBootstrapParams>('bootstrap_
 export interface IBootstrapParams {
 }
 
-export type IModuleFactory<T> = (params: IBootstrapParams, selector: string) => Type<T>;
+export type IModuleFactory<T> = (params: IBootstrapParams, selector: string, service: IInstantiationService) => Type<T>;
 
 function createUniqueSelector(selector: string): string {
 	let num: number;
@@ -39,32 +48,14 @@ export function bootstrapAngular<T>(service: IInstantiationService, moduleType: 
 	let selector = document.createElement(uniqueSelectorString);
 	container.appendChild(selector);
 
-	serviceMap.set(uniqueSelectorString, service);
-
 	if (!platform) {
-		// Perform the bootsrap
-
-		const providers: Provider = [];
-
-		_util.serviceIds.forEach(id => {
-			providers.push({
-				provide: id, useFactory: () => {
-					return (<any>serviceMap.get(uniqueSelectorString))._getOrCreateServiceInstance(id);
-				}
-			});
-		});
-
-		platform = platformBrowserDynamic(providers);
+		platform = platformBrowserDynamic();
 	}
 
-	platform.bootstrapModule(moduleType(params, uniqueSelectorString)).then(moduleRef => {
+	platform.bootstrapModule(moduleType(params, uniqueSelectorString, service)).then(moduleRef => {
 		if (input) {
 			input.onDispose(() => {
-				serviceMap.delete(uniqueSelectorString);
 				moduleRef.destroy();
-			});
-			moduleRef.onDestroy(() => {
-				serviceMap.delete(uniqueSelectorString);
 			});
 		}
 		if (callbackSetModule) {

--- a/src/sql/services/common/commonServiceInterface.service.ts
+++ b/src/sql/services/common/commonServiceInterface.service.ts
@@ -95,7 +95,6 @@ export class SingleQueryManagementService {
 */
 @Injectable()
 export class CommonServiceInterface extends AngularDisposable {
-	protected _uniqueSelector: string;
 	protected _uri: string;
 
 	/* Special Services */
@@ -115,6 +114,9 @@ export class CommonServiceInterface extends AngularDisposable {
 		@Inject(IQueryManagementService) protected _queryManagementService: IQueryManagementService
 	) {
 		super();
+		this.scopedContextKeyService = this._params.scopedContextService;
+		this._connectionContextKey = this._params.connectionContextKey;
+		this.uri = this._params.ownerUri;
 	}
 
 	public get metadataService(): SingleConnectionMetadataService {
@@ -131,20 +133,6 @@ export class CommonServiceInterface extends AngularDisposable {
 
 	public get queryManagementService(): SingleQueryManagementService {
 		return this._singleQueryManagementService;
-	}
-
-	/**
-	 * Set the selector for this instance, should only be set once
-	 */
-	public set selector(selector: string) {
-		this._uniqueSelector = selector;
-		this._getbootstrapParams();
-	}
-
-	protected _getbootstrapParams(): void {
-		this.scopedContextKeyService = this._params.scopedContextService;
-		this._connectionContextKey = this._params.connectionContextKey;
-		this.uri = this._params.ownerUri;
 	}
 
 	protected setUri(uri: string) {

--- a/src/sql/services/common/commonServiceInterface.service.ts
+++ b/src/sql/services/common/commonServiceInterface.service.ts
@@ -114,9 +114,12 @@ export class CommonServiceInterface extends AngularDisposable {
 		@Inject(IQueryManagementService) protected _queryManagementService: IQueryManagementService
 	) {
 		super();
-		this.scopedContextKeyService = this._params.scopedContextService;
-		this._connectionContextKey = this._params.connectionContextKey;
-		this.uri = this._params.ownerUri;
+		// during testing there may not be params
+		if (this._params) {
+			this.scopedContextKeyService = this._params.scopedContextService;
+			this._connectionContextKey = this._params.connectionContextKey;
+			this.uri = this._params.ownerUri;
+		}
 	}
 
 	public get metadataService(): SingleConnectionMetadataService {


### PR DESCRIPTION
Before the injection of vscode services was being done via the platform, but because all modules share a platform this complicates providing the hierarchical structure of injection. So instead I moved the injection method to the module level which will fix some bugs as well as properly fix the hierarchical goal.