### PR TITLE
Save edit data scroll position when switching tabs

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.17",
+	"version": "1.5.0-alpha.18",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.1.zip",
 		"Windows_64": "win-x64-netcoreapp2.1.zip",

--- a/src/sql/parts/editData/common/editDataInput.ts
+++ b/src/sql/parts/editData/common/editDataInput.ts
@@ -16,6 +16,7 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import Severity from 'vs/base/common/severity';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { EditDataResultsInput } from 'sql/parts/editData/common/editDataResultsInput';
+import { IEditorViewState } from 'vs/editor/common/editorCommon';
 
 /**
  * Input for the EditDataEditor.
@@ -36,6 +37,8 @@ export class EditDataInput extends EditorInput implements IConnectableInput {
 	private _objectType: string;
 	private _css: HTMLStyleElement;
 	private _useQueryFilter: boolean;
+
+	public savedViewState: IEditorViewState;
 
 	constructor(
 		private _uri: URI,

--- a/src/sql/parts/editData/common/editDataResultsInput.ts
+++ b/src/sql/parts/editData/common/editDataResultsInput.ts
@@ -8,6 +8,7 @@
 import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorInput } from 'vs/workbench/common/editor';
+import { Emitter } from 'vs/base/common/event';
 
 /**
  * Input for the EditDataResultsEditor. This input helps with logic for the viewing and editing of
@@ -24,6 +25,9 @@ export class EditDataResultsInput extends EditorInput {
 	// Holds the HTML content for the editor when the editor discards this input and loads another
 	private _editorContainer: HTMLElement;
 	public css: HTMLStyleElement;
+
+	public readonly onRestoreViewStateEmitter = new Emitter<void>();
+	public readonly onSaveViewStateEmitter = new Emitter<void>();
 
 	constructor(private _uri: string) {
 		super();

--- a/src/sql/parts/editData/editor/editDataEditor.ts
+++ b/src/sql/parts/editData/editor/editDataEditor.ts
@@ -81,9 +81,6 @@ export class EditDataEditor extends BaseEditor {
 	private _queryEditorVisible: IContextKey<boolean>;
 	private hideQueryResultsView = false;
 
-	// private _savedViewStates = new Map<IEditorInput, IEditorViewState>();
-	// private _resultViewStateChangeEmitters = new Map<EditDataResultsInput, { onSaveViewState: Emitter<void>; onRestoreViewState: Emitter<void> }>();
-
 	constructor(
 		@ITelemetryService _telemetryService: ITelemetryService,
 		@IThemeService themeService: IThemeService,

--- a/src/sql/parts/editData/editor/editDataResultsEditor.ts
+++ b/src/sql/parts/editData/editor/editDataResultsEditor.ts
@@ -31,8 +31,6 @@ export class EditDataResultsEditor extends BaseEditor {
 	public static AngularSelectorString: string = 'slickgrid-container.slickgridContainer';
 	protected _input: EditDataResultsInput;
 	protected _rawOptions: BareResultsGridInfo;
-	private _restoreViewStateEvent: Event<void>;
-	private _saveViewStateEvent: Event<void>;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -72,11 +70,6 @@ export class EditDataResultsEditor extends BaseEditor {
 			this._bootstrapAngular();
 		}
 		return TPromise.wrap<void>(null);
-	}
-
-	public setViewStateChangeEvents(onRestoreViewStateEvent: Event<void>, onSaveViewStateEvent: Event<void>) {
-		this._restoreViewStateEvent = onRestoreViewStateEvent;
-		this._saveViewStateEvent = onSaveViewStateEvent;
 	}
 
 	private _applySettings() {
@@ -119,8 +112,8 @@ export class EditDataResultsEditor extends BaseEditor {
 		const parent = input.container;
 		let params: IEditDataComponentParams = {
 			dataService: dataService,
-			onSaveViewState: this._saveViewStateEvent,
-			onRestoreViewState: this._restoreViewStateEvent
+			onSaveViewState: input.onSaveViewStateEmitter.event,
+			onRestoreViewState: input.onRestoreViewStateEmitter.event
 		};
 		bootstrapAngular(this._instantiationService,
 			EditDataModule,

--- a/src/sql/parts/editData/editor/editDataResultsEditor.ts
+++ b/src/sql/parts/editData/editor/editDataResultsEditor.ts
@@ -23,6 +23,7 @@ import { IEditDataComponentParams } from 'sql/services/bootstrap/bootstrapParams
 import { EditDataModule } from 'sql/parts/grid/views/editData/editData.module';
 import { EDITDATA_SELECTOR } from 'sql/parts/grid/views/editData/editData.component';
 import { EditDataResultsInput } from 'sql/parts/editData/common/editDataResultsInput';
+import { Event } from 'vs/base/common/event';
 
 export class EditDataResultsEditor extends BaseEditor {
 
@@ -30,6 +31,8 @@ export class EditDataResultsEditor extends BaseEditor {
 	public static AngularSelectorString: string = 'slickgrid-container.slickgridContainer';
 	protected _input: EditDataResultsInput;
 	protected _rawOptions: BareResultsGridInfo;
+	private _restoreViewStateEvent: Event<void>;
+	private _saveViewStateEvent: Event<void>;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -71,6 +74,11 @@ export class EditDataResultsEditor extends BaseEditor {
 		return TPromise.wrap<void>(null);
 	}
 
+	public setViewStateChangeEvents(onRestoreViewStateEvent: Event<void>, onSaveViewStateEvent: Event<void>) {
+		this._restoreViewStateEvent = onRestoreViewStateEvent;
+		this._saveViewStateEvent = onSaveViewStateEvent;
+	}
+
 	private _applySettings() {
 		if (this.input && this.input.container) {
 			Configuration.applyFontInfoSlow(this.getContainer(), this._rawOptions);
@@ -109,7 +117,11 @@ export class EditDataResultsEditor extends BaseEditor {
 		// Otherwise many components will be left around and be subscribed
 		// to events from the backing data service
 		const parent = input.container;
-		let params: IEditDataComponentParams = { dataService: dataService };
+		let params: IEditDataComponentParams = {
+			dataService: dataService,
+			onSaveViewState: this._saveViewStateEvent,
+			onRestoreViewState: this._restoreViewStateEvent
+		};
 		bootstrapAngular(this._instantiationService,
 			EditDataModule,
 			parent,

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -37,9 +37,6 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 	private _onColumnsChanged = new Emitter<Slick.Column<Slick.SlickData>[]>();
 	public onColumnsChanged: Event<Slick.Column<Slick.SlickData>[]> = this._onColumnsChanged.event;
 
-	public readonly onRestoreViewStateEmitter = new Emitter<void>();
-	public readonly onSaveViewStateEmitter = new Emitter<void>();
-
 	constructor(
 		private _connection: IConnectionProfile,
 		@IInstantiationService private _instantiationService: IInstantiationService,

--- a/src/sql/parts/query/common/queryInput.ts
+++ b/src/sql/parts/query/common/queryInput.ts
@@ -11,6 +11,7 @@ import URI from 'vs/base/common/uri';
 import { UntitledEditorInput } from 'vs/workbench/common/editor/untitledEditorInput';
 import { EditorInput, EditorModel, ConfirmResult, EncodingMode, IEncodingSupport } from 'vs/workbench/common/editor';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IEditorViewState } from 'vs/editor/common/editorCommon';
 
 import { IConnectionManagementService, IConnectableInput, INewConnectionParams, RunQueryOnConnectionMode } from 'sql/parts/connection/common/connectionManagement';
 import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
@@ -55,6 +56,8 @@ export class QueryInput extends EditorInput implements IEncodingSupport, IConnec
 
 	private _toDispose: IDisposable[];
 	private _currentEventCallbacks: IDisposable[];
+
+	public savedViewState: IEditorViewState;
 
 	constructor(
 		private _description: string,

--- a/src/sql/parts/query/common/queryResultsInput.ts
+++ b/src/sql/parts/query/common/queryResultsInput.ts
@@ -8,6 +8,7 @@
 import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorInput } from 'vs/workbench/common/editor';
+import { Emitter } from 'vs/base/common/event';
 
 /**
  * Input for the QueryResultsEditor. This input helps with logic for the viewing and editing of
@@ -24,6 +25,9 @@ export class QueryResultsInput extends EditorInput {
 	// Holds the HTML content for the editor when the editor discards this input and loads another
 	private _editorContainer: HTMLElement;
 	public css: HTMLStyleElement;
+
+	public readonly onRestoreViewStateEmitter = new Emitter<void>();
+	public readonly onSaveViewStateEmitter = new Emitter<void>();
 
 	constructor(private _uri: string) {
 		super();

--- a/src/sql/parts/query/editor/queryEditor.ts
+++ b/src/sql/parts/query/editor/queryEditor.ts
@@ -111,6 +111,14 @@ export class QueryEditor extends BaseEditor {
 		if (contextKeyService) {
 			this.queryEditorVisible = queryContext.QueryEditorVisibleContext.bindTo(contextKeyService);
 		}
+
+		if (_editorGroupService) {
+			_editorGroupService.onEditorOpening(e => {
+				if (this.isVisible() && (e.input !== this.input || e.position !== this.position)) {
+					this.saveEditorViewState();
+				}
+			});
+		}
 	}
 
 	// PROPERTIES //////////////////////////////////////////////////////////
@@ -225,6 +233,7 @@ export class QueryEditor extends BaseEditor {
 	 * input should be freed.
 	 */
 	public clearInput(): void {
+		// this.saveEditorViewState(this.input as QueryInput);
 		if (this._resultsEditor) {
 			this._resultsEditor.clearInput();
 		}
@@ -500,19 +509,11 @@ export class QueryEditor extends BaseEditor {
 	 * Handles setting input for this editor.
 	 */
 	private _updateInput(oldInput: QueryInput, newInput: QueryInput, options?: EditorOptions): TPromise<void> {
-
 		if (this._sqlEditor) {
-			let sqlEditorViewState = this._sqlEditor.getControl().saveViewState();
-			this._savedViewStates.set(this._sqlEditor.input, sqlEditorViewState);
 			this._sqlEditor.clearInput();
 		}
 
 		if (oldInput) {
-			let resultViewStateChangeEmitters = this._resultViewStateChangeEmitters.get(oldInput.results);
-			if (resultViewStateChangeEmitters) {
-				resultViewStateChangeEmitters.onSaveViewState.fire();
-			}
-
 			this._disposeEditors();
 		}
 
@@ -889,6 +890,20 @@ export class QueryEditor extends BaseEditor {
 		editor.revealRange(rangeConversion);
 		editor.setSelection(rangeConversion);
 		editor.focus();
+	}
+
+	private saveEditorViewState(): void {
+		if (this._sqlEditor) {
+			let sqlEditorViewState = this._sqlEditor.getControl().saveViewState();
+			this._savedViewStates.set(this._sqlEditor.input, sqlEditorViewState);
+		}
+
+		if (this.input) {
+			let resultViewStateChangeEmitters = this._resultViewStateChangeEmitters.get((this.input as QueryInput).results);
+			if (resultViewStateChangeEmitters) {
+				resultViewStateChangeEmitters.onSaveViewState.fire();
+			}
+		}
 	}
 
 	// TESTING PROPERTIES ////////////////////////////////////////////////////////////

--- a/src/sql/parts/query/editor/queryEditor.ts
+++ b/src/sql/parts/query/editor/queryEditor.ts
@@ -233,7 +233,6 @@ export class QueryEditor extends BaseEditor {
 	 * input should be freed.
 	 */
 	public clearInput(): void {
-		// this.saveEditorViewState(this.input as QueryInput);
 		if (this._resultsEditor) {
 			this._resultsEditor.clearInput();
 		}

--- a/src/sql/parts/query/editor/queryResultsEditor.ts
+++ b/src/sql/parts/query/editor/queryResultsEditor.ts
@@ -96,8 +96,6 @@ export class QueryResultsEditor extends BaseEditor {
 	public static AngularSelectorString: string = 'slickgrid-container.slickgridContainer';
 	protected _rawOptions: BareResultsGridInfo;
 	protected _input: QueryResultsInput;
-	private _restoreViewStateEvent: Event<void>;
-	private _saveViewStateEvent: Event<void>;
 
 	constructor(
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -152,11 +150,6 @@ export class QueryResultsEditor extends BaseEditor {
 		return TPromise.wrap<void>(null);
 	}
 
-	public setViewStateChangeEvents(onRestoreViewStateEvent: Event<void>, onSaveViewStateEvent: Event<void>) {
-		this._restoreViewStateEvent = onRestoreViewStateEvent;
-		this._saveViewStateEvent = onSaveViewStateEvent;
-	}
-
 	/**
 	 * Load the angular components and record for this input that we have done so
 	 */
@@ -179,8 +172,8 @@ export class QueryResultsEditor extends BaseEditor {
 		// to events from the backing data service
 		let params: IQueryComponentParams = {
 			dataService: dataService,
-			onSaveViewState: this._saveViewStateEvent,
-			onRestoreViewState: this._restoreViewStateEvent
+			onSaveViewState: this.input.onSaveViewStateEmitter.event,
+			onRestoreViewState: this.input.onRestoreViewStateEmitter.event
 		};
 		bootstrapAngular(this._instantiationService,
 			QueryOutputModule,

--- a/src/sql/services/bootstrap/bootstrapParams.ts
+++ b/src/sql/services/bootstrap/bootstrapParams.ts
@@ -18,6 +18,8 @@ export interface IQueryComponentParams extends IBootstrapParams {
 
 export interface IEditDataComponentParams extends IBootstrapParams {
 	dataService: DataService;
+	onSaveViewState: Event<void>;
+	onRestoreViewState: Event<void>;
 }
 
 export interface IDefaultComponentParams extends IBootstrapParams {


### PR DESCRIPTION
This updates the edit data query editor and results grid so that the scroll position gets saved when switching tabs or moving the editor in split view. It also fixes some bugs with my first code for saving editor scroll positions where the query editor's position didn't get saved when switching columns in split view or when switching between different kinds of editors.

Also added some logic to save the state for profiler