### PR TITLE
Bump yarn.lock package reference

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -174,9 +174,9 @@ angular2-grid@2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/angular2-grid/-/angular2-grid-2.0.6.tgz#01fe225dc13b2822370b6c61f9a6913b3a26f989"
 
-"angular2-slickgrid@github:Microsoft/angular2-slickgrid#1.4.1":
-  version "1.4.1"
-  resolved "https://codeload.github.com/Microsoft/angular2-slickgrid/tar.gz/e13c098aa50f43de21a5fdcd1a1a0263455b92d6"
+"angular2-slickgrid@github:Microsoft/angular2-slickgrid#1.4.3":
+  version "1.4.3"
+  resolved "https://codeload.github.com/Microsoft/angular2-slickgrid/tar.gz/a9801217a1b25ee2bf001cacfd9edf4cbb6992d2"
 
 ansi-colors@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
@alanrenmsft please include the yarn.lock file when updating package.json (the lock file is built from the package.json file during `yarn install`)