### PR TITLE
Save query result selection/scroll when switching tabs

### DIFF
--- a/src/sql/parts/grid/views/query/query.component.html
+++ b/src/sql/parts/grid/views/query/query.component.html
@@ -10,7 +10,7 @@
 		<span> {{LocalizedConstants.resultPaneLabel}} </span>
 		<span class="queryResultsShortCut"> {{resultShortcut}} </span>
 	</div>
-	<div id="results" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
+	<div #resultsScrollBox id="results" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
 		 (onScroll)="onScroll($event)" [scrollEnabled]="scrollEnabled" [class.hidden]="!resultActive"
 		 (focusin)="onGridFocus()" (focusout)="onGridFocusout()">
 		<div class="boxRow content horzBox slickgrid" *ngFor="let dataSet of renderedDataSets; let i = index"

--- a/src/sql/parts/grid/views/query/query.component.html
+++ b/src/sql/parts/grid/views/query/query.component.html
@@ -11,8 +11,8 @@
 		<span class="queryResultsShortCut"> {{resultShortcut}} </span>
 	</div>
 	<div #resultsScrollBox id="results" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
-		 (onScroll)="onScroll($event)" [scrollEnabled]="scrollEnabled" [class.hidden]="!resultActive"
-		 (focusin)="onGridFocus()" (focusout)="onGridFocusout()">
+		(onScroll)="onScroll($event)" [scrollEnabled]="scrollEnabled" [class.hidden]="!resultActive"
+		(focusin)="onGridFocus()" (focusout)="onGridFocusout()">
 		<div class="boxRow content horzBox slickgrid" *ngFor="let dataSet of renderedDataSets; let i = index"
 			[style.max-height]="dataSet.maxHeight" [style.min-height]="dataSet.minHeight">
 			<slick-grid #slickgrid id="slickgrid_{{i}}" [columnDefinitions]="dataSet.columnDefinitions"

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -235,8 +235,8 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 			self._cd.detectChanges();
 		});
 
-		this.queryParameters.saveViewStateEvent(() => this.saveViewState());
-		this.queryParameters.restoreViewStateEvent(() => this.restoreViewState());
+		this.queryParameters.onSaveViewState(() => this.saveViewState());
+		this.queryParameters.onRestoreViewState(() => this.restoreViewState());
 
 		this.dataService.onAngularLoaded();
 	}

