### PR TITLE
Make sure chart viewer height gets set correctly

### DIFF
--- a/src/sql/parts/query/editor/media/queryEditor.css
+++ b/src/sql/parts/query/editor/media/queryEditor.css
@@ -22,3 +22,8 @@
 .editDataEditor {
 	height: inherit
 }
+
+#chartViewerDiv .chartViewer {
+	display: flex;
+	flex-direction: column;
+}

--- a/src/sql/parts/query/views/queryOutput.component.html
+++ b/src/sql/parts/query/views/queryOutput.component.html
@@ -33,7 +33,7 @@
 	<tab *ngIf="showChartView" [visibilityType]="'visibility'" [title]="chartViewerTitle" [identifier]="chartViewerTabIdentifier">
 		<ng-template>
 			<div id="chartViewerDiv" class="headersVisible fullsize" >
-				<chart-viewer [dataSet]="activeDataSet" class="fullsize" style="display: block">
+				<chart-viewer [dataSet]="activeDataSet" class="fullsize chartViewer">
 				</chart-viewer>
 			</div>
 		</ng-template>


### PR DESCRIPTION
Fixes #1497 where chart viewer options could get cut off because the height of the panel was 100% but it got pushed down by the toolbar above it, meaning that some content got put out of view.