### PR TITLE
Hackathon - Add Import to Recommended extensions list

### DIFF
--- a/product.json
+++ b/product.json
@@ -34,6 +34,7 @@
 	"date": "2017-12-15T12:00:00.000Z",
 	"recommendedExtensions": [
 		"Microsoft.agent",
+		"Microsoft.import",
 		"Microsoft.profiler",
 		"Microsoft.server-report",
 		"Microsoft.whoisactive",


### PR DESCRIPTION
This give `SQL Server Import` extension a Green Star in Extension Manager.