### PR TITLE
Style SQL input box correctly when enabled/disabled

### DIFF
--- a/src/sql/base/browser/ui/inputBox/inputBox.ts
+++ b/src/sql/base/browser/ui/inputBox/inputBox.ts
@@ -63,13 +63,13 @@ export class InputBox extends vsInputBox {
 		this.enabledInputBorder = this.inputBorder;
 		this.disabledInputBackground = styles.disabledInputBackground;
 		this.disabledInputForeground = styles.disabledInputForeground;
+		this.updateInputEnabledDisabledColors();
+		this.applyStyles();
 	}
 
 	public enable(): void {
 		super.enable();
-		this.inputBackground = this.enabledInputBackground;
-		this.inputForeground = this.enabledInputForeground;
-		this.inputBorder = this.enabledInputBorder;
+		this.updateInputEnabledDisabledColors();
 		this.applyStyles();
 	}
 
@@ -89,9 +89,7 @@ export class InputBox extends vsInputBox {
 
 	public disable(): void {
 		super.disable();
-		this.inputBackground = this.disabledInputBackground;
-		this.inputForeground = this.disabledInputForeground;
-		this.inputBorder = this.disabledInputBorder;
+		this.updateInputEnabledDisabledColors();
 		this.applyStyles();
 	}
 
@@ -120,5 +118,12 @@ export class InputBox extends vsInputBox {
 		if (!this.hideErrors) {
 			super.showMessage(message, force);
 		}
+	}
+
+	private updateInputEnabledDisabledColors(): void {
+		let enabled = this.isEnabled();
+		this.inputBackground = enabled ? this.enabledInputBackground : this.disabledInputBackground;
+		this.inputForeground = enabled ? this.enabledInputForeground : this.disabledInputForeground;
+		this.inputBorder = enabled ? this.enabledInputBorder : this.disabledInputBorder;
 	}
 }

--- a/src/sql/parts/modelComponents/inputbox.component.ts
+++ b/src/sql/parts/modelComponents/inputbox.component.ts
@@ -12,10 +12,10 @@ import * as sqlops from 'sqlops';
 
 import { ComponentBase } from 'sql/parts/modelComponents/componentBase';
 import { IComponent, IComponentDescriptor, IModelStore, ComponentEventType } from 'sql/parts/modelComponents/interfaces';
-
 import { InputBox } from 'sql/base/browser/ui/inputBox/inputBox';
+import { attachInputBoxStyler } from 'sql/common/theme/styler';
+
 import { IInputOptions, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
-import { attachInputBoxStyler, attachListStyler } from 'vs/platform/theme/common/styler';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import * as nls from 'vs/nls';


### PR DESCRIPTION
Updates our input box implementation so that boxes get the correct styles when they are disabled.

Before:
![Form with a disabled input box which just displays as text on a blank background](https://user-images.githubusercontent.com/3758704/42666260-f125e59a-85f8-11e8-9b1c-6cd1b7560995.png)

After:
![Form with a disabled input box which displays as text on a greyed-out background](https://user-images.githubusercontent.com/3758704/42666274-fefbc6d0-85f8-11e8-9dd4-60b668d0e9c4.png)
