### PR TITLE
Update dashboard, profiler and query icons

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -936,11 +936,11 @@
 		},
 		"_shell_light": {
 			"fontCharacter": "\\E073",
-			"fontColor": "#455155"
+			"fontColor": "#bfc2c1"
 		},
 		"_shell": {
 			"fontCharacter": "\\E073",
-			"fontColor": "#4d5a5e"
+			"fontColor": "#d4d7d6"
 		},
 		"_slim_light": {
 			"fontCharacter": "\\E074",
@@ -1374,7 +1374,9 @@
 		"cmakelists.txt": "_makefile_3",
 		"procfile": "_heroku",
 		"todo": "_todo",
-		"npm-debug.log": "_npm_ignored"
+		"npm-debug.log": "_npm_ignored",
+		"dashboard": "_shell",
+		"profiler": "_csv"
 	},
 	"languageIds": {
 		"bat": "_windows",
@@ -1409,7 +1411,7 @@
 		"rust": "_rust",
 		"scss": "_sass",
 		"shellscript": "_shell",
-		"sql": "_db",
+		"sql": "_default",
 		"swift": "_swift",
 		"typescript": "_typescript",
 		"typescriptreact": "_react",
@@ -1614,7 +1616,7 @@
 			"rust": "_rust_light",
 			"scss": "_sass_light",
 			"shellscript": "_shell_light",
-			"sql": "_db_light",
+			"sql": "_default_light",
 			"swift": "_swift_light",
 			"typescript": "_typescript_light",
 			"typescriptreact": "_react_light",
@@ -1660,7 +1662,9 @@
 			"omakefile": "_makefile_2_light",
 			"cmakelists.txt": "_makefile_3_light",
 			"procfile": "_heroku_light",
-			"npm-debug.log": "_npm_ignored_light"
+			"npm-debug.log": "_npm_ignored_light",
+			"dashboard": "_shell_light",
+			"profiler": "_csv_light"
 		}
 	},
 	"version": "https://github.com/jesseweed/seti-ui/commit/188dda34a56b9555c7d363771264c24f4693983d"

--- a/src/sql/parts/profiler/editor/profilerInput.ts
+++ b/src/sql/parts/profiler/editor/profilerInput.ts
@@ -20,6 +20,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IDialogService, IConfirmation, IConfirmationResult } from 'vs/platform/dialogs/common/dialogs';
 import { escape } from 'sql/base/common/strings';
+import URI from 'vs/base/common/uri';
 
 export class ProfilerInput extends EditorInput implements IProfilerSession {
 
@@ -116,7 +117,19 @@ export class ProfilerInput extends EditorInput implements IProfilerSession {
 	}
 
 	public getName(): string {
-		return nls.localize('profilerInput.profiler', 'Profiler');
+		let name: string = nls.localize('profilerInput.profiler', 'Profiler');
+		if (!this._connection) {
+			return name;
+		}
+		name += ': ' + this._connection.serverName.substring(0, 20);
+		return name;
+	}
+
+	public getResource(): URI {
+		return URI.from({
+			scheme: ProfilerInput.SCHEMA,
+			path: 'profiler'
+		});
 	}
 
 	public get data(): TableDataView<Slick.SlickData> {


### PR DESCRIPTION
This updates the dashboard, profiler and query editor icons so they are at least all different using neural colors.

This is for issues https://github.com/Microsoft/sqlopsstudio/issues/2107 and https://github.com/Microsoft/sqlopsstudio/issues/387.

> Note we have special icons for these editors, but the shell doesn't seem to respect dark theme styles for tab icons, so we'll need to make those icons theme-neutral or resolve otherwise.

Light icons:
![screen](https://user-images.githubusercontent.com/599935/43620621-878b4940-9688-11e8-81d2-ab5bd89bc443.png)

Dark icons:
![screen2](https://user-images.githubusercontent.com/599935/43620632-95a75b68-9688-11e8-997b-4a54ddf83cbd.png)

