### PR TITLE
Use event element to determine whether to hide dropdown

### DIFF
--- a/src/sql/base/browser/ui/editableDropdown/dropdown.ts
+++ b/src/sql/base/browser/ui/editableDropdown/dropdown.ts
@@ -233,8 +233,8 @@ export class Dropdown extends Disposable {
 					this._layoutTree();
 					return { dispose: () => { } };
 				},
-				onDOMEvent: (e, activeElement) => {
-					if (!DOM.isAncestor(activeElement, this.$el.getHTMLElement()) && !DOM.isAncestor(activeElement, this.$treeContainer.getHTMLElement())) {
+				onDOMEvent: e => {
+					if (!DOM.isAncestor(e.srcElement, this.$el.getHTMLElement()) && !DOM.isAncestor(e.srcElement, this.$treeContainer.getHTMLElement())) {
 						this._input.validate();
 						this._onBlur.fire();
 						this._contextView.hide();


### PR DESCRIPTION
Fixes #1575 which happened because if the user triggered the dom event by clicking on some element that didn't take focus then the document's active element would still be the dropdown, even if the user had clicked outside of the dropdown.