### PR TITLE
Update card layout to give more icon space

### DIFF
--- a/src/sql/parts/modelComponents/button.css
+++ b/src/sql/parts/modelComponents/button.css
@@ -6,4 +6,5 @@
 modelview-button a.monaco-button.monaco-text-button.icon {
 	background-repeat: no-repeat;
 	background-position: 0% 50%;
+	background-size: contain;
 }

--- a/src/sql/parts/modelComponents/card.component.html
+++ b/src/sql/parts/modelComponents/card.component.html
@@ -6,7 +6,7 @@
 		<ng-container *ngIf="isVerticalButton">
 			<div class="card-vertical-button">
 				<div *ngIf="iconPath" class="iconContainer">
-					<div [class]="iconClass" [style.width]="iconWidth" [style.height]="iconHeight"></div>
+					<div [class]="iconClass" [style.maxWidth]="iconWidth" [style.maxHeight]="iconHeight"></div>
 				</div>
 				<h4 class="card-label">{{label}}</h4>
 			</div>

--- a/src/sql/parts/modelComponents/card.component.html
+++ b/src/sql/parts/modelComponents/card.component.html
@@ -5,10 +5,10 @@
 
 		<ng-container *ngIf="isVerticalButton">
 			<div class="card-vertical-button">
-				<div *ngIf="iconPath" class="iconContainer"><div [class]="iconClass" [style.width]="iconWidth" [style.height]="iconHeight"></div>
-				<hr/>
-				<h4 class="card-label">{{label}}</h4>
+				<div *ngIf="iconPath" class="iconContainer">
+					<div [class]="iconClass" [style.width]="iconWidth" [style.height]="iconHeight"></div>
 				</div>
+				<h4 class="card-label">{{label}}</h4>
 			</div>
 		</ng-container>
 

--- a/src/sql/parts/modelComponents/card.css
+++ b/src/sql/parts/modelComponents/card.css
@@ -61,6 +61,7 @@
 
 .model-card .iconContainer {
 	display: flex;
+	flex-direction: column;
 	justify-content: center;
 	align-items: center;
 	flex-grow: 1;
@@ -71,8 +72,11 @@
 
 .model-card .cardIcon {
 	display: inline-block;
-	width: 40px;
-	height: 40px;
+	flex-grow: 1;
+	width: 100%;
+	height: 100%;
+	max-width: 50px;
+	max-height: 50px;
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: contain;

--- a/src/sql/parts/modelComponents/card.css
+++ b/src/sql/parts/modelComponents/card.css
@@ -68,6 +68,7 @@
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
 	padding: 10px 0px 10px 0px;
+	border-color: rgb(214, 214, 214);
 }
 
 .model-card .cardIcon {

--- a/src/sql/parts/modelComponents/card.css
+++ b/src/sql/parts/modelComponents/card.css
@@ -39,7 +39,9 @@
 
 .model-card .card-vertical-button {
 	position: relative;
-	display: inline-block;
+	display: flex;
+	flex-direction: column;
+	text-align: center;
 	height: auto;
 	width: auto;
 	padding: 5px 5px 5px 5px;
@@ -58,9 +60,12 @@
 }
 
 .model-card .iconContainer {
-	width: 100%;
-	height: 50px;
-	text-align: center;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-grow: 1;
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
 	padding: 10px 0px 10px 0px;
 }
 

--- a/src/sql/parts/modelComponents/componentWithIconBase.ts
+++ b/src/sql/parts/modelComponents/componentWithIconBase.ts
@@ -91,11 +91,11 @@ export abstract class ComponentWithIconBase extends ComponentBase {
 	}
 
 	public get iconHeight(): number | string {
-		return this.getPropertyOrDefault<sqlops.ComponentWithIcon, number | string>((props) => props.iconHeight, '40px');
+		return this.getPropertyOrDefault<sqlops.ComponentWithIcon, number | string>((props) => props.iconHeight, '50px');
 	}
 
 	public get iconWidth(): number | string {
-		return this.getPropertyOrDefault<sqlops.ComponentWithIcon, number | string>((props) => props.iconWidth, '40px');
+		return this.getPropertyOrDefault<sqlops.ComponentWithIcon, number | string>((props) => props.iconWidth, '50px');
 	}
 
 	ngOnDestroy(): void {


### PR DESCRIPTION
This updates icon cards to look more like the mockups by making the icon area fill all of the card's available space instead of making the text area fill the space like it did before. It also lets extension authors use percentages to set the height and width:

<img width="191" alt="Two icon cards, the first with default height and width and the second with 100% height and width." src="https://user-images.githubusercontent.com/3758704/42348642-12234408-805f-11e8-98d4-8358e60e7bfd.png">
<img width="176" alt="Two icon cards, the first with 500px height and width (which displays the same as 100% since the card is not that large) and the second with 20x30px height and width" src="https://user-images.githubusercontent.com/3758704/42348643-12380456-805f-11e8-91bc-1be9f0d0bb7f.png">
