### PR TITLE
Prompt to create Profiler session per server

### DIFF
--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -454,7 +454,7 @@ export class ProfilerEditor extends BaseEditor {
 			this._connectAction.connected = this.input.state.isConnected;
 
 			if (this.input.state.isConnected) {
-				let uiState = this._profilerService.getSessionViewState(this.input.getResource().toString());
+
 				this._updateToolbar();
 				this._sessionSelector.enable();
 				this._profilerService.getXEventSessions(this.input.id).then((r) => {
@@ -467,6 +467,7 @@ export class ProfilerEditor extends BaseEditor {
 					this._sessionsList = r;
 					if ((this.input.sessionName === undefined || this.input.sessionName === '') && this._sessionsList.length > 0) {
 						let sessionIndex: number = 0;
+						let uiState = this._profilerService.getSessionViewState(this.input.id);
 						if (uiState && uiState.previousSessionName) {
 							sessionIndex = this._sessionsList.indexOf(uiState.previousSessionName);
 						} else {
@@ -478,6 +479,7 @@ export class ProfilerEditor extends BaseEditor {
 						}
 
 						this.input.sessionName = this._sessionsList[sessionIndex];
+						this._sessionSelector.selectWithOptionName(this.input.sessionName);
 					}
 				});
 			} else {

--- a/src/sql/parts/profiler/editor/profilerEditor.ts
+++ b/src/sql/parts/profiler/editor/profilerEditor.ts
@@ -460,9 +460,14 @@ export class ProfilerEditor extends BaseEditor {
 				this._updateToolbar();
 				this._sessionSelector.enable();
 				this._profilerService.getXEventSessions(this.input.id).then((r) => {
+					// set undefined result to empty list
+					if (!r) {
+						r = [];
+					}
+
 					this._sessionSelector.setOptions(r);
 					this._sessionsList = r;
-					if (this.input.sessionName === undefined || this.input.sessionName === '') {
+					if ((this.input.sessionName === undefined || this.input.sessionName === '') && this._sessionsList.length > 0) {
 						this.input.sessionName = this._sessionsList[0];
 					}
 				});
@@ -493,9 +498,14 @@ export class ProfilerEditor extends BaseEditor {
 				this._updateToolbar();
 				this._sessionSelector.enable();
 				this._profilerService.getXEventSessions(this.input.id).then((r) => {
+					// set undefined result to empty list
+					if (!r) {
+						r = [];
+					}
+
 					this._sessionsList = r;
 					this._sessionSelector.setOptions(r);
-					if (this.input.sessionName === undefined || this.input.sessionName === '') {
+					if ((this.input.sessionName === undefined || this.input.sessionName === '') && this._sessionsList.length > 0) {
 						this.input.sessionName = this._sessionsList[0];
 					}
 				});

--- a/src/sql/parts/profiler/service/interfaces.ts
+++ b/src/sql/parts/profiler/service/interfaces.ts
@@ -110,6 +110,12 @@ export interface IProfilerService {
 	 */
 	getSessionTemplates(providerId?: string): Array<IProfilerSessionTemplate>;
 	/**
+	 * Gets the session view state
+	 * @param sessionId The session ID to get the view state for
+	 * @returns Sessions view state
+	 */
+	getSessionViewState(sessionId: string): any;
+	/**
 	 * Launches the dialog for editing the view columns of a profiler session template for the given input
 	 * @param input input object that contains the necessary information which will be modified based on used input
 	 */


### PR DESCRIPTION
Update Profiler to (1) prompt the user to create a new session when they try to profile a server for the first time (2) remember the session that was most recently used for a server and select it by default next time.