### PR TITLE
Prevent the insights dialog from showing duplicate buttons

### DIFF
--- a/src/sql/base/browser/ui/modal/modal.ts
+++ b/src/sql/base/browser/ui/modal/modal.ts
@@ -358,6 +358,21 @@ export abstract class Modal extends Disposable implements IThemable {
 	}
 
 	/**
+	 * Returns a footer button matching the provided label
+	 * @param label Label to show on the button
+	 * @param onSelect The callback to call when the button is selected
+	 */
+	protected findFooterButton(label: string): Button {
+		return this._footerButtons.find(e => {
+			try {
+				return e && e.element.innerText === label;
+			} catch {
+				return false;
+			}
+		});
+	}
+
+	/**
 	 * Show an error in the error message element
 	 * @param err Text to show in the error message
 	 */

--- a/src/sql/parts/insights/browser/insightsDialogView.ts
+++ b/src/sql/parts/insights/browser/insightsDialogView.ts
@@ -295,8 +295,9 @@ export class InsightsDialogView extends Modal {
 			for (let action of this._insight.actions.types) {
 				let task = tasks.includes(action);
 				let commandAction = MenuRegistry.getCommand(action);
-				if (task) {
-					let button = this.addFooterButton(types.isString(commandAction.title) ? commandAction.title : commandAction.title.value, () => {
+				let commandLabel = types.isString(commandAction.title) ? commandAction.title : commandAction.title.value;
+				if (task && !this.findFooterButton(commandLabel)) {
+					let button = this.addFooterButton(commandLabel, () => {
 						let element = this._topTable.getSelectedRows();
 						let resource: ListResource;
 						if (element && element.length > 0) {


### PR DESCRIPTION
This fixes https://github.com/Microsoft/sqlopsstudio/issues/1632.  The issue is that the dialog is rebuilt every time the model changes, which is apparently happens several times when showing a dialog.  The implementation doesn't clear out the buttons from the previous rebuild hence the duplicates.  This change prevents the duplicates from being added.  I didn't see an easy way to reset the buttons in the build method.