### PR TITLE
Fixed issue where empty unresizable block appeared below result.

### DIFF
--- a/src/sql/parts/grid/common/interfaces.ts
+++ b/src/sql/parts/grid/common/interfaces.ts
@@ -47,8 +47,8 @@ export interface IGridDataSet {
 	totalRows: number;
 	batchId: number;
 	resultId: number;
-	maxHeight: number | string;
-	minHeight: number | string;
+	maxHeight?: number | string;
+	minHeight?: number | string;
 }
 
 export enum SaveFormat {

--- a/src/sql/parts/grid/views/query/query.component.html
+++ b/src/sql/parts/grid/views/query/query.component.html
@@ -13,8 +13,7 @@
 	<div #resultsScrollBox id="results" *ngIf="renderedDataSets.length > 0" class="results vertBox scrollable"
 		(onScroll)="onScroll($event)" [scrollEnabled]="scrollEnabled" [class.hidden]="!resultActive"
 		(focusin)="onGridFocus()" (focusout)="onGridFocusout()">
-		<div class="boxRow content horzBox slickgrid" *ngFor="let dataSet of renderedDataSets; let i = index"
-			[style.max-height]="dataSet.maxHeight" [style.min-height]="dataSet.minHeight">
+		<div class="boxRow content horzBox slickgrid" *ngFor="let dataSet of renderedDataSets; let i = index">
 			<slick-grid #slickgrid id="slickgrid_{{i}}"
 				class="boxCol content vertBox slickgrid"
 				enableAsyncPostRender="true"

--- a/src/sql/parts/grid/views/query/query.component.ts
+++ b/src/sql/parts/grid/views/query/query.component.ts
@@ -339,19 +339,6 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 			});
 		};
 
-		// Precalculate the max height and min height
-		let maxHeight: string = 'inherit';
-		if (resultSet.rowCount < self._defaultNumShowingRows) {
-			let maxHeightNumber: number = Math.max((resultSet.rowCount + 1) * self._rowHeight, self.dataIcons.length * 30) + 10;
-			maxHeight = maxHeightNumber.toString() + 'px';
-		}
-
-		let minHeight: string = maxHeight;
-		if (resultSet.rowCount >= self._defaultNumShowingRows) {
-			let minHeightNumber: number = (self._defaultNumShowingRows + 1) * self._rowHeight + 10;
-			minHeight = minHeightNumber.toString() + 'px';
-		}
-
 		let rowNumberColumn = new RowNumberColumn({ numberOfRows: resultSet.rowCount });
 
 		// Store the result set from the event
@@ -360,8 +347,6 @@ export class QueryComponent extends GridParentComponent implements OnInit, OnDes
 			batchId: resultSet.batchId,
 			resultId: resultSet.id,
 			totalRows: resultSet.rowCount,
-			maxHeight: maxHeight,
-			minHeight: minHeight,
 			dataRows: new VirtualizedCollection(
 				self.windowSize,
 				resultSet.rowCount,


### PR DESCRIPTION
When initalizing the results grid a min/max height was set which wasn't calculated properly.
By removing this we inherit the height from the base container which fits perfectly and removes the unnecessary block.
#1914