### PR TITLE
Do not disconnect editor when canceling change connection

### DIFF
--- a/src/sql/parts/connection/common/connectionManagementService.ts
+++ b/src/sql/parts/connection/common/connectionManagementService.ts
@@ -1120,7 +1120,8 @@ export class ConnectionManagementService extends Disposable implements IConnecti
 					resolve(result);
 				});
 			} else {
-				resolve(self.disconnectEditor(owner));
+				// If the editor is connected then there is nothing to cancel
+				resolve(false);
 			}
 		});
 	}

--- a/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionDialogService.ts
@@ -144,9 +144,6 @@ export class ConnectionDialogService implements IConnectionDialogService {
 			} else {
 				this._connectionManagementService.cancelConnection(this._model);
 			}
-			if (params && params.input && params.input.onConnectReject) {
-				params.input.onConnectReject();
-			}
 			this._connectionDialog.resetConnection();
 			this._connecting = false;
 		}


### PR DESCRIPTION
Fixes #1474 by removing the code that disconnected an editor when canceling out of the change connection dialog