--- a/src/sql/parts/query/editor/queryEditor.ts
+++ b/src/sql/parts/query/editor/queryEditor.ts
@@ -492,8 +492,9 @@ export class QueryEditor extends BaseEditor {
 		}
 
 		if (oldInput) {
-			if (this._resultViewStateChangeEmitters.has(oldInput.results)) {
-				this._resultViewStateChangeEmitters.get(oldInput.results).onSaveViewStateEmitter.fire();
+			let resultViewStateChangeEmitters = this._resultViewStateChangeEmitters.get(oldInput.results);
+			if (resultViewStateChangeEmitters) {
+				resultViewStateChangeEmitters.onSaveViewStateEmitter.fire();
 			}
 
 			this._disposeEditors();

--- a/src/sql/parts/query/editor/queryEditor.ts
+++ b/src/sql/parts/query/editor/queryEditor.ts
@@ -90,7 +90,7 @@ export class QueryEditor extends BaseEditor {
 	private _actualQueryPlanAction: ActualQueryPlanAction;
 
 	private _savedViewStates = new Map<IEditorInput, IEditorViewState>();
-	private _resultViewStateChangeEmitters = new Map<QueryResultsInput, { onSaveViewStateEmitter: Emitter<void>; onRestoreViewStateEmitter: Emitter<void> }>();
+	private _resultViewStateChangeEmitters = new Map<QueryResultsInput, { onSaveViewState: Emitter<void>; onRestoreViewState: Emitter<void> }>();
 
 	constructor(
 		@ITelemetryService _telemetryService: ITelemetryService,
@@ -494,7 +494,7 @@ export class QueryEditor extends BaseEditor {
 		if (oldInput) {
 			let resultViewStateChangeEmitters = this._resultViewStateChangeEmitters.get(oldInput.results);
 			if (resultViewStateChangeEmitters) {
-				resultViewStateChangeEmitters.onSaveViewStateEmitter.fire();
+				resultViewStateChangeEmitters.onSaveViewState.fire();
 			}
 
 			this._disposeEditors();
@@ -572,7 +572,7 @@ export class QueryEditor extends BaseEditor {
 			.then(doLayout)
 			.then(() => {
 				if (this._resultViewStateChangeEmitters.has(newInput.results)) {
-					this._resultViewStateChangeEmitters.get(newInput.results).onRestoreViewStateEmitter.fire();
+					this._resultViewStateChangeEmitters.get(newInput.results).onRestoreViewState.fire();
 				}
 				if (this._savedViewStates.has(newInput.sql)) {
 					this._sqlEditor.getControl().restoreViewState(this._savedViewStates.get(newInput.sql));
@@ -610,12 +610,12 @@ export class QueryEditor extends BaseEditor {
 		this._resultsEditor = resultsEditor;
 		if (!this._resultViewStateChangeEmitters.has(resultsInput)) {
 			this._resultViewStateChangeEmitters.set(resultsInput, {
-				onRestoreViewStateEmitter: new Emitter<void>(),
-				onSaveViewStateEmitter: new Emitter<void>()
+				onRestoreViewState: new Emitter<void>(),
+				onSaveViewState: new Emitter<void>()
 			});
 		}
 		let emitters = this._resultViewStateChangeEmitters.get(resultsInput);
-		this._resultsEditor.setViewStateChangeEvents(emitters.onRestoreViewStateEmitter.event, emitters.onSaveViewStateEmitter.event);
+		this._resultsEditor.setViewStateChangeEvents(emitters.onRestoreViewState.event, emitters.onSaveViewState.event);
 		return this._resultsEditor.setInput(resultsInput, options);
 	}
 

--- a/src/sql/parts/query/editor/queryResultsEditor.ts
+++ b/src/sql/parts/query/editor/queryResultsEditor.ts
@@ -96,8 +96,8 @@ export class QueryResultsEditor extends BaseEditor {
 	public static AngularSelectorString: string = 'slickgrid-container.slickgridContainer';
 	protected _rawOptions: BareResultsGridInfo;
 	protected _input: QueryResultsInput;
-	private _onRestoreViewStateEvent: Event<void>;
-	private _onSaveViewStateEvent: Event<void>;
+	private _restoreViewStateEvent: Event<void>;
+	private _saveViewStateEvent: Event<void>;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -153,8 +153,8 @@ export class QueryResultsEditor extends BaseEditor {
 	}
 
 	public setViewStateChangeEvents(onRestoreViewStateEvent: Event<void>, onSaveViewStateEvent: Event<void>) {
-		this._onRestoreViewStateEvent = onRestoreViewStateEvent;
-		this._onSaveViewStateEvent = onSaveViewStateEvent;
+		this._restoreViewStateEvent = onRestoreViewStateEvent;
+		this._saveViewStateEvent = onSaveViewStateEvent;
 	}
 
 	/**
@@ -179,8 +179,8 @@ export class QueryResultsEditor extends BaseEditor {
 		// to events from the backing data service
 		let params: IQueryComponentParams = {
 			dataService: dataService,
-			saveViewStateEvent: this._onSaveViewStateEvent,
-			restoreViewStateEvent: this._onRestoreViewStateEvent
+			onSaveViewState: this._saveViewStateEvent,
+			onRestoreViewState: this._restoreViewStateEvent
 		};
 		bootstrapAngular(this._instantiationService,
 			QueryOutputModule,

--- a/src/sql/parts/query/editor/queryResultsEditor.ts
+++ b/src/sql/parts/query/editor/queryResultsEditor.ts
@@ -26,6 +26,7 @@ import { IQueryComponentParams } from 'sql/services/bootstrap/bootstrapParams';
 import { QueryOutputModule } from 'sql/parts/query/views/queryOutput.module';
 import { QUERY_OUTPUT_SELECTOR } from 'sql/parts/query/views/queryOutput.component';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
 
 export const RESULTS_GRID_DEFAULTS = {
 	cellPadding: [6, 10, 5],
@@ -95,6 +96,8 @@ export class QueryResultsEditor extends BaseEditor {
 	public static AngularSelectorString: string = 'slickgrid-container.slickgridContainer';
 	protected _rawOptions: BareResultsGridInfo;
 	protected _input: QueryResultsInput;
+	private _onRestoreViewStateEvent: Event<void>;
+	private _onSaveViewStateEvent: Event<void>;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -149,6 +152,11 @@ export class QueryResultsEditor extends BaseEditor {
 		return TPromise.wrap<void>(null);
 	}
 
+	public setViewStateChangeEvents(onRestoreViewStateEvent: Event<void>, onSaveViewStateEvent: Event<void>) {
+		this._onRestoreViewStateEvent = onRestoreViewStateEvent;
+		this._onSaveViewStateEvent = onSaveViewStateEvent;
+	}
+
 	/**
 	 * Load the angular components and record for this input that we have done so
 	 */
@@ -169,7 +177,11 @@ export class QueryResultsEditor extends BaseEditor {
 		// Note: pass in input so on disposal this is cleaned up.
 		// Otherwise many components will be left around and be subscribed
 		// to events from the backing data service
-		let params: IQueryComponentParams = { dataService: dataService };
+		let params: IQueryComponentParams = {
+			dataService: dataService,
+			saveViewStateEvent: this._onSaveViewStateEvent,
+			restoreViewStateEvent: this._onRestoreViewStateEvent
+		};
 		bootstrapAngular(this._instantiationService,
 			QueryOutputModule,
 			this.getContainer(),

--- a/src/sql/services/bootstrap/bootstrapParams.ts
+++ b/src/sql/services/bootstrap/bootstrapParams.ts
@@ -8,9 +8,12 @@ import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { ConnectionContextKey } from 'sql/parts/connection/common/connectionContextKey';
 import { IBootstrapParams } from './bootstrapService';
+import { Event } from 'vs/base/common/event';
 
 export interface IQueryComponentParams extends IBootstrapParams {
 	dataService: DataService;
+	saveViewStateEvent: Event<void>;
+	restoreViewStateEvent: Event<void>;
 }
 
 export interface IEditDataComponentParams extends IBootstrapParams {

--- a/src/sql/services/bootstrap/bootstrapParams.ts
+++ b/src/sql/services/bootstrap/bootstrapParams.ts
@@ -12,8 +12,8 @@ import { Event } from 'vs/base/common/event';
 
 export interface IQueryComponentParams extends IBootstrapParams {
 	dataService: DataService;
-	saveViewStateEvent: Event<void>;
-	restoreViewStateEvent: Event<void>;
+	onSaveViewState: Event<void>;
+	onRestoreViewState: Event<void>;
 }
 
 export interface IEditDataComponentParams extends IBootstrapParams {


### PR DESCRIPTION
This is for #1744.

Since we use a custom editor implementation to display results its view state does not get saved when switching tabs. This adds logic so that the editor will save the scroll position of its result and message panes as well as its slick grid selections.