### PR TITLE
Fixes implicit any type - issue #1814

### DIFF
--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -1131,7 +1131,7 @@ declare module 'sqlops' {
 		frequencyTypes: FrequencyTypes;
 		frequencySubDayTypes: FrequencySubDayTypes;
 		frequencySubDayInterval: number;
-		frequencyRelativeIntervals; FrequencyRelativeIntervals;
+		frequencyRelativeIntervals: FrequencyRelativeIntervals;
 		frequencyRecurrenceFactor: number;
 		frequencyInterval: number;
 		dateCreated: string;


### PR DESCRIPTION
This requests fixes the issues in #1814 

There is a typo in src/sql/sqlops.d.ts where an incorrect `;` should be `:` and causing an implicit any type declaration.