### PR TITLE
Switch back DB icon but use default colors

### DIFF
--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -232,11 +232,11 @@
 		},
 		"_db_light": {
 			"fontCharacter": "\\E01C",
-			"fontColor": "#dd4b78"
+			"fontColor": "#bfc2c1"
 		},
 		"_db": {
 			"fontCharacter": "\\E01C",
-			"fontColor": "#f55385"
+			"fontColor": "#d4d7d6"
 		},
 		"_default_light": {
 			"fontCharacter": "\\E01D",
@@ -1411,7 +1411,7 @@
 		"rust": "_rust",
 		"scss": "_sass",
 		"shellscript": "_shell",
-		"sql": "_default",
+		"sql": "_db",
 		"swift": "_swift",
 		"typescript": "_typescript",
 		"typescriptreact": "_react",
@@ -1616,7 +1616,7 @@
 			"rust": "_rust_light",
 			"scss": "_sass_light",
 			"shellscript": "_shell_light",
-			"sql": "_default_light",
+			"sql": "_db_light",
 			"swift": "_swift_light",
 			"typescript": "_typescript_light",
 			"typescriptreact": "_react_light",


### PR DESCRIPTION
Fixes https://github.com/Microsoft/sqlopsstudio/issues/2196 by switching back to the DB icon for .SQL files.  Though I'm changing the color to match the default file type to resolve https://github.com/Microsoft/sqlopsstudio/issues/387.

*Light Theme*
![image](https://user-images.githubusercontent.com/599935/44289762-8811e380-a22a-11e8-8ede-811e83d4d561.png)

*Dark Theme*
![image](https://user-images.githubusercontent.com/599935/44289801-b099dd80-a22a-11e8-9082-6c8ecebbb5e6.png)


