### PR TITLE
Fix for: https://github.com/Microsoft/sqlopsstudio/issues/1317

### DIFF
--- a/src/sql/parts/dashboard/widgets/insights/insightsWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/insightsWidget.component.ts
@@ -231,7 +231,7 @@ export class InsightsWidget extends DashboardWidget implements IDashboardWidget,
 		if (componentInstance.setConfig) {
 			componentInstance.setConfig(this.insightConfig.type[this._typeKey]);
 		}
-		componentInstance.data = { columns: result.columnInfo.map(item => item.columnName), rows: result.rows.map(row => row.map(item => item.displayValue)) };
+		componentInstance.data = { columns: result.columnInfo.map(item => item.columnName), rows: result.rows.map(row => row.map(item => (item.invariantCultureDisplayValue === null || item.invariantCultureDisplayValue === undefined) ?  item.displayValue : item.invariantCultureDisplayValue)) };
 
 		if (componentInstance.init) {
 			componentInstance.init();

--- a/src/sql/parts/grid/views/query/chartViewer.component.ts
+++ b/src/sql/parts/grid/views/query/chartViewer.component.ts
@@ -329,7 +329,7 @@ export class ChartViewerComponent implements OnInit, OnDestroy, IChartViewAction
 		this._executeResult = <IInsightData>{};
 		this._executeResult.columns = dataSet.columnDefinitions.map(def => def.name);
 		this._executeResult.rows = dataSet.dataRows.getRange(0, dataSet.dataRows.getLength()).map(gridRow => {
-			return gridRow.values.map(cell => cell.displayValue);
+			return gridRow.values.map(cell => (cell.invariantCultureDisplayValue === null || cell.invariantCultureDisplayValue === undefined) ? cell.displayValue : cell.invariantCultureDisplayValue);
 		});
 	}
 

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -816,6 +816,7 @@ declare module 'sqlops' {
 	export interface DbCellValue {
 		displayValue: string;
 		isNull: boolean;
+		invariantCultureDisplayValue: string;
 	}
 
 	export interface ResultSetSubset {


### PR DESCRIPTION
When SQL tools service passes the query result back, a ToString operation is used to get the display value for each cell, this works fine if we are only showing the results in the query result window, but can be problematic if we need to use the display value to convert to specific types, for example decimal type. the fix is to introduce a new property to the contract type DbCellType: InvariantCultureDisplayValue, then from the client side we can safely convert the data to specific types.

@kburtram , I didn't implement the fix as we discussed yesterday because we have a different entry point for the chart: in the query editor's result panel, there is an option "view as chart". we also need to cover this scenario.

This fix to the issue needs to be implemented in both SqlToolsService and SqlOpsStudio.  there will be a separate PR for sqltoolsservice.