### PR TITLE
Update query editor connection display when connecting via API

### DIFF
--- a/src/sql/workbench/api/node/mainThreadQueryEditor.ts
+++ b/src/sql/workbench/api/node/mainThreadQueryEditor.ts
@@ -9,9 +9,7 @@ import * as sqlops from 'sqlops';
 import * as vscode from 'vscode';
 import { IExtHostContext } from 'vs/workbench/api/node/extHost.protocol';
 import { extHostNamedCustomer } from 'vs/workbench/api/electron-browser/extHostCustomers';
-import { IConnectableInput, IConnectionManagementService, IConnectionCompletionOptions,
-	ConnectionType , RunQueryOnConnectionMode
-} from 'sql/parts/connection/common/connectionManagement';
+import { IConnectionManagementService, IConnectionCompletionOptions, ConnectionType, RunQueryOnConnectionMode } from 'sql/parts/connection/common/connectionManagement';
 import { IQueryEditorService } from 'sql/parts/query/common/queryEditorService';
 import { QueryEditor } from 'sql/parts/query/editor/queryEditor';
 import { IWorkbenchEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -41,12 +39,13 @@ export class MainThreadQueryEditor implements MainThreadQueryEditorShape {
 
 	public $connect(fileUri: string, connectionId: string): Thenable<void> {
 		return new Promise<void>((resolve, reject) => {
+			let editor = this._editorService.getVisibleEditors().find(editor => editor.input.getResource().toString() === fileUri);
 			let options: IConnectionCompletionOptions = {
-				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none },
+				params: { connectionType: ConnectionType.editor, runQueryOnCompletion: RunQueryOnConnectionMode.none, input: editor ? editor.input as any : undefined },
 				saveTheConnection: false,
 				showDashboard: false,
 				showConnectionDialogOnError: true,
-				showFirewallRuleOnError: true
+				showFirewallRuleOnError: true,
 			};
 			if (connectionId) {
 				let connection = this._connectionManagementService.getActiveConnections().filter(c => c.id === connectionId);
@@ -54,7 +53,7 @@ export class MainThreadQueryEditor implements MainThreadQueryEditorShape {
 					this._connectionManagementService.connect(connection[0], fileUri, options).then(() => {
 						resolve();
 					}).catch(error => {
-						reject();
+						reject(error);
 					});
 				} else {
 					resolve();


### PR DESCRIPTION
Fixes #1791 by including the editor input in the connect call when using the `sqlops.queryeditor.connect` API if the editor is visible. This still works correctly for editors that aren't visible since their task bars get updated when the user reopens the editor.