### PR TITLE
Loading spinner while validating next/done

### DIFF
--- a/src/sql/platform/dialog/dialogModal.ts
+++ b/src/sql/platform/dialog/dialogModal.ts
@@ -125,11 +125,19 @@ export class DialogModal extends Modal {
 
 	public async done(): Promise<void> {
 		if (this._doneButton.enabled) {
+			let buttonSpinnerHandler = setTimeout(() => {
+				this._doneButton.enabled = false;
+				this._doneButton.element.innerHTML = '&nbsp';
+				this._doneButton.element.classList.add('validating');
+			}, 100);
 			if (await this._dialog.validateClose()) {
 				this._onDone.fire();
 				this.dispose();
 				this.hide();
 			}
+			clearTimeout(buttonSpinnerHandler);
+			this._doneButton.element.classList.remove('validating');
+			this.updateButtonElement(this._doneButton, this._dialog.okButton, true);
 		}
 	}
 

--- a/src/sql/platform/dialog/media/dialogModal.css
+++ b/src/sql/platform/dialog/media/dialogModal.css
@@ -31,6 +31,21 @@
 	margin: 0;
 }
 
+.footer-button .validating {
+	background-size: 15px;
+	background-repeat: no-repeat;
+	background-position: center;
+}
+
+.vs .footer-button .validating {
+	background-image: url("loading.svg");
+}
+
+.vs-dark .footer-button .validating,
+.hc-black .footer-button .validating {
+	background-image: url("loading_inverse.svg");
+}
+
 .dialogModal-wizardHeader {
 	padding: 10px 30px;
 }

--- a/src/sql/platform/dialog/media/loading.svg
+++ b/src/sql/platform/dialog/media/loading.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' standalone='no' ?>
+<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='10px' height='10px'>
+	<style>
+    circle {
+      animation: ball 0.6s linear infinite;
+    }
+
+    circle:nth-child(2) { animation-delay: 0.075s; }
+    circle:nth-child(3) { animation-delay: 0.15s; }
+    circle:nth-child(4) { animation-delay: 0.225s; }
+    circle:nth-child(5) { animation-delay: 0.3s; }
+    circle:nth-child(6) { animation-delay: 0.375s; }
+    circle:nth-child(7) { animation-delay: 0.45s; }
+    circle:nth-child(8) { animation-delay: 0.525s; }
+
+    @keyframes ball {
+      from { opacity: 1; }
+      to { opacity: 0.3; }
+    }
+	</style>
+	<g>
+		<circle cx='5' cy='1' r='1' style='opacity:0.3;' />
+		<circle cx='7.8284' cy='2.1716' r='1' style='opacity:0.3;' />
+		<circle cx='9' cy='5' r='1' style='opacity:0.3;' />
+		<circle cx='7.8284' cy='7.8284' r='1' style='opacity:0.3;' />
+		<circle cx='5' cy='9' r='1' style='opacity:0.3;' />
+		<circle cx='2.1716' cy='7.8284' r='1' style='opacity:0.3;' />
+		<circle cx='1' cy='5' r='1' style='opacity:0.3;' />
+		<circle cx='2.1716' cy='2.1716' r='1' style='opacity:0.3;' />
+	</g>
+</svg>

--- a/src/sql/platform/dialog/media/loading_inverse.svg
+++ b/src/sql/platform/dialog/media/loading_inverse.svg
@@ -1,0 +1,31 @@
+<?xml version='1.0' standalone='no' ?>
+<svg xmlns='http://www.w3.org/2000/svg' version='1.1' width='10px' height='10px'>
+	<style>
+    circle {
+      animation: ball 0.6s linear infinite;
+    }
+
+    circle:nth-child(2) { animation-delay: 0.075s; }
+    circle:nth-child(3) { animation-delay: 0.15s; }
+    circle:nth-child(4) { animation-delay: 0.225s; }
+    circle:nth-child(5) { animation-delay: 0.3s; }
+    circle:nth-child(6) { animation-delay: 0.375s; }
+    circle:nth-child(7) { animation-delay: 0.45s; }
+    circle:nth-child(8) { animation-delay: 0.525s; }
+
+    @keyframes ball {
+      from { opacity: 1; }
+      to { opacity: 0.3; }
+    }
+	</style>
+	<g style="fill:white;">
+		<circle cx='5' cy='1' r='1' style='opacity:0.3;' />
+		<circle cx='7.8284' cy='2.1716' r='1' style='opacity:0.3;' />
+		<circle cx='9' cy='5' r='1' style='opacity:0.3;' />
+		<circle cx='7.8284' cy='7.8284' r='1' style='opacity:0.3;' />
+		<circle cx='5' cy='9' r='1' style='opacity:0.3;' />
+		<circle cx='2.1716' cy='7.8284' r='1' style='opacity:0.3;' />
+		<circle cx='1' cy='5' r='1' style='opacity:0.3;' />
+		<circle cx='2.1716' cy='2.1716' r='1' style='opacity:0.3;' />
+	</g>
+</svg>

--- a/src/sql/workbench/api/node/extHostModelViewDialog.ts
+++ b/src/sql/workbench/api/node/extHostModelViewDialog.ts
@@ -213,12 +213,16 @@ class BackgroundOperationHandler {
 	}
 
 	public createOperation(): void {
+		if (!this._operationInfo) {
+			return;
+		}
+
 		if (!this._operationInfo.operationId) {
 			let uniqueId = generateUuid();
 			this._operationInfo.operationId = 'OperationId' + uniqueId + this._name;
 		}
 
-		if (this._operationInfo && this._operationInfo.operation) {
+		if (this._operationInfo.operation) {
 			this._extHostTaskManagement.$registerTask(this._operationInfo);
 		}
 	}


### PR DESCRIPTION
Disables the next/done button and adds a loading spinner to it during navigation validation for dialogs and wizards.

There are also a couple small bug fixes here:
- Fixed a bug where `createOperation` tried to use `_operationInfo` even if it hadn't been created
- Fixed a bug where the extension updating the wizard next/done buttons when they were hidden would unhide them

![Wizard toolbar after the next button has been clicked showing it disabled with a spinner](https://user-images.githubusercontent.com/3758704/42965170-12b74b90-8b4e-11e8-8639-9739a56898d9.png)
