### PR TITLE
File Browser Tree now expands on clicking rows too

### DIFF
--- a/src/sql/parts/fileBrowser/fileBrowserController.ts
+++ b/src/sql/parts/fileBrowser/fileBrowserController.ts
@@ -15,7 +15,7 @@ import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 export class FileBrowserController extends treedefaults.DefaultController {
 
 	constructor() {
-		super({ clickBehavior: treedefaults.ClickBehavior.ON_MOUSE_DOWN });
+		super({ clickBehavior: treedefaults.ClickBehavior.ON_MOUSE_DOWN, openMode: treedefaults.OpenMode.SINGLE_CLICK });
 	}
 
 	protected onLeftClick(tree: ITree, element: any, event: IMouseEvent, origin: string = 'mouse'): boolean {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/sqlopsstudio/issues/1578

The File Browser Tree now expands on clicking not just on the arrow, but also the `FileNode`.