### PR TITLE
Fix directory name error exporting results multiple times

### DIFF
--- a/src/sql/parts/query/common/resultSerializer.ts
+++ b/src/sql/parts/query/common/resultSerializer.ts
@@ -144,7 +144,7 @@ export class ResultSerializer {
 	}
 
 	private promptForFilepath(saveRequest: ISaveRequest): Thenable<string> {
-		let filepathPlaceHolder = (prevSavePath) ? prevSavePath : PathUtilities.resolveCurrentDirectory(this._uri, this.rootPath);
+		let filepathPlaceHolder = (prevSavePath) ? path.dirname(prevSavePath) : PathUtilities.resolveCurrentDirectory(this._uri, this.rootPath);
 		filepathPlaceHolder = path.join(filepathPlaceHolder, this.getResultsDefaultFilename(saveRequest));
 		return this._windowService.showSaveDialog({
 			title: nls.localize('resultsSerializer.saveAsFileTitle', 'Choose Results File'),


### PR DESCRIPTION
Fixes #1748. There was a bug in the logic that saved it in the old directory where the old filename would be included and then the new filename would be appended to the path, making the OS think that we were trying to access a directory that doesn't exist.