### PR TITLE
Render column titles as text not html in query results

### DIFF
--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -367,11 +367,16 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			columnDefinitions: resultSet.columnInfo.map((c, i) => {
 				let isLinked = c.isXml || c.isJson;
 				let linkType = c.isXml ? 'xml' : 'json';
+
+				// Ensure that the column names are rendered as text and not HTML
+				let columnNameElement = document.createElement('div');
+				columnNameElement.textContent = c.columnName;
+
 				return {
 					id: i.toString(),
 					name: c.columnName === 'Microsoft SQL Server 2005 XML Showplan'
 						? 'XML Showplan'
-						: c.columnName,
+						: columnNameElement.innerHTML,
 					type: self.stringToFieldType('string'),
 					formatter: isLinked ? Services.hyperLinkFormatter : Services.textFormatter,
 					asyncPostRender: isLinked ? self.linkHandler(linkType) : undefined,

--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -24,6 +24,7 @@ import { error } from 'sql/base/common/log';
 import { clone, mixin } from 'sql/base/common/objects';
 import { IQueryEditorService } from 'sql/parts/query/common/queryEditorService';
 import { IBootstrapParams } from 'sql/services/bootstrap/bootstrapService';
+import { escape } from 'sql/base/common/strings';
 
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import Severity from 'vs/base/common/severity';
@@ -368,15 +369,11 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 				let isLinked = c.isXml || c.isJson;
 				let linkType = c.isXml ? 'xml' : 'json';
 
-				// Ensure that the column names are rendered as text and not HTML
-				let columnNameElement = document.createElement('div');
-				columnNameElement.textContent = c.columnName;
-
 				return {
 					id: i.toString(),
 					name: c.columnName === 'Microsoft SQL Server 2005 XML Showplan'
 						? 'XML Showplan'
-						: columnNameElement.innerHTML,
+						: escape(c.columnName),
 					type: self.stringToFieldType('string'),
 					formatter: isLinked ? Services.hyperLinkFormatter : Services.textFormatter,
 					asyncPostRender: isLinked ? self.linkHandler(linkType) : undefined,

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -349,15 +349,11 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 				let isLinked = c.isXml || c.isJson;
 				let linkType = c.isXml ? 'xml' : 'json';
 
-				// Ensure that the column names are rendered as text and not HTML
-				let columnNameElement = document.createElement('div');
-				columnNameElement.textContent = c.columnName;
-
 				return {
 					id: i.toString(),
 					name: c.columnName === 'Microsoft SQL Server 2005 XML Showplan'
 						? 'XML Showplan'
-						: columnNameElement.innerHTML,
+						: escape(c.columnName),
 					type: self.stringToFieldType('string'),
 					formatter: isLinked ? Services.hyperLinkFormatter : Services.textFormatter,
 					asyncPostRender: isLinked ? self.linkHandler(linkType) : undefined

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -348,11 +348,16 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 			columnDefinitions: resultSet.columnInfo.map((c, i) => {
 				let isLinked = c.isXml || c.isJson;
 				let linkType = c.isXml ? 'xml' : 'json';
+
+				// Ensure that the column names are rendered as text and not HTML
+				let columnNameElement = document.createElement('div');
+				columnNameElement.textContent = c.columnName;
+
 				return {
 					id: i.toString(),
 					name: c.columnName === 'Microsoft SQL Server 2005 XML Showplan'
 						? 'XML Showplan'
-						: c.columnName,
+						: columnNameElement.innerHTML,
 					type: self.stringToFieldType('string'),
 					formatter: isLinked ? Services.hyperLinkFormatter : Services.textFormatter,
 					asyncPostRender: isLinked ? self.linkHandler(linkType) : undefined


### PR DESCRIPTION
Query result and edit data column titles should be displayed as plain text instead of HTML so I've added code that escapes HTML by inserting it as text into an html element and then retrieving the corresponding HTML.