### PR TITLE
changed desktop icon flag

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -60,7 +60,7 @@ Type: files; Name: "{app}\resources\app\Credits_45.0.2454.85.html"; Check: IsNot
 Type: filesandordirs; Name: "{app}\_"
 
 [Tasks]
-Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: checkedonce;
 Name: "quicklaunchicon"; Description: "{cm:CreateQuickLaunchIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked; OnlyBelowVersion: 0,6.1
 Name: "associatewithfiles"; Description: "{cm:AssociateWithFiles,{#NameShort}}"; GroupDescription: "{cm:Other}"; Flags: unchecked
 Name: "addtopath"; Description: "{cm:AddToPath}"; GroupDescription: "{cm:Other}"


### PR DESCRIPTION
Changed the flag based on the [documentation](http://www.jrsoftware.org/ishelp/index.php?topic=taskssection)-

**Flags**
This parameter is a set of extra options. Multiple options may be used by separating them by spaces. The following options are supported:

**checkedonce**
Instructs Setup that this task should be unchecked initially when Setup finds a previous version of the same application is already installed.

**unchecked**
Instructs Setup that this task should be unchecked initially.

