### PR TITLE
Ensure dashboard tabs only show for supported providers

### DIFF
--- a/src/sql/parts/connection/common/constants.ts
+++ b/src/sql/parts/connection/common/constants.ts
@@ -21,6 +21,8 @@ export const capabilitiesOptions = 'OPTIONS_METADATA';
 export const configMaxRecentConnections = 'maxRecentConnections';
 
 export const mssqlProviderName = 'MSSQL';
+export const anyProviderName = '*';
+export const connectionProviderContextKey = 'connectionProvider';
 
 export const applicationName = 'sqlops';
 

--- a/src/sql/parts/dashboard/common/dashboardHelper.ts
+++ b/src/sql/parts/dashboard/common/dashboardHelper.ts
@@ -168,11 +168,9 @@ export function addContext(config: WidgetConfig[], collection: any, context: str
  */
 export function filterConfigs<T extends { provider?: string | string[], when?: string }, K extends { contextKeyService: IContextKeyService }>(config: T[], collection: K): Array<T> {
 	return config.filter((item) => {
-		let when = item.when;
-
 		if (!hasCompatibleProvider(item.provider, collection.contextKeyService)) {
 			return false;
-		} else if (!when) {
+		} else if (!item.when) {
 			return true;
 		} else {
 			return collection.contextKeyService.contextMatchesRules(ContextKeyExpr.deserialize(item.when));

--- a/src/sql/parts/dashboard/common/dashboardPage.component.ts
+++ b/src/sql/parts/dashboard/common/dashboardPage.component.ts
@@ -17,11 +17,12 @@ import { IDashboardRegistry, Extensions as DashboardExtensions, IDashboardTab } 
 import { PinUnpinTabAction, AddFeatureTabAction } from './actions';
 import { TabComponent, TabChild } from 'sql/base/browser/ui/panel/tab.component';
 import { AngularEventType, IAngularEventingService } from 'sql/services/angularEventing/angularEventingService';
-import { DashboardTab } from 'sql/parts/dashboard/common/interfaces';
+import { DashboardTab, IConfigModifierCollection } from 'sql/parts/dashboard/common/interfaces';
 import * as dashboardHelper from 'sql/parts/dashboard/common/dashboardHelper';
 import { WIDGETS_CONTAINER } from 'sql/parts/dashboard/containers/dashboardWidgetContainer.contribution';
 import { GRID_CONTAINER } from 'sql/parts/dashboard/containers/dashboardGridContainer.contribution';
 import { AngularDisposable } from 'sql/base/common/lifecycle';
+import * as Constants from 'sql/parts/connection/common/constants';
 
 import { Registry } from 'vs/platform/registry/common/platform';
 import * as types from 'vs/base/common/types';
@@ -38,16 +39,11 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 const dashboardRegistry = Registry.as<IDashboardRegistry>(DashboardExtensions.DashboardContributions);
 
-interface IConfigModifierCollection {
-	connectionManagementService: SingleConnectionManagementService;
-	contextKeyService: IContextKeyService;
-}
-
 @Component({
 	selector: 'dashboard-page',
 	templateUrl: decodeURI(require.toUrl('sql/parts/dashboard/common/dashboardPage.component.html'))
 })
-export abstract class DashboardPage extends AngularDisposable {
+export abstract class DashboardPage extends AngularDisposable implements IConfigModifierCollection {
 
 	protected tabs: Array<TabConfig> = [];
 
@@ -140,6 +136,7 @@ export abstract class DashboardPage extends AngularDisposable {
 		// Create home tab
 		let homeTab: TabConfig = {
 			id: 'homeTab',
+			provider: Constants.anyProviderName,
 			publisher: undefined,
 			title: this.homeTabTitle,
 			container: { 'widgets-container': homeWidgets },
@@ -218,7 +215,7 @@ export abstract class DashboardPage extends AngularDisposable {
 				if (key === WIDGETS_CONTAINER || key === GRID_CONTAINER) {
 					let configs = <WidgetConfig[]>Object.values(containerResult.container)[0];
 					this._configModifiers.forEach(cb => {
-						configs = cb.apply(this, [configs, this.dashboardService, this.context]);
+						configs = cb.apply(this, [configs, this, this.context]);
 					});
 					this._gridModifiers.forEach(cb => {
 						configs = cb.apply(this, [configs]);

--- a/src/sql/parts/dashboard/common/dashboardTab.contribution.ts
+++ b/src/sql/parts/dashboard/common/dashboardTab.contribution.ts
@@ -44,7 +44,7 @@ const tabSchema: IJSONSchema = {
 			type: 'string'
 		},
 		provider: {
-			description: localize('sqlops.extension.contributes.tab.provider', 'Defines the types of connection can this tab work with. Defaults to "MSSQL" if not set'),
+			description: localize('sqlops.extension.contributes.tab.provider', 'Defines the connection types this tab is compatible with. Defaults to "MSSQL" if not set'),
 			type: ['string', 'array']
 
 		},

--- a/src/sql/parts/dashboard/common/dashboardTab.contribution.ts
+++ b/src/sql/parts/dashboard/common/dashboardTab.contribution.ts
@@ -7,6 +7,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { localize } from 'vs/nls';
 import * as types from 'vs/base/common/types';
 
+import * as Constants from 'sql/parts/connection/common/constants';
 import { registerTab } from 'sql/platform/dashboard/common/dashboardRegistry';
 import { generateContainerTypeSchemaProperties } from 'sql/platform/dashboard/common/dashboardContainerRegistry';
 import { NAV_SECTION, validateNavSectionContributionAndRegisterIcon } from 'sql/parts/dashboard/containers/dashboardNavSection.contribution';
@@ -17,6 +18,7 @@ export interface IDashboardTabContrib {
 	id: string;
 	title: string;
 	container: object;
+	provider: string | string[];
 	when?: string;
 	description?: string;
 	alwaysShow?: boolean;
@@ -40,6 +42,11 @@ const tabSchema: IJSONSchema = {
 		when: {
 			description: localize('sqlops.extension.contributes.tab.when', 'Condition which must be true to show this item'),
 			type: 'string'
+		},
+		provider: {
+			description: localize('sqlops.extension.contributes.tab.provider', 'Defines the types of connection can this tab work with. Defaults to "MSSQL" if not set'),
+			type: ['string', 'array']
+
 		},
 		container: {
 			description: localize('sqlops.extension.contributes.dashboard.tab.container', "The container that will be displayed in this tab."),
@@ -67,7 +74,7 @@ const tabContributionSchema: IJSONSchema = {
 ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabContrib[]>('dashboard.tabs', [], tabContributionSchema).setHandler(extensions => {
 
 	function handleCommand(tab: IDashboardTabContrib, extension: IExtensionPointUser<any>) {
-		let { description, container, title, when, id, alwaysShow } = tab;
+		let { description, container, provider, title, when, id, alwaysShow } = tab;
 
 		// If always show is not specified, set it to true by default.
 		if (!types.isBoolean(alwaysShow)) {
@@ -86,6 +93,11 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 		if (!container) {
 			extension.collector.error(localize('dashboardTab.contribution.noContainerError', 'No container specified for extension.'));
 			return;
+		}
+
+		if (!provider) {
+			// Use a default. Consider warning extension developers about this in the future if in development mode
+			provider = Constants.mssqlProviderName;
 		}
 
 		if (Object.keys(container).length !== 1) {
@@ -110,7 +122,7 @@ ExtensionsRegistry.registerExtensionPoint<IDashboardTabContrib | IDashboardTabCo
 		}
 
 		if (result) {
-			registerTab({ description, title, container, when, id, alwaysShow, publisher });
+			registerTab({ description, title, container, provider, when, id, alwaysShow, publisher });
 		}
 	}
 

--- a/src/sql/parts/dashboard/common/interfaces.ts
+++ b/src/sql/parts/dashboard/common/interfaces.ts
@@ -7,9 +7,11 @@ import { OnDestroy } from '@angular/core';
 
 import { Event } from 'vs/base/common/event';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 import { AngularDisposable } from 'sql/base/common/lifecycle';
 import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
+import { SingleConnectionManagementService } from 'sql/services/common/commonServiceInterface.service';
 
 export enum Conditional {
 	'equals',
@@ -49,4 +51,9 @@ export abstract class DashboardTab extends TabChild implements OnDestroy {
 	ngOnDestroy() {
 		this.dispose();
 	}
+}
+
+export interface IConfigModifierCollection {
+	connectionManagementService: SingleConnectionManagementService;
+	contextKeyService: IContextKeyService;
 }

--- a/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
+++ b/src/sql/parts/dashboard/containers/dashboardNavSection.component.ts
@@ -5,28 +5,27 @@
 
 import 'vs/css!./dashboardNavSection';
 
-import { Component, Inject, Input, forwardRef, ViewChild, ElementRef, ViewChildren, QueryList, OnDestroy, ChangeDetectorRef, EventEmitter, OnChanges, AfterContentInit } from '@angular/core';
+import { Component, Inject, Input, forwardRef, ViewChild, ElementRef, ViewChildren, QueryList, OnDestroy, ChangeDetectorRef, OnChanges, AfterContentInit } from '@angular/core';
 
-import { DashboardServiceInterface } from 'sql/parts/dashboard/services/dashboardServiceInterface.service';
-import { CommonServiceInterface } from 'sql/services/common/commonServiceInterface.service';
+import { CommonServiceInterface, SingleConnectionManagementService } from 'sql/services/common/commonServiceInterface.service';
 import { WidgetConfig, TabConfig, NavSectionConfig } from 'sql/parts/dashboard/common/dashboardWidget';
 import { PanelComponent, IPanelOptions, NavigationBarLayout } from 'sql/base/browser/ui/panel/panel.component';
-import { TabComponent, TabChild } from 'sql/base/browser/ui/panel/tab.component';
-import { DashboardTab } from 'sql/parts/dashboard/common/interfaces';
+import { TabChild } from 'sql/base/browser/ui/panel/tab.component';
+import { DashboardTab, IConfigModifierCollection } from 'sql/parts/dashboard/common/interfaces';
 import { WIDGETS_CONTAINER } from 'sql/parts/dashboard/containers/dashboardWidgetContainer.contribution';
 import { GRID_CONTAINER } from 'sql/parts/dashboard/containers/dashboardGridContainer.contribution';
 import * as dashboardHelper from 'sql/parts/dashboard/common/dashboardHelper';
 
-import { Registry } from 'vs/platform/registry/common/platform';
 import { Event, Emitter } from 'vs/base/common/event';
 import * as nls from 'vs/nls';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 @Component({
 	selector: 'dashboard-nav-section',
 	providers: [{ provide: TabChild, useExisting: forwardRef(() => DashboardNavSection) }],
 	templateUrl: decodeURI(require.toUrl('sql/parts/dashboard/containers/dashboardNavSection.component.html'))
 })
-export class DashboardNavSection extends DashboardTab implements OnDestroy, OnChanges, AfterContentInit {
+export class DashboardNavSection extends DashboardTab implements OnDestroy, OnChanges, AfterContentInit, IConfigModifierCollection {
 	@Input() private tab: TabConfig;
 	protected tabs: Array<TabConfig> = [];
 	private _onResize = new Emitter<void>();
@@ -38,7 +37,7 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 	};
 
 	// a set of config modifiers
-	private readonly _configModifiers: Array<(item: Array<WidgetConfig>, dashboardServer: DashboardServiceInterface, context: string) => Array<WidgetConfig>> = [
+	private readonly _configModifiers: Array<(item: Array<WidgetConfig>, collection: IConfigModifierCollection, context: string) => Array<WidgetConfig>> = [
 		dashboardHelper.removeEmpty,
 		dashboardHelper.initExtensionConfigs,
 		dashboardHelper.addProvider,
@@ -103,7 +102,7 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 				if (key === WIDGETS_CONTAINER || key === GRID_CONTAINER) {
 					let configs = <WidgetConfig[]>Object.values(containerResult.container)[0];
 					this._configModifiers.forEach(cb => {
-						configs = cb.apply(this, [configs, this.dashboardService, this.tab.context]);
+						configs = cb.apply(this, [configs, this, this.tab.context]);
 					});
 					this._gridModifiers.forEach(cb => {
 						configs = cb.apply(this, [configs]);
@@ -168,5 +167,13 @@ export class DashboardNavSection extends DashboardTab implements OnDestroy, OnCh
 				tabContent.enableEdit();
 			});
 		}
+	}
+
+	public get connectionManagementService(): SingleConnectionManagementService {
+		return this.dashboardService.connectionManagementService;
+	}
+
+	public get contextKeyService(): IContextKeyService {
+		return this.dashboardService.scopedContextKeyService;
 	}
 }

--- a/src/sql/platform/dashboard/common/dashboardRegistry.ts
+++ b/src/sql/platform/dashboard/common/dashboardRegistry.ts
@@ -7,7 +7,6 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IConfigurationRegistry, Extensions as ConfigurationExtension } from 'vs/platform/configuration/common/configurationRegistry';
 import { IJSONSchema, IJSONSchemaMap } from 'vs/base/common/jsonSchema';
 import * as nls from 'vs/nls';
-import { deepClone } from 'vs/base/common/objects';
 import { IExtensionPointUser, ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
 
 import { ProviderProperties } from 'sql/parts/dashboard/widgets/properties/propertiesWidget.component';
@@ -22,6 +21,7 @@ export const Extensions = {
 export interface IDashboardTab {
 	id: string;
 	title: string;
+	provider: string | string[];
 	publisher: string;
 	description?: string;
 	container?: object;


### PR DESCRIPTION
- Fixes #1764, fixes #1765
- Fixes bug where configModifiers were passed in the dashboard service in some places, and a different object with incompatible / missing fields in a different one. Now it always passes in the owner object, and this should have the required fields
  - Note: this doesn't fix the problem where the code does not fail to build, which I would have expected to be the case.
- Adds "provider" as an option for TabConfig including in the schema
- Filter by "provider" type when loading tabs. If provider is not set for a tab, will assume "MSSQL" since it's the default provider. This is a design decision - without this, we would either have to disable tabs that don't show this or have them incorrectly show for non-MSSQL provider types

Notes:
- Does not override behavior for individual widgets, which still get the current provider set as their provider if not specified. This seems to be required so should be fine.
- We will fix tasks/widgets that aren't supported by a provider showing up in a separate PR, since it's a different issue