### PR TITLE
Hide correct element when hiding buttons on wizards/dialogs

### DIFF
--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -105,7 +105,7 @@ export class DialogModal extends Modal {
 	private updateButtonElement(buttonElement: Button, dialogButton: DialogButton, requireDialogValid: boolean = false) {
 		buttonElement.label = dialogButton.label;
 		buttonElement.enabled = requireDialogValid ? dialogButton.enabled && this._dialog.valid : dialogButton.enabled;
-		dialogButton.hidden ? buttonElement.element.classList.add('dialogModal-hidden') : buttonElement.element.classList.remove('dialogModal-hidden');
+		dialogButton.hidden ? buttonElement.element.parentElement.classList.add('dialogModal-hidden') : buttonElement.element.parentElement.classList.remove('dialogModal-hidden');
 	}
 
 	protected renderBody(container: HTMLElement): void {

--- a/src/sql/platform/dialog/wizardModal.ts
+++ b/src/sql/platform/dialog/wizardModal.ts
@@ -119,7 +119,7 @@ export class WizardModal extends Modal {
 	private updateButtonElement(buttonElement: Button, dialogButton: DialogButton, requirePageValid: boolean = false) {
 		buttonElement.label = dialogButton.label;
 		buttonElement.enabled = requirePageValid ? dialogButton.enabled && this._wizard.pages[this._wizard.currentPage].valid : dialogButton.enabled;
-		dialogButton.hidden ? buttonElement.element.classList.add('dialogModal-hidden') : buttonElement.element.classList.remove('dialogModal-hidden');
+		dialogButton.hidden ? buttonElement.element.parentElement.classList.add('dialogModal-hidden') : buttonElement.element.parentElement.classList.remove('dialogModal-hidden');
 	}
 
 	protected renderBody(container: HTMLElement): void {


### PR DESCRIPTION
When wizard and dialog buttons got hidden the wrong element was hidden, causing the spacing between them to get messed up.

This may be related to #1941 but I'm not sure since I haven't been able to reproduce that bug.

Before (notice the space between Next and Cancel because Generate Script is hidden):
![Wizard buttons with extra space between two where one is hidden](https://user-images.githubusercontent.com/3758704/42786509-6cb5319c-890b-11e8-9472-171ded67eb10.png)

After:
![Wizard buttons with no extra space where the button is hidden](https://user-images.githubusercontent.com/3758704/42786516-703d2522-890b-11e8-9e88-e88ed6696eda.png)
