### PR TITLE
Fix null ref error when no database or server node are in object tree

### DIFF
--- a/src/sql/parts/objectExplorer/common/treeNode.ts
+++ b/src/sql/parts/objectExplorer/common/treeNode.ts
@@ -96,11 +96,11 @@ export class TreeNode {
 			return undefined;
 		}
 		var currentNode: TreeNode = this;
-		while (currentNode.nodeTypeId !== NodeType.Database && currentNode.nodeTypeId !== NodeType.Server) {
+		while (currentNode.nodeTypeId !== NodeType.Database && currentNode.nodeTypeId !== NodeType.Server && currentNode.parent) {
 			currentNode = currentNode.parent;
 		}
 
-		if (currentNode.nodeTypeId === NodeType.Database) {
+		if (currentNode && currentNode.nodeTypeId === NodeType.Database) {
 			return currentNode.metadata ? currentNode.metadata.name : null;
 		}
 		return undefined;

--- a/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
+++ b/src/sql/parts/objectExplorer/viewlet/treeUpdateUtils.ts
@@ -181,7 +181,7 @@ export class TreeUpdateUtils {
 					connectedConnection.options['groupId'] = connection.groupId;
 					connectedConnection.options['databaseDisplayName'] = connection.databaseName;
 
-					var rootNode: TreeNode = objectExplorerService.getObjectExplorerNode(connectedConnection);
+					let rootNode: TreeNode = objectExplorerService.getObjectExplorerNode(connectedConnection);
 					if (!rootNode) {
 						objectExplorerService.updateObjectExplorerNodes(connectedConnection).then(() => {
 							rootNode = objectExplorerService.getObjectExplorerNode(connectedConnection);
@@ -207,7 +207,7 @@ export class TreeUpdateUtils {
 			if (connection.isDisconnecting) {
 				resolve([]);
 			} else {
-				var rootNode = objectExplorerService.getObjectExplorerNode(connection);
+				let rootNode = objectExplorerService.getObjectExplorerNode(connection);
 				if (rootNode) {
 					objectExplorerService.resolveTreeNodeChildren(rootNode.getSession(), rootNode).then(() => {
 						resolve(rootNode.children);
@@ -226,7 +226,7 @@ export class TreeUpdateUtils {
 		if (objectExplorerNode && objectExplorerNode.parent) {
 			// if object explorer node's parent is root, return connection profile
 			if (!objectExplorerNode.parent.parent) {
-				var connectionId = objectExplorerNode.getConnectionProfile().id;
+				let connectionId = objectExplorerNode.getConnectionProfile().id;
 
 				// get connection profile from connection profile groups
 				let root = TreeUpdateUtils.getTreeInput(connectionManagementService);
@@ -268,8 +268,8 @@ export class TreeUpdateUtils {
 	 * Get connection profile with the current database
 	 */
 	public static getConnectionProfile(treeNode: TreeNode): ConnectionProfile {
-		var connectionProfile = treeNode.getConnectionProfile();
-		var databaseName = treeNode.getDatabaseName();
+		let connectionProfile = treeNode.getConnectionProfile();
+		let databaseName = treeNode.getDatabaseName();
 		if (databaseName !== undefined && connectionProfile.databaseName !== databaseName) {
 			connectionProfile = connectionProfile.cloneWithDatabase(databaseName);
 		}


### PR DESCRIPTION
- Also fixed minor issue where `var` was used instead of `let` in a related file, since this is discouraged in our codebase.