### PR TITLE
Providers without metadata service or serverInfo shouldn't break dashboard

### DIFF
--- a/extensions/mssql/src/contextProvider.ts
+++ b/extensions/mssql/src/contextProvider.ts
@@ -37,7 +37,7 @@ export default class ContextProvider {
 	public onDashboardOpen(e: sqlops.DashboardDocument): void {
 		let iscloud: boolean;
 		let edition: number;
-		if (e.profile.providerName.toLowerCase() === 'mssql' && !types.isUndefinedOrNull(e.serverInfo.engineEditionId)) {
+		if (e.profile.providerName.toLowerCase() === 'mssql' && !types.isUndefinedOrNull(e.serverInfo) && !types.isUndefinedOrNull(e.serverInfo.engineEditionId)) {
 			if (isCloudEditions.some(i => i === e.serverInfo.engineEditionId)) {
 				iscloud = true;
 			} else {

--- a/src/sql/parts/dashboard/common/dashboardHelper.ts
+++ b/src/sql/parts/dashboard/common/dashboardHelper.ts
@@ -136,13 +136,17 @@ export function addProvider<T extends { connectionManagementService: SingleConne
  */
 export function addEdition<T extends { connectionManagementService: SingleConnectionManagementService }>(config: WidgetConfig[], collection: DashboardServiceInterface): Array<WidgetConfig> {
 	let connectionInfo: ConnectionManagementInfo = collection.connectionManagementService.connectionInfo;
-	let edition = connectionInfo.serverInfo.engineEditionId;
-	return config.map((item) => {
-		if (item.edition === undefined) {
-			item.edition = edition;
-		}
-		return item;
-	});
+	if (connectionInfo.serverInfo) {
+		let edition = connectionInfo.serverInfo.engineEditionId;
+		return config.map((item) => {
+			if (item.edition === undefined) {
+				item.edition = edition;
+			}
+			return item;
+		});
+	} else {
+		return config;
+	}
 }
 
 /**

--- a/src/sql/parts/dashboard/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/explorer/explorerWidget.component.ts
@@ -28,6 +28,7 @@ import { IContextViewService, IContextMenuService } from 'vs/platform/contextvie
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IProgressService } from 'vs/platform/progress/common/progress';
+import * as types from 'vs/base/common/types';
 
 @Component({
 	selector: 'explorer-widget',
@@ -120,6 +121,10 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			let currentProfile = this._bootstrap.connectionManagementService.connectionInfo.connectionProfile;
 			this._register(toDisposableSubscription(this._bootstrap.metadataService.databaseNames.subscribe(
 				data => {
+					// Handle the case where there is no metadata service
+					if (types.isUndefinedOrNull(data)) {
+						data = [];
+					}
 					let profileData = data.map(d => {
 						let profile = new ConnectionProfile(this.capabilitiesService, currentProfile);
 						profile.databaseName = d;

--- a/src/sql/parts/dashboard/widgets/explorer/explorerWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/explorer/explorerWidget.component.ts
@@ -122,9 +122,7 @@ export class ExplorerWidget extends DashboardWidget implements IDashboardWidget,
 			this._register(toDisposableSubscription(this._bootstrap.metadataService.databaseNames.subscribe(
 				data => {
 					// Handle the case where there is no metadata service
-					if (types.isUndefinedOrNull(data)) {
-						data = [];
-					}
+					data = data || [];
 					let profileData = data.map(d => {
 						let profile = new ConnectionProfile(this.capabilitiesService, currentProfile);
 						profile.databaseName = d;

--- a/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
@@ -166,7 +166,6 @@ export class TasksWidget extends DashboardWidget implements IDashboardWidget, On
 	}
 
 	public runTask(task: ICommandAction) {
-		let serverInfo = this._bootstrap.connectionManagementService.connectionInfo.serverInfo;
 		this.commandService.executeCommand(task.id, this._profile);
 	}
 

--- a/src/sql/services/metadata/metadataService.ts
+++ b/src/sql/services/metadata/metadataService.ts
@@ -63,7 +63,7 @@ export class MetadataService implements IMetadataService {
 			}
 		}
 
-		return Promise.resolve(undefined);
+		return Promise.resolve([]);
 	}
 
 	public getTableInfo(connectionUri: string, metadata: sqlops.ObjectMetadata): Thenable<sqlops.ColumnMetadata[]> {


### PR DESCRIPTION
- Fix a number of issues that arose while testing a provider without a metadata service or serverInfo object returned via DMP calls. These should be optional services/features and we should be resilient to them not existing. In most places we already have these checks
- This does not cover a number of "improvement" scenarios, such as filtering extension tabs by provider, and defaulting any tabs that don't specify a provider to be MSSQL. This and some other features to ensure things make sense will be implemented in separate PRs but this unblocked the scenario