### PR TITLE
Add context keys for a connection's server info.

### DIFF
--- a/src/sql/parts/connection/common/serverInfoContextKey.ts
+++ b/src/sql/parts/connection/common/serverInfoContextKey.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { RawContextKey, IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ServerInfo } from 'sqlops';
+
+export class ServerInfoContextKey implements IContextKey<ServerInfo> {
+
+	static ServerInfo = new RawContextKey<ServerInfo>('serverInfo', undefined);
+	static ServerMajorVersion = new RawContextKey<number>('serverMajorVersion', undefined);
+	static ServerMinorVersion = new RawContextKey<number>('serverMinorVersion', undefined);
+	static IsCloud = new RawContextKey<boolean>('isCloud', undefined);
+
+	private _serverInfoKey: IContextKey<ServerInfo>;
+	private _serverMajorVersion: IContextKey<number>;
+	private _serverMinorVersion: IContextKey<number>;
+	private _isCloud: IContextKey<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService
+	) {
+		this._serverInfoKey = ServerInfoContextKey.ServerInfo.bindTo(contextKeyService);
+		this._serverMajorVersion = ServerInfoContextKey.ServerMajorVersion.bindTo(contextKeyService);
+		this._serverMinorVersion = ServerInfoContextKey.ServerMinorVersion.bindTo(contextKeyService);
+		this._isCloud = ServerInfoContextKey.IsCloud.bindTo(contextKeyService);
+	}
+
+	set(value: ServerInfo) {
+		this._serverInfoKey.set(value);
+		this._serverMajorVersion.set(value && value.serverMajorVersion);
+		this._serverMinorVersion.set(value && value.serverMinorVersion);
+		this._isCloud.set(value && value.isCloud);
+	}
+
+	reset(): void {
+		this._serverInfoKey.reset();
+		this._serverMajorVersion.reset();
+		this._serverMinorVersion.reset();
+		this._isCloud.reset();
+	}
+
+	public get(): ServerInfo {
+		return this._serverInfoKey.get();
+	}
+}

--- a/src/sql/parts/dashboard/dashboardEditor.ts
+++ b/src/sql/parts/dashboard/dashboardEditor.ts
@@ -23,6 +23,7 @@ import { IDashboardService } from 'sql/services/dashboard/common/dashboardServic
 import { ConnectionProfile } from 'sql/parts/connection/common/connectionProfile';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { IConnectionManagementService } from 'sql/parts/connection/common/connectionManagement';
+import { ServerInfoContextKey } from '../connection/common/serverInfoContextKey';
 
 export class DashboardEditor extends BaseEditor {
 
@@ -113,6 +114,8 @@ export class DashboardEditor extends BaseEditor {
 		let scopedContextService = this._contextKeyService.createScoped(input.container);
 		let connectionContextKey = new ConnectionContextKey(scopedContextService);
 		connectionContextKey.set(input.connectionProfile);
+		let serverInfoContextKey = new ServerInfoContextKey(scopedContextService);
+		serverInfoContextKey.set(serverInfo);
 
 		let params: IDashboardComponentParams = {
 			connection: input.connectionProfile,

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeActionProvider.ts
@@ -35,6 +35,8 @@ import { TreeNodeContextKey } from './treeNodeContextKey';
 import { IQueryManagementService } from 'sql/parts/query/common/queryManagement';
 import { IScriptingService } from 'sql/services/scripting/scriptingService';
 import * as constants from 'sql/common/constants';
+import { ServerInfoContextKey } from '../../connection/common/serverInfoContextKey';
+import * as Utils from 'sql/parts/connection/common/utils';
 
 /**
  *  Provides actions for the server tree elements
@@ -132,8 +134,16 @@ export class ServerTreeActionProvider extends ContributableActionProvider {
 
 	private getContextKeyService(context: ObjectExplorerContext): IContextKeyService {
 		let scopedContextService = this._contextKeyService.createScoped();
+
 		let connectionContextKey = new ConnectionContextKey(scopedContextService);
 		connectionContextKey.set(context.profile);
+
+		let serverInfoContextKey = new ServerInfoContextKey(scopedContextService);
+		let connectInfo = this._connectionManagementService.getConnectionInfo(Utils.generateUri(context.profile));
+		if (connectInfo) {
+			serverInfoContextKey.set(connectInfo.serverInfo);
+		}
+
 		let treeNodeContextKey = new TreeNodeContextKey(scopedContextService);
 		if (context.treeNode) {
 			treeNodeContextKey.set(context.treeNode);


### PR DESCRIPTION
These would be used for checking the server version from the dashboard and object explorer in order to display/hide version-specific tasks, context menu options, etc.