### PR TITLE
Add dialog close validation

### DIFF
--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -120,11 +120,13 @@ export class DialogModal extends Modal {
 		this.show();
 	}
 
-	public done(): void {
+	public async done(): Promise<void> {
 		if (this._dialog.okButton.enabled) {
-			this._onDone.fire();
-			this.dispose();
-			this.hide();
+			if (await this._dialog.validateClose()) {
+				this._onDone.fire();
+				this.dispose();
+				this.hide();
+			}
 		}
 	}
 

--- a/src/sql/platform/dialog/dialogTypes.ts
+++ b/src/sql/platform/dialog/dialogTypes.ts
@@ -49,6 +49,7 @@ export class Dialog extends ModelViewPane {
 	private _onMessageChange = new Emitter<DialogMessage>();
 	public readonly onMessageChange = this._onMessageChange.event;
 	private _message: DialogMessage;
+	private _closeValidator: () => boolean | Thenable<boolean>;
 
 	constructor(public title: string, content?: string | DialogTab[]) {
 		super();
@@ -65,6 +66,18 @@ export class Dialog extends ModelViewPane {
 		if (this._message && !value || !this._message && value || this._message && value && (this._message.level !== value.level || this._message.text !== value.text)) {
 			this._message = value;
 			this._onMessageChange.fire(this._message);
+		}
+	}
+
+	public registerCloseValidator(validator: () => boolean | Thenable<boolean>): void {
+		this._closeValidator = validator;
+	}
+
+	public validateClose(): Thenable<boolean> {
+		if (this._closeValidator) {
+			return Promise.resolve(this._closeValidator());
+		} else {
+			return Promise.resolve(true);
 		}
 	}
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -656,6 +656,15 @@ declare module 'sqlops' {
 				 * undefined or the text is empty or undefined. The default level is error.
 				 */
 				message: DialogMessage;
+
+				/**
+				 * Register a callback that will be called when the user tries to click done. Only
+				 * one callback can be registered at once, so each registration call will clear
+				 * the previous registration.
+				 * @param validator The callback that gets executed when the user tries to click
+				 * done. Return true to allow the dialog to close or false to block it from closing
+				 */
+				registerCloseValidator(validator: () => boolean | Thenable<boolean>): void;
 			}
 
 			export interface DialogTab extends ModelViewPanel {

--- a/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
+++ b/src/sql/workbench/api/node/mainThreadModelViewDialog.ts
@@ -80,6 +80,7 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 			dialog.okButton = okButton;
 			dialog.cancelButton = cancelButton;
 			dialog.onValidityChanged(valid => this._proxy.$onPanelValidityChanged(handle, valid));
+			dialog.registerCloseValidator(() => this.validateDialogClose(handle));
 			this._dialogs.set(handle, dialog);
 		}
 
@@ -261,5 +262,9 @@ export class MainThreadModelViewDialog implements MainThreadModelViewDialogShape
 
 	private validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean> {
 		return this._proxy.$validateNavigation(handle, info);
+	}
+
+	private validateDialogClose(handle: number): Thenable<boolean> {
+		return this._proxy.$validateDialogClose(handle);
 	}
 }

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -563,6 +563,7 @@ export interface ExtHostModelViewDialogShape {
 	$onWizardPageChanged(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): void;
 	$updateWizardPageInfo(handle: number, pageHandles: number[], currentPageIndex: number): void;
 	$validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean>;
+	$validateDialogClose(handle: number): Thenable<boolean>;
 }
 
 export interface MainThreadModelViewDialogShape extends IDisposable {

--- a/src/sqltest/workbench/api/extHostModelViewDialog.test.ts
+++ b/src/sqltest/workbench/api/extHostModelViewDialog.test.ts
@@ -307,4 +307,23 @@ suite('ExtHostModelViewDialog Tests', () => {
 		// Then the main thread gets notified of the new details
 		mockProxy.verify(x => x.$setWizardDetails(It.isAny(), It.is(x => x.message === newMessage)), Times.once());
 	});
+
+	test('Main thread can execute dialog close validation', () => {
+		// Set up the main thread mock to record the dialog handle
+		let dialogHandle: number;
+		mockProxy.setup(x => x.$setDialogDetails(It.isAny(), It.isAny())).callback((handle, details) => dialogHandle = handle);
+
+		// Create the dialog and add a validation that records that it has been called
+		let dialog = extHostModelViewDialog.createDialog('dialog_1');
+		extHostModelViewDialog.updateDialogContent(dialog);
+		let callCount = 0;
+		dialog.registerCloseValidator(() => {
+			callCount++;
+			return true;
+		});
+
+		// If I call the validation from the main thread then it should run
+		extHostModelViewDialog.$validateDialogClose(dialogHandle);
+		assert.equal(callCount, 1);
+	});
 });

--- a/src/sqltest/workbench/api/mainThreadModelViewDialog.test.ts
+++ b/src/sqltest/workbench/api/mainThreadModelViewDialog.test.ts
@@ -60,7 +60,8 @@ suite('MainThreadModelViewDialog Tests', () => {
 			$onPanelValidityChanged: (handle, valid) => undefined,
 			$onWizardPageChanged: (handle, info) => undefined,
 			$updateWizardPageInfo: (wizardHandle, pageHandles, currentPageIndex) => undefined,
-			$validateNavigation: (handle, info) => undefined
+			$validateNavigation: (handle, info) => undefined,
+			$validateDialogClose: handle => undefined
 		});
 		let extHostContext = <IExtHostContext>{
 			getProxy: proxyType => mockExtHostModelViewDialog.object
@@ -346,5 +347,16 @@ suite('MainThreadModelViewDialog Tests', () => {
 		// Then the message gets changed on the wizard
 		assert.equal(newMessage, wizardDetails.message, 'New message was not included in the fired event');
 		assert.equal(openedWizard.message, wizardDetails.message, 'New message was not set on the wizard');
+	});
+
+	test('Creating a dialog adds a close validation that calls the extension host', () => {
+		mockExtHostModelViewDialog.setup(x => x.$validateDialogClose(It.isAny()));
+
+		// If I call validateClose on the dialog that gets created
+		mainThreadModelViewDialog.$openDialog(dialogHandle);
+		openedDialog.validateClose();
+
+		// Then the call gets forwarded to the extension host
+		mockExtHostModelViewDialog.verify(x => x.$validateDialogClose(It.is(handle => handle === dialogHandle)), Times.once());
 	});
 });


### PR DESCRIPTION
Adds a dialog close validation, like the one for wizard navigation, that allows extension authors to validate a dialog when the user clicks done and to cancel closing the dialog if anything is wrong with the user's input.

This handles part of #1664. I'll add some code to prompt the user when canceling a dialog or wizard in a separate PR too