### PR TITLE
Updating keybindings

### DIFF
--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -60,6 +60,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: CommandsRegistry.getCommand('profiler.newProfiler').handler
 });
 
+/*
 CommandsRegistry.registerCommand({
 	id: 'profiler.start',
 	handler: (accessor: ServicesAccessor) => {
@@ -89,9 +90,10 @@ CommandsRegistry.registerCommand({
 		return TPromise.as(false);
 	}
 });
+*/
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: 'profiler.toggleStart',
+	id: 'profiler.toggleStartStop',
 	weight: KeybindingsRegistry.WEIGHT.editorContrib(),
 	when: undefined,
 	primary: KeyMod.Alt | KeyCode.KEY_S,

--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -55,7 +55,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'profiler.newProfiler',
 	weight: KeybindingsRegistry.WEIGHT.builtinExtension(),
 	when: undefined,
-	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_P,
+	primary: KeyMod.Alt | KeyCode.KEY_P,
 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_P },
 	handler: CommandsRegistry.getCommand('profiler.newProfiler').handler
 });
@@ -85,6 +85,29 @@ CommandsRegistry.registerCommand({
 		if (activeEditor instanceof ProfilerEditor) {
 			let profilerInput = activeEditor.input;
 			return profilerService.stopSession(profilerInput.id);
+		}
+		return TPromise.as(false);
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'profiler.toggleStart',
+	weight: KeybindingsRegistry.WEIGHT.editorContrib(),
+	when: undefined,
+	primary: KeyMod.Alt | KeyCode.KEY_S,
+	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_S },
+	handler: (accessor: ServicesAccessor) => {
+		let profilerService: IProfilerService = accessor.get(IProfilerService);
+		let editorService: IWorkbenchEditorService = accessor.get(IWorkbenchEditorService);
+
+		let activeEditor = editorService.getActiveEditor();
+		if (activeEditor instanceof ProfilerEditor) {
+			let profilerInput = activeEditor.input;
+			if (profilerInput.state.isRunning){
+				return profilerService.stopSession(profilerInput.id);
+			} else {
+				return profilerService.startSession(profilerInput.id);
+			}
 		}
 		return TPromise.as(false);
 	}

--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -76,6 +76,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 			if (profilerInput.state.isRunning){
 				return profilerService.stopSession(profilerInput.id);
 			} else {
+				// clear data when profiler is started
+				profilerInput.data.clear();
 				return profilerService.startSession(profilerInput.id);
 			}
 		}

--- a/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.contribution.ts
@@ -56,48 +56,16 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingsRegistry.WEIGHT.builtinExtension(),
 	when: undefined,
 	primary: KeyMod.Alt | KeyCode.KEY_P,
-	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_P },
+	mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.KEY_P },
 	handler: CommandsRegistry.getCommand('profiler.newProfiler').handler
 });
-
-/*
-CommandsRegistry.registerCommand({
-	id: 'profiler.start',
-	handler: (accessor: ServicesAccessor) => {
-		let profilerService: IProfilerService = accessor.get(IProfilerService);
-		let editorService: IWorkbenchEditorService = accessor.get(IWorkbenchEditorService);
-
-		let activeEditor = editorService.getActiveEditor();
-		if (activeEditor instanceof ProfilerEditor) {
-			let profilerInput = activeEditor.input;
-			return profilerService.startSession(profilerInput.id);
-		}
-		return TPromise.as(false);
-	}
-});
-
-CommandsRegistry.registerCommand({
-	id: 'profiler.stop',
-	handler: (accessor: ServicesAccessor) => {
-		let profilerService: IProfilerService = accessor.get(IProfilerService);
-		let editorService: IWorkbenchEditorService = accessor.get(IWorkbenchEditorService);
-
-		let activeEditor = editorService.getActiveEditor();
-		if (activeEditor instanceof ProfilerEditor) {
-			let profilerInput = activeEditor.input;
-			return profilerService.stopSession(profilerInput.id);
-		}
-		return TPromise.as(false);
-	}
-});
-*/
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'profiler.toggleStartStop',
 	weight: KeybindingsRegistry.WEIGHT.editorContrib(),
 	when: undefined,
 	primary: KeyMod.Alt | KeyCode.KEY_S,
-	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KEY_S },
+	mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.KEY_S },
 	handler: (accessor: ServicesAccessor) => {
 		let profilerService: IProfilerService = accessor.get(IProfilerService);
 		let editorService: IWorkbenchEditorService = accessor.get(IWorkbenchEditorService);


### PR DESCRIPTION
Addressing default profiler keybinding changes in #1695. Instead of two separate commands for starting and stopping the profiler there's now a toggle command, and default keybindings are changed.