### PR TITLE
hide the backup restore commands from command palette

### DIFF
--- a/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
@@ -86,7 +86,7 @@ export class TasksWidget extends DashboardWidget implements IDashboardWidget, On
 			}).filter(i => !!i);
 		}
 
-		this._tasks = tasks.map(i => MenuRegistry.getCommand(i)).filter(v => !!v);
+		this._tasks = tasks.map(i => TaskRegistry.getCommandActionById(i)).filter(v => !!v);
 	}
 
 	ngOnInit() {

--- a/src/sql/workbench/common/actions.contribution.ts
+++ b/src/sql/workbench/common/actions.contribution.ts
@@ -15,8 +15,8 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } fr
 import { ShowCurrentReleaseNotesAction } from 'sql/workbench/update/releaseNotes';
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 
-new Actions.BackupAction().registerTask();
-new Actions.RestoreAction().registerTask();
+new Actions.BackupAction().registerTask(false);
+new Actions.RestoreAction().registerTask(false);
 new Actions.NewQueryAction().registerTask();
 new Actions.ConfigureDashboardAction().registerTask();
 


### PR DESCRIPTION
add support to allow registering a command without exposing it in command palette, and use the way to hide backup/restore from command palette.

#1781 