### PR TITLE
Improving profiler controls and toolbar

### DIFF
--- a/src/sql/parts/profiler/contrib/profilerActions.ts
+++ b/src/sql/parts/profiler/contrib/profilerActions.ts
@@ -77,7 +77,6 @@ export class ProfilerStart extends Action {
 	}
 
 	public run(input: ProfilerInput): TPromise<boolean> {
-		this.enabled = false;
 		input.data.clear();
 		return TPromise.wrap(this._profilerService.startSession(input.id));
 	}
@@ -127,7 +126,6 @@ export class ProfilerStop extends Action {
 	}
 
 	public run(input: ProfilerInput): TPromise<boolean> {
-		this.enabled = false;
 		return TPromise.wrap(this._profilerService.stopSession(input.id));
 	}
 }
@@ -137,7 +135,7 @@ export class ProfilerClear extends Action {
 	public static LABEL = nls.localize('profiler.clear', "Clear Data");
 
 	constructor(id: string, label: string) {
-		super(id, label, 'stop');
+		super(id, label);
 	}
 
 	run(input: ProfilerInput): TPromise<void> {
@@ -148,14 +146,15 @@ export class ProfilerClear extends Action {
 
 export class ProfilerAutoScroll extends Action {
 	public static ID = 'profiler.autoscroll';
-	public static LABEL = nls.localize('profiler.toggleAutoscroll', "Toggle Auto Scroll");
+	public static LABEL = nls.localize('profiler.autoscrollOn', "Auto Scroll: On");
 
 	constructor(id: string, label: string) {
-		super(id, label, 'stop');
+		super(id, label);
 	}
 
 	run(input: ProfilerInput): TPromise<boolean> {
 		this.checked = !this.checked;
+		this._setLabel(this.checked ? nls.localize('profilerAction.autoscrollOn', "Auto Scroll: On") : nls.localize('profilerAction.autoscrollOff', "Auto Scroll: Off"));
 		input.state.change({ autoscroll: this.checked });
 		return TPromise.as(true);
 	}

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -116,6 +116,7 @@ export class ProfilerEditor extends BaseEditor {
 
 	private _viewTemplateSelector: SelectBox;
 	private _viewTemplates: Array<IProfilerViewTemplate>;
+	private _connectionInfoText: HTMLElement;
 
 	// Actions
 	private _connectAction: Actions.ProfilerConnect;
@@ -174,6 +175,10 @@ export class ProfilerEditor extends BaseEditor {
 		);
 		this._panelView.headerSize = 35;
 		this._splitView.addView(this._panelView);
+
+		this._editorInput.onDispose(()=> {
+
+		})
 	}
 
 	private _createHeader(): void {
@@ -199,7 +204,15 @@ export class ProfilerEditor extends BaseEditor {
 		}));
 		let dropdownContainer = document.createElement('div');
 		dropdownContainer.style.width = '150px';
+		dropdownContainer.style.paddingRight = '5px';
 		this._viewTemplateSelector.render(dropdownContainer);
+
+		this._connectionInfoText = document.createElement('div');
+		this._connectionInfoText.style.paddingRight = '5px';
+		this._connectionInfoText.innerText = '';
+		this._connectionInfoText.style.textAlign = 'center';
+		this._connectionInfoText.style.display = 'flex';
+		this._connectionInfoText.style.alignItems = 'center';
 
 		this._register(attachSelectBoxStyler(this._viewTemplateSelector, this.themeService));
 
@@ -211,6 +224,8 @@ export class ProfilerEditor extends BaseEditor {
 			{ action: this._autoscrollAction },
 			{ action: this._instantiationService.createInstance(Actions.ProfilerClear, Actions.ProfilerClear.ID, Actions.ProfilerClear.LABEL) },
 			{ element: dropdownContainer },
+			{ element: Taskbar.createTaskbarSeparator() },
+			{ element: this._connectionInfoText }
 		]);
 	}
 
@@ -361,6 +376,7 @@ export class ProfilerEditor extends BaseEditor {
 				autoscroll: true,
 				isPanelCollapsed: true
 			});
+			this._connectionInfoText.innerText = input.connectionName;
 			this._profilerTableEditor.updateState();
 			this._splitView.layout();
 			this._profilerTableEditor.focus();

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -175,10 +175,6 @@ export class ProfilerEditor extends BaseEditor {
 		);
 		this._panelView.headerSize = 35;
 		this._splitView.addView(this._panelView);
-
-		this._editorInput.onDispose(()=> {
-
-		})
 	}
 
 	private _createHeader(): void {

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -9,6 +9,7 @@ import { ProfilerState } from './profilerState';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 
 import * as sqlops from 'sqlops';
+import * as nls from 'vs/nls';
 
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorInput } from 'vs/workbench/common/editor';
@@ -17,9 +18,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { Event, Emitter } from 'vs/base/common/event';
 import { generateUuid } from 'vs/base/common/uuid';
