### PR TITLE
Add >= and <= operators for context key expressions.

### DIFF
--- a/src/vs/platform/contextkey/test/common/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/common/contextkey.test.ts
@@ -28,18 +28,26 @@ suite('ContextKeyExpr', () => {
 			ContextKeyExpr.notEquals('c1', 'cc1'),
 			ContextKeyExpr.notEquals('c2', 'cc2'),
 			ContextKeyExpr.not('d1'),
-			ContextKeyExpr.not('d2')
+			ContextKeyExpr.not('d2'),
+			ContextKeyExpr.greaterThanEquals('e1', 'ee1'),
+			ContextKeyExpr.greaterThanEquals('e2', 'ee2'),
+			ContextKeyExpr.lessThanEquals('f1', 'ff1'),
+			ContextKeyExpr.lessThanEquals('f2', 'ff2')
 		);
 		let b = ContextKeyExpr.and(
+			ContextKeyExpr.greaterThanEquals('e2', 'ee2'),
 			ContextKeyExpr.equals('b2', 'bb2'),
 			ContextKeyExpr.notEquals('c1', 'cc1'),
 			ContextKeyExpr.not('d1'),
+			ContextKeyExpr.lessThanEquals('f1', 'ff1'),
 			ContextKeyExpr.regex('d4', /\*\*3*/),
+			ContextKeyExpr.greaterThanEquals('e1', 'ee1'),
 			ContextKeyExpr.notEquals('c2', 'cc2'),
 			ContextKeyExpr.has('a2'),
 			ContextKeyExpr.equals('b1', 'bb1'),
 			ContextKeyExpr.regex('d3', /d.*/),
 			ContextKeyExpr.has('a1'),
+			ContextKeyExpr.lessThanEquals('f2', 'ff2'),
 			ContextKeyExpr.and(ContextKeyExpr.equals('and.a', true)),
 			ContextKeyExpr.not('d2')
 		);
@@ -82,6 +90,12 @@ suite('ContextKeyExpr', () => {
 			testExpression('!' + expr, !value);
 			testExpression(expr + ' =~ /d.*/', /d.*/.test(value));
 			testExpression(expr + ' =~ /D/i', /D/i.test(value));
+			testExpression(expr + ' >= 5', value >= <any>'5');
+			testExpression(expr + ' <= 5', value <= <any>'5');
+			testExpression(expr + ' >= true', value >= true);
+			testExpression(expr + ' <= true', value <= true);
+			testExpression(expr + ' >= false', value >= false);
+			testExpression(expr + ' <= false', value <= false);
 		}
 
 		testBatch('a', true);


### PR DESCRIPTION
This allows for checking minimum or maximum values in the when clauses of a package's context contributions. For example, only showing a context menu option in the server explorer if the server's version is above a certain value.