### PR TITLE
Fixed problem where vertical charts didn't display labels correctly.

### DIFF
--- a/src/sql/parts/grid/views/query/chartViewer.component.ts
+++ b/src/sql/parts/grid/views/query/chartViewer.component.ts
@@ -327,9 +327,11 @@ export class ChartViewerComponent implements OnInit, OnDestroy, IChartViewAction
 	@Input() set dataSet(dataSet: IGridDataSet) {
 		// Setup the execute result
 		this._executeResult = <IInsightData>{};
-		this._executeResult.columns = dataSet.columnDefinitions.map(def => def.name);
+
+		// Remove first column and its value since this is the row number column
+		this._executeResult.columns = dataSet.columnDefinitions.slice(1).map(def => def.name);
 		this._executeResult.rows = dataSet.dataRows.getRange(0, dataSet.dataRows.getLength()).map(gridRow => {
-			return gridRow.values.map(cell => (cell.invariantCultureDisplayValue === null || cell.invariantCultureDisplayValue === undefined) ? cell.displayValue : cell.invariantCultureDisplayValue);
+			return gridRow.values.slice(1).map(cell => (cell.invariantCultureDisplayValue === null || cell.invariantCultureDisplayValue === undefined) ? cell.displayValue : cell.invariantCultureDisplayValue);
 		});
 	}
 


### PR DESCRIPTION
Charts didn't display labels correctly since the row number wasn't expected in the column array.
For some reason the rows of this column were always undefined which resulted in unexpected undefined labels since the first column is used for labels.

Removal of the column in the chart component solves the problem.
Related to #2017 

Edit:
This might also have solved the issues of #18 
I have tried a few queries and haven't been able to reproduce the error.
It would be great if we could confirm this.
