### PR TITLE
Fix model view input box bugs

### DIFF
--- a/src/sql/base/browser/ui/inputBox/inputBox.ts
+++ b/src/sql/base/browser/ui/inputBox/inputBox.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';
-import { InputBox as vsInputBox, IInputOptions, IInputBoxStyles as vsIInputBoxStyles } from 'vs/base/browser/ui/inputbox/inputBox';
+import { InputBox as vsInputBox, IInputOptions, IInputBoxStyles as vsIInputBoxStyles, IMessage } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IContextViewProvider } from 'vs/base/browser/ui/contextview/contextview';
 import { Color } from 'vs/base/common/color';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -33,6 +33,7 @@ export class InputBox extends vsInputBox {
 	public onLoseFocus: Event<OnLoseFocusParams> = this._onLoseFocus.event;
 
 	private _isTextAreaInput: boolean;
+	private _hideErrors = false;
 
 	constructor(container: HTMLElement, contextViewProvider: IContextViewProvider, options?: IInputOptions) {
 		super(container, contextViewProvider, options);
@@ -102,5 +103,22 @@ export class InputBox extends vsInputBox {
 
 	public isEnabled(): boolean {
 		return !this.inputElement.hasAttribute('disabled');
+	}
+
+	public get hideErrors(): boolean {
+		return this._hideErrors;
+	}
+
+	public set hideErrors(hideErrors: boolean) {
+		this._hideErrors = hideErrors;
+		if (hideErrors) {
+			this.hideMessage();
+		}
+	}
+
+	public showMessage(message: IMessage, force?: boolean): void {
+		if (!this.hideErrors) {
+			super.showMessage(message, force);
+		}
 	}
 }

--- a/src/sql/parts/modelComponents/componentBase.ts
+++ b/src/sql/parts/modelComponents/componentBase.ts
@@ -207,7 +207,9 @@ export abstract class ContainerBase<T> extends ComponentBase {
 	) {
 		super(_changeRef);
 		this.items = [];
-		this._validations.push(() => this.items.every(item => this.modelStore.getComponent(item.descriptor.id).valid));
+		this._validations.push(() => this.items.every(item => {
+			return this.modelStore.getComponent(item.descriptor.id).valid;
+		}));
 	}
 
 	/// IComponent container-related implementation

--- a/src/sql/platform/dialog/dialogContainer.component.ts
+++ b/src/sql/platform/dialog/dialogContainer.component.ts
@@ -56,7 +56,7 @@ export class DialogContainer implements AfterContentInit {
 
 	ngAfterContentInit(): void {
 		this._modelViewContent.onEvent(event => {
-			if (event.eventType === ComponentEventType.validityChanged) {
+			if (event.isRootComponent && event.eventType === ComponentEventType.validityChanged) {
 				this._params.validityChangedCallback(event.args);
 			}
 		});

--- a/src/sql/services/model/modelViewService.ts
+++ b/src/sql/services/model/modelViewService.ts
@@ -6,12 +6,17 @@
 'use strict';
 import * as sqlops from 'sqlops';
 import { IItemConfig, IComponentShape } from 'sql/workbench/api/common/sqlExtHostTypes';
-import { Event, Emitter } from 'vs/base/common/event';
+import { IComponentEventArgs } from 'sql/parts/modelComponents/interfaces';
+import { Event } from 'vs/base/common/event';
 
 export interface IView {
 	readonly id: string;
 	readonly connection: sqlops.connection.Connection;
 	readonly serverInfo: sqlops.ServerInfo;
+}
+
+export interface IModelViewEventArgs extends IComponentEventArgs {
+	isRootComponent: boolean;
 }
 
 export interface IModelView extends IView {
@@ -21,7 +26,7 @@ export interface IModelView extends IView {
 	setLayout(componentId: string, layout: any): void;
 	setProperties(componentId: string, properties: { [key: string]: any }): void;
 	registerEvent(componentId: string);
-	onEvent: Event<any>;
+	onEvent: Event<IModelViewEventArgs>;
 	validate(componentId: string): Thenable<boolean>;
 	readonly onDestroy: Event<void>;
 }

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -133,6 +133,7 @@ declare module 'sqlops' {
 		component: Component;
 		title: string;
 		actions?: Component[];
+		required?: boolean;
 	}
 
 	export interface ToolbarComponent {
@@ -240,7 +241,6 @@ declare module 'sqlops' {
 		componentWidth?: number | string;
 		componentHeight?: number | string;
 		titleFontSize?: number | string;
-		required?: boolean;
 		info?: string;
 	}
 

--- a/src/sql/workbench/api/node/extHostModelView.ts
+++ b/src/sql/workbench/api/node/extHostModelView.ts
@@ -255,7 +255,7 @@ class FormContainerBuilder extends ContainerBuilderImpl<sqlops.FormContainer, sq
 
 	private convertToItemConfig(formComponent: sqlops.FormComponent, itemLayout?: sqlops.FormItemLayout): InternalItemConfig {
 		let componentWrapper = formComponent.component as ComponentWrapper;
-		if (itemLayout && itemLayout.required && componentWrapper) {
+		if (formComponent.required && componentWrapper) {
 			componentWrapper.required = true;
 		}
 		let actions: string[] = undefined;
@@ -269,7 +269,8 @@ class FormContainerBuilder extends ContainerBuilderImpl<sqlops.FormContainer, sq
 		return new InternalItemConfig(componentWrapper, Object.assign({}, itemLayout, {
 			title: formComponent.title,
 			actions: actions,
-			isFormComponent: true
+			isFormComponent: true,
+			required: componentWrapper.required
 		}));
 	}
 

--- a/src/sqltest/workbench/api/extHostModelView.test.ts
+++ b/src/sqltest/workbench/api/extHostModelView.test.ts
@@ -128,4 +128,24 @@ suite('ExtHostModelView Validation Tests', () => {
 		});
 		assert.equal(validityFromEvent, false, 'Main thread validityChanged event did not cause component to fire its own event');
 	});
+
+	test('Setting a form component as required initializes the model with the component required', () => {
+		// Set up the input component with required initially set to false
+		let inputComponent = modelView.modelBuilder.inputBox().component();
+		inputComponent.required = false;
+
+		// If I build a form that sets the input component as required
+		let inputFormComponent: sqlops.FormComponent = {
+			component: inputComponent,
+			title: 'test_input',
+			required: true
+		};
+		let requiredFormContainer = modelView.modelBuilder.formContainer().withFormItems([inputFormComponent]).component();
+		modelView.initializeModel(requiredFormContainer);
+
+		// Then the input component is sent to the main thread with required set to true
+		mockProxy.verify(x => x.$initializeModel(It.isAny(), It.is(rootComponent => {
+			return rootComponent.itemConfigs.length === 1 && rootComponent.itemConfigs[0].componentShape.id === inputComponent.id && rootComponent.itemConfigs[0].componentShape.properties['required'] === true;
+		})), Times.once());
+	});
 });


### PR DESCRIPTION
This fixes #1767, specifically
- Validation messages aren't shown on input boxes until the user has entered some input into the box (like the connection dialog)
- Input boxes are now marked with * when they're required even if the required property was set directly on the input box instead of on the form component
- Fixed a bug where dialog pages became valid if any one of their components became valid, rather than all of their components, which happened because pages subscribed to the validity changed events for all their components instead of just the root container

Note that this changes the form API slightly by putting the `required` property on the form component itself rather than the item layout