### PR TITLE
Profiler display fixes

### DIFF
--- a/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
@@ -126,12 +126,9 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 		actions.push(this._instantiationService.createInstance(DeleteConnectionAction, DeleteConnectionAction.ID, DeleteConnectionAction.DELETE_CONNECTION_LABEL, context.profile));
 		actions.push(this._instantiationService.createInstance(RefreshAction, RefreshAction.ID, RefreshAction.LABEL, context.tree, context.profile));
 
-		this._extensionManagementService.getInstalled().then(extensions => {
-			let profilerExtension = extensions.find((e) => {return e.manifest.name === 'profiler';});
-			if(profilerExtension && this._extensionEnablementService.isEnabled(profilerExtension)) {
-				actions.push(this._instantiationService.createInstance(OEAction, NewProfilerAction.ID, NewProfilerAction.LABEL));
-			}
-		});
+		if (process.env['VSCODE_DEV'] && constants.MssqlProviderId === context.profile.providerName) {
+			actions.push(this._instantiationService.createInstance(OEAction, NewProfilerAction.ID, NewProfilerAction.LABEL));
+		}
 
 		return actions;
 	}

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
@@ -35,7 +35,6 @@ import { TreeNodeContextKey } from './treeNodeContextKey';
 import { IQueryManagementService } from 'sql/parts/query/common/queryManagement';
 import { IScriptingService } from 'sql/services/scripting/scriptingService';
 import * as constants from 'sql/common/constants';
-import { IExtensionManagementService, IExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 
 /**
  *  Provides actions for the server tree elements
@@ -49,9 +48,7 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 		@IScriptingService private _scriptingService: IScriptingService,
 		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IMenuService private menuService: IMenuService,
-		@IContextKeyService private _contextKeyService: IContextKeyService,
-		@IExtensionManagementService private _extensionManagementService: IExtensionManagementService,
-		@IExtensionEnablementService private _extensionEnablementService: IExtensionEnablementService
+		@IContextKeyService private _contextKeyService: IContextKeyService
 	) {
 		super();
 	}

--- a/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
+++ b/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
@@ -166,6 +166,7 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 	public layout(dimension: Dimension): void {
 		this._currentDimensions = dimension;
 		this._profilerTable.layout(dimension);
+		this._profilerTable.autosizeColumns();
 		this._onDidChangeConfiguration.fire({ layoutInfo: true });
 	}
 

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -50,6 +50,7 @@ class BasicView extends View {
 	private _previousSize: number;
 	private _collapsed: boolean;
 	public headerSize: number;
+
 	constructor(
 		initialSize: number,
 		private _element: HTMLElement,
@@ -58,6 +59,7 @@ class BasicView extends View {
 		opts: IViewOptions
 	) {
 		super(initialSize, opts);
+		this._previousSize = initialSize;
 	}
 
 	render(container: HTMLElement, orientation: Orientation): void {

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -155,7 +155,6 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 			} else {
 				return `${ this._connection.serverName }`;
 			}
-
 		}
 		else {
 			return nls.localize('profilerInput.notConnected', "Not connected");

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -150,7 +150,12 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 
 	public get connectionName(): string {
 		if (this._connection !== null) {
-			return `${ this._connection.serverName } ${ this._connection.databaseName }`;
+			if (this._connection.databaseName) {
+				return `${ this._connection.serverName } ${ this._connection.databaseName }`;
+			} else {
+				return `${ this._connection.serverName }`;
+			}
+
 		}
 		else {
 			return nls.localize('profilerInput.notConnected', "Not connected");

--- a/src/sql/parts/profiler/service/interfaces.ts
+++ b/src/sql/parts/profiler/service/interfaces.ts
@@ -98,7 +98,6 @@ export interface IProfilerSettings {
 
 export interface IColumnViewTemplate {
 	name: string;
-	width: string;
 	eventsMapped: Array<string>;
 }
 


### PR DESCRIPTION
Fixing #1938 and #1939 
Text and details pane shows up consistently, and grid resizes correctly with the window. Also fixed an error with displaying connection names and removed an unnecessary and unused view template variable
