### PR TITLE
Fix webview editor height issue

### DIFF
--- a/src/sql/platform/dialog/dialogContainer.component.ts
+++ b/src/sql/platform/dialog/dialogContainer.component.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 import 'vs/css!./media/dialogModal';
-import { Component, AfterContentInit, ViewChild, Input, Inject, forwardRef, ElementRef } from '@angular/core';
+import { Component, ViewChild, Inject, forwardRef, ElementRef, AfterViewInit } from '@angular/core';
 import { ModelViewContent } from 'sql/parts/modelComponents/modelViewContent.component';
 import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
 import { DialogPane } from 'sql/platform/dialog/dialogPane';
@@ -24,7 +24,7 @@ export interface DialogComponentParams extends IBootstrapParams {
 	selector: 'dialog-modelview-container',
 	providers: [],
 	template: `
-		<div class="dialogContainer">
+		<div class="dialogContainer" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
 			<div class="dialogModal-wizardHeader" *ngIf="_dialogPane && _dialogPane.displayPageTitle">
 				<div *ngIf="_dialogPane.pageNumber" class="wizardPageNumber">Step {{_dialogPane.pageNumber}}</div>
 				<h1 class="wizardPageTitle">{{_dialogPane.title}}</h1>
@@ -33,9 +33,11 @@ export interface DialogComponentParams extends IBootstrapParams {
 			<modelview-content [modelViewId]="modelViewId">
 			</modelview-content>
 		</div>
+		<modelview-content [modelViewId]="modelViewId" *ngIf="!_dialogPane || !_dialogPane.displayPageTitle">
+		</modelview-content>
 	`
 })
-export class DialogContainer implements AfterContentInit {
+export class DialogContainer implements AfterViewInit {
 	private _onResize = new Emitter<void>();
 	public readonly onResize: Event<void> = this._onResize.event;
 	private _dialogPane: DialogPane;
@@ -54,7 +56,7 @@ export class DialogContainer implements AfterContentInit {
 		this._dialogPane = this._params.dialogPane;
 	}
 
-	ngAfterContentInit(): void {
+	ngAfterViewInit(): void {
 		this._modelViewContent.onEvent(event => {
 			if (event.isRootComponent && event.eventType === ComponentEventType.validityChanged) {
 				this._params.validityChangedCallback(event.args);


### PR DESCRIPTION
Fixes #1806 by using different templates for model views contained in dialogs/editors vs. wizards
