### PR TITLE
Fix enter button behavior for wizards and dialogs

### DIFF
--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -124,7 +124,7 @@ export class DialogModal extends Modal {
 	}
 
 	public async done(): Promise<void> {
-		if (this._dialog.okButton.enabled) {
+		if (this._doneButton.enabled) {
 			if (await this._dialog.validateClose()) {
 				this._onDone.fire();
 				this.dispose();

--- a/src/sql/platform/dialog/wizardModal.ts
+++ b/src/sql/platform/dialog/wizardModal.ts
@@ -207,7 +207,7 @@ export class WizardModal extends Modal {
 	}
 
 	public async done(validate: boolean = true): Promise<void> {
-		if (this._wizard.doneButton.enabled) {
+		if (this._doneButton.enabled) {
 			if (validate && !await this._wizard.validateNavigation(undefined)) {
 				return;
 			}
@@ -242,7 +242,13 @@ export class WizardModal extends Modal {
 	 * Overridable to change behavior of enter key
 	 */
 	protected onAccept(e: StandardKeyboardEvent) {
-		this.done();
+		if (this._wizard.currentPage === this._wizard.pages.length - 1) {
+			this.done();
+		} else {
+			if (this._nextButton.enabled) {
+				this.showPage(this._wizard.currentPage + 1);
+			}
+		}
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
Fixes #1864 by updating the wizard enter button handler to move to the next page or click done as needed, with proper validation, and by changing the dialog enter button to respect validation.