### PR TITLE
Fix error where rename controller wasn't in InstantiationService

### DIFF
--- a/src/sql/parts/modelComponents/queryTextEditor.ts
+++ b/src/sql/parts/modelComponents/queryTextEditor.ts
@@ -24,16 +24,16 @@ import { EditorOptions } from 'vs/workbench/common/editor';
 import { CodeEditor } from 'vs/editor/browser/codeEditor';
 import { IEditorContributionCtor } from 'vs/editor/browser/editorExtensions';
 import { FoldingController } from 'vs/editor/contrib/folding/folding';
+import { RenameController } from 'vs/editor/contrib/rename/rename';
 
 class QueryCodeEditor extends CodeEditor {
 
 	protected _getContributions(): IEditorContributionCtor[] {
 		let contributions = super._getContributions();
-		let skipContributions = [FoldingController.prototype];
+		let skipContributions = [FoldingController.prototype, RenameController.prototype];
 		contributions = contributions.filter(c => skipContributions.indexOf(c.prototype) === -1);
 		return contributions;
 	}
-
 }
 
 /**

--- a/src/vs/editor/contrib/rename/rename.ts
+++ b/src/vs/editor/contrib/rename/rename.ts
@@ -97,7 +97,8 @@ export async function rename(model: ITextModel, position: Position, newName: str
 
 const CONTEXT_RENAME_INPUT_VISIBLE = new RawContextKey<boolean>('renameInputVisible', false);
 
-class RenameController implements IEditorContribution {
+// {{SQL CARBON EDIT}}
+export class RenameController implements IEditorContribution {
 
 	private static readonly ID = 'editor.contrib.renameController';
 


### PR DESCRIPTION
This was throwing an exception in the console when loading modelview.editor() component. Adding this to the existing filter list. 

I'd like long-term for us to understand why these aren't being found in the instantiation service - I'd guess other code editor implementations are doing an instantiationService.copy and adding in some components, but I couldn't find the exact place this is happening.