### PR TITLE
Temporarily roll back SqlToolsService update to fix #2304

### DIFF
--- a/extensions/mssql/src/config.json
+++ b/extensions/mssql/src/config.json
@@ -1,6 +1,6 @@
 {
 	"downloadUrl": "https://github.com/Microsoft/sqltoolsservice/releases/download/v{#version#}/microsoft.sqltools.servicelayer-{#fileName#}",
-	"version": "1.5.0-alpha.29",
+	"version": "1.5.0-alpha.28",
 	"downloadFileNames": {
 		"Windows_86": "win-x86-netcoreapp2.1.zip",
 		"Windows_64": "win-x64-netcoreapp2.1.zip",


### PR DESCRIPTION
- Credential Service and Azure / Resource Provider Services are all broken in 1.5.0-alpha.29 so rolling back until fixed