### PR TITLE
fix the active cell's bottom border disappearing issue

### DIFF
--- a/src/sql/parts/grid/media/slickColorTheme.css
+++ b/src/sql/parts/grid/media/slickColorTheme.css
@@ -73,7 +73,7 @@
 /* grid styling */
 
 .vs slick-grid.active .grid .slick-cell.active {
-  border: dotted 1px var(--color-cell-border-active);
+  border-color: var(--color-cell-border-active);
 }
 
 .vs slick-grid.active .grid .slick-cell.selected {
@@ -199,7 +199,7 @@
 /* grid styling */
 
 .vs-dark slick-grid.active .grid .slick-cell.active {
-  border: dotted 1px var(--color-cell-border-active);
+  border-color: var(--color-cell-border-active);
 }
 
 .vs-dark slick-grid.active .grid .slick-cell.selected {
@@ -332,7 +332,7 @@
 /* grid styling */
 
 .hc-black slick-grid.active .grid .slick-cell.active {
-  border: solid 1px var(--color-cell-border-active);
+  border-color: var(--color-cell-border-active);
 }
 
 .hc-black slick-grid.active .grid .slick-cell.selected {


### PR DESCRIPTION
Issue: #9 

For a cell in normal state, the border width is (0px, 0px, 1px, 1px) (left, top, right, bottom ). the active cell border's width is set to 1px by the modified CSS entries, which will cause the position of the active cell to move down 1 pixel. this works fine if we are selecting only one cell, but when we select multiple cells, the cell below the active cell will overlap with the active cell's bottom border, which caused the symptom described in issue #9.

The fix is to only set the color and not the width of the border to avoid the issue.