### PR TITLE
Update form layout defaults to match design

### DIFF
--- a/src/sql/parts/modelComponents/formContainer.component.ts
+++ b/src/sql/parts/modelComponents/formContainer.component.ts
@@ -45,7 +45,7 @@ class FormItem {
 	template: `
 		<div #container *ngIf="items" class="form-table" [style.padding]="getFormPadding()" [style.width]="getFormWidth()" [style.height]="getFormHeight()">
 			<ng-container *ngFor="let item of items">
-			<div class="form-row" *ngIf="isGroupLabel(item)">
+			<div class="form-row" *ngIf="isGroupLabel(item)" [style.font-size]="getItemTitleFontSize(item)">
 				<div class="form-item-row form-group-label">
 					<model-component-wrapper [descriptor]="item.descriptor" [modelStore]="modelStore">
 					</model-component-wrapper>
@@ -179,8 +179,12 @@ export default class FormContainer extends ContainerBase<FormItemLayout> impleme
 	}
 
 	private getItemTitleFontSize(item: FormItem): string {
+		let defaultFontSize = '14px';
+		if (this.isInGroup(item)) {
+			defaultFontSize = '12px';
+		}
 		let itemConfig = item.config;
-		return itemConfig && itemConfig.titleFontSize ? this.convertSize(itemConfig.titleFontSize, '11px') : '11px';
+		return itemConfig && itemConfig.titleFontSize ? this.convertSize(itemConfig.titleFontSize, defaultFontSize) : defaultFontSize;
 	}
 
 	private getActionComponents(item: FormItem): FormItem[] {

--- a/src/sql/parts/modelComponents/formLayout.css
+++ b/src/sql/parts/modelComponents/formLayout.css
@@ -18,7 +18,7 @@
 }
 
 .form-vertical-container {
-	padding-bottom: 15px;
+	padding-bottom: 5px;
 	width: 100%;
 }
 

--- a/src/sql/parts/modelComponents/formLayout.css
+++ b/src/sql/parts/modelComponents/formLayout.css
@@ -57,11 +57,8 @@
 	display: table-cell;
 }
 
-.form-group-item .form-item-row,
-.form-group-item.form-cell {
-	padding-left: 30px;
-}
-
 .form-group-label {
+	padding-top: 3px;
 	padding-bottom: 0px;
+	font-weight: bold;
 }


### PR DESCRIPTION
Makes the headers of top level components and groups bigger, makes the headers of groups bold, removes indentation for groups, and reduces the space between components.

![Form in a wizard with the new defaults](https://user-images.githubusercontent.com/3758704/42478780-db7c062c-838a-11e8-8403-ce66462a7a1b.png)
