### PR TITLE
Enable custom delimiters when saving as CSV

### DIFF
--- a/src/sql/parts/query/common/query.contribution.ts
+++ b/src/sql/parts/query/common/query.contribution.ts
@@ -275,6 +275,11 @@ let registryProperties = {
 		'description': localize('sql.saveAsCsv.includeHeaders', '[Optional] When true, column headers are included when saving results as CSV'),
 		'default': true
 	},
+	'sql.saveAsCsv.delimiter': {
+		'type': 'string',
+		'description': localize('sql.saveAsCsv.delimiter', '[Optional] The custom delimiter to use between values when saving as CSV'),
+		'default': ','
+	},
 	'sql.copyIncludeHeaders': {
 		'type': 'boolean',
 		'description': localize('sql.copyIncludeHeaders', '[Optional] Configuration options for copying results from the Results View'),

--- a/src/sql/parts/query/common/resultSerializer.ts
+++ b/src/sql/parts/query/common/resultSerializer.ts
@@ -186,7 +186,11 @@ export class ResultSerializer {
 			if (saveConfig.includeHeaders !== undefined) {
 				saveResultsParams.includeHeaders = saveConfig.includeHeaders;
 			}
+			if (saveConfig.delimiter !== undefined) {
+				saveResultsParams.delimiter = saveConfig.delimiter;
+			}
 		}
+
 		return saveResultsParams;
 	}
 
@@ -202,6 +206,7 @@ export class ResultSerializer {
 		// and we want to have just 1 setting that lists this.
 		let config = this.getConfigForCsv();
 		config.resultFormat = SaveFormat.EXCEL;
+		config.delimiter = undefined;
 		return config;
 	}
 

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -1188,7 +1188,7 @@ declare module 'sqlops' {
 	}
 
 	export enum FrequencyTypes {
-		Unknown ,
+		Unknown,
 		OneTime = 1 << 1,
 		Daily = 1 << 2,
 		Weekly = 1 << 3,
@@ -1396,15 +1396,14 @@ declare module 'sqlops' {
 		job: AgentJobInfo;
 	}
 
-	export interface AgentJobCategory
-	{
+	export interface AgentJobCategory {
 		id: string;
 		name: string;
 	}
 
 	export interface AgentJobDefaultsResult extends ResultStatus {
 		owner: string;
-	   	categories: AgentJobCategory[];
+		categories: AgentJobCategory[];
 	}
 
 	export interface CreateAgentJobStepResult extends ResultStatus {

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -840,6 +840,7 @@ declare module 'sqlops' {
 		columnStartIndex: number;
 		columnEndIndex: number;
 		includeHeaders?: boolean;
+		delimiter?: string;
 	}
 
 	export interface SaveResultRequestResult {


### PR DESCRIPTION
Exposes the setting contributed to SQL Tools Service in https://github.com/Microsoft/sqltoolsservice/pull/653 to allow users to set their own CSV delimiters in their settings files