### PR TITLE
Save editor cursor/scroll position when switching sql files

### DIFF
--- a/src/sql/parts/query/editor/queryEditor.ts
+++ b/src/sql/parts/query/editor/queryEditor.ts
@@ -31,6 +31,7 @@ import { IEditorGroupService } from 'vs/workbench/services/group/common/groupSer
 import { CodeEditor } from 'vs/editor/browser/codeEditor';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { IRange } from 'vs/editor/common/core/range';
+import { IEditorViewState } from 'vs/editor/common/editorCommon';
 
 import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
 import { QueryInput } from 'sql/parts/query/common/queryInput';
@@ -46,7 +47,6 @@ import { IQueryModelService } from 'sql/parts/query/execution/queryModel';
 import { IEditorDescriptorService } from 'sql/parts/query/editor/editorDescriptorService';
 import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
 import { attachEditableDropdownStyler } from 'sql/common/theme/styler';
-import { IEditorViewState } from 'vs/editor/common/editorCommon';
 
 /**
  * Editor that hosts 2 sub-editors: A TextResourceEditor for SQL file editing, and a QueryResultsEditor

--- a/src/sql/parts/query/editor/queryEditor.ts
+++ b/src/sql/parts/query/editor/queryEditor.ts
@@ -562,7 +562,12 @@ export class QueryEditor extends BaseEditor {
 		// Run all three steps synchronously
 		return createEditors()
 			.then(onEditorsCreated)
-			.then(doLayout);
+			.then(doLayout)
+			.then(() => {
+				if (this._savedViewStates.has(newInput.sql)) {
+					this._sqlEditor.getControl().restoreViewState(this._savedViewStates.get(newInput.sql));
+				}
+			});
 	}
 
 	/**
@@ -585,11 +590,7 @@ export class QueryEditor extends BaseEditor {
 	 */
 	private _onSqlEditorCreated(sqlEditor: TextResourceEditor, sqlInput: UntitledEditorInput, options: EditorOptions): TPromise<void> {
 		this._sqlEditor = sqlEditor;
-		return this._sqlEditor.setInput(sqlInput, options).then(() => {
-			if (this._savedViewStates.has(sqlInput)) {
-				this._sqlEditor.getControl().restoreViewState(this._savedViewStates.get(sqlInput));
-			}
-		});
+		return this._sqlEditor.setInput(sqlInput, options);
 	}
 
 	/**


### PR DESCRIPTION
This PR is designed to address #114 and #1882 by saving the sql query editor's state when switching tabs.

This doesn't save the scroll position or selection for the results grid. I'll look into that too and put it in a separate PR.