-
-import * as nls from 'vs/nls';
-import { SaveReason } from 'vs/workbench/services/textfile/common/textfiles';
 import { IDialogService, IConfirmation, IConfirmationResult } from 'vs/platform/dialogs/common/dialogs';
 
 export class ProfilerInput extends EditorInput implements IProfilerSession {
@@ -152,7 +150,7 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 
 	public get connectionName(): string {
 		if (this._connection !== null) {
-			return `${this._connection.serverName} ${this._connection.databaseName}`;
+			return `${ this._connection.serverName } ${ this._connection.databaseName }`;
 		}
 		else {
 			return nls.localize('profilerInput.notConnected', "Not connected");

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -19,6 +19,8 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { generateUuid } from 'vs/base/common/uuid';
 
 import * as nls from 'vs/nls';
+import { SaveReason } from 'vs/workbench/services/textfile/common/textfiles';
+import { IDialogService, IConfirmation, IConfirmationResult } from 'vs/platform/dialogs/common/dialogs';
 
 export class ProfilerInput extends EditorInput implements IProfilerSession {
 
@@ -40,7 +42,8 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 		private _connection: IConnectionProfile,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IProfilerService private _profilerService: IProfilerService,
-		@INotificationService private _notificationService: INotificationService
+		@INotificationService private _notificationService: INotificationService,
+		@IDialogService private _dialogService: IDialogService
 	) {
 		super();
 		this._state = new ProfilerState();
@@ -64,6 +67,23 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 			return ret;
 		};
 		this._data = new TableDataView<Slick.SlickData>(undefined, searchFn);
+
+		this.onDispose(() => {
+			if (this._state.isRunning || this.state.isPaused) {
+				let confirm: IConfirmation = {
+					message: nls.localize('confirmStopProfilerSession', "Would you like to stop the running XEvent session?"),
+					primaryButton: nls.localize('profilerClosingActions.yes', 'Yes'),
+					secondaryButton: nls.localize('profilerClosingActions.no', 'No'),
+					type: 'question'
+				};
+
+				this._dialogService.confirm(confirm).then(result => {
+					if (result.confirmed) {
+						this._profilerService.stopSession(this.id);
+					}
+				});
+			}
+		});
 	}
 
 	public set viewTemplate(template: IProfilerViewTemplate) {
@@ -128,6 +148,15 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 		this._columns = columns;
 		this._columnMapping = mapping;
 		this._onColumnsChanged.fire(this.columns);
+	}
+
+	public get connectionName(): string {
+		if (this._connection !== null) {
+			return `${this._connection.serverName} ${this._connection.databaseName}`;
+		}
+		else {
+			return nls.localize('profilerInput.notConnected', "Not connected");
+		}
 	}
 
 	public get id(): ProfilerSessionID {

--- a/src/sql/parts/profiler/service/profilerService.ts
+++ b/src/sql/parts/profiler/service/profilerService.ts
@@ -17,6 +17,7 @@ import * as sqlops from 'sqlops';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { INotificationService } from 'vs/platform/notification/common/notification';
 
 class TwoWayMap<T, K> {
 	private forwardMap: Map<T, K>;
@@ -52,7 +53,8 @@ export class ProfilerService implements IProfilerService {
 	constructor(
 		@IConnectionManagementService private _connectionService: IConnectionManagementService,
 		@IConfigurationService public _configurationService: IConfigurationService,
-		@IInstantiationService private _instantiationService: IInstantiationService
+		@IInstantiationService private _instantiationService: IInstantiationService,
+		@INotificationService private _notificationService: INotificationService
 	) { }
 
 	public registerProvider(providerId: string, provider: sqlops.ProfilerProvider): void {
@@ -99,6 +101,8 @@ export class ProfilerService implements IProfilerService {
 		return this._runAction(id, provider => provider.startSession(this._idMap.get(id))).then(() => {
 			this._sessionMap.get(this._idMap.reverseGet(id)).onSessionStateChanged({ isRunning: true, isStopped: false, isPaused: false });
 			return true;
+		}, (reason) => {
+			this._notificationService.error(reason.message);
 		});
 	}
 
@@ -110,6 +114,8 @@ export class ProfilerService implements IProfilerService {
 		return this._runAction(id, provider => provider.stopSession(this._idMap.get(id))).then(() => {
 			this._sessionMap.get(this._idMap.reverseGet(id)).onSessionStateChanged({ isStopped: true, isPaused: false, isRunning: false });
 			return true;
+		}, (reason) => {
+			this._notificationService.error(reason.message);
 		});
 	}
 


### PR DESCRIPTION
Some fixes for the profiler controls, mainly around improved stability on starting and stopping, and more intuitive button actions and labels.
- Fix inconsistent error message displays, now errors from starting or stopping a session display clearly and the start/stop buttons are still functional, allowing users to retry
- The current connection info is displayed on the end of the toolbar (fixes #1800)
- Toggling starting and stopping auto scroll changes the text of the button
- auto scroll and clear data no longer have stop button icons next to them
- If a session is running when the profiler is closed, a dialog is displayed giving the option to stop the running session.