### PR TITLE
Show no account message after deleting all azure accounts

### DIFF
--- a/src/sql/parts/accountManagement/accountDialog/accountDialog.ts
+++ b/src/sql/parts/accountManagement/accountDialog/accountDialog.ts
@@ -171,11 +171,15 @@ export class AccountDialog extends Modal {
 		if (!this.isEmptyLinkedAccount()) {
 			this.showSplitView();
 		} else {
-			this._splitViewContainer.hidden = true;
-			this._noaccountViewContainer.hidden = false;
-			this._addAccountButton.focus();
+			this.showNoAccountContainer();
 		}
 
+	}
+
+	private showNoAccountContainer() {
+		this._splitViewContainer.hidden = true;
+		this._noaccountViewContainer.hidden = false;
+		this._addAccountButton.focus();
 	}
 
 	private showSplitView() {
@@ -296,6 +300,10 @@ export class AccountDialog extends Modal {
 
 		if (args.accountList.length > 0 && this._splitViewContainer.hidden) {
 			this.showSplitView();
+		}
+
+		if (this.isEmptyLinkedAccount() && this._noaccountViewContainer.hidden) {
+			this.showNoAccountContainer();
 		}
 
 		this.layout();


### PR DESCRIPTION
Previously if you had an existing account and then deleted it, the "please add an account" message would not show up until you closed and reopened the dialog.

![Linked account dialog showing the "please add an account" message](https://user-images.githubusercontent.com/3758704/44483229-608e9280-a5ff-11e8-8a95-560d6f905f05.png)
