### PR TITLE
fix edit data issue

### DIFF
--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -304,8 +304,8 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 			self.currentCell = {
 				row: row,
 				column: column,
-				isEditable: self.dataSet.columnDefinitions[column - 1]
-					? self.dataSet.columnDefinitions[column - 1].isEditable
+				isEditable: self.dataSet.columnDefinitions[column]
+					? self.dataSet.columnDefinitions[column].isEditable
 					: false
 			};
 		});


### PR DESCRIPTION
The dataSet.columnDefinitions collection contains the row number column, so the UI and the columnDefinitions are in sync we don't have to do -1 for the column index.

the issue #2270 occurred because the previous column is not editable and caused the updateCell logic not being triggered. also you will see weird behavior for any tables if you try to edit the cells in the first column due to this.