### PR TITLE
Feature: Ability to add connection name

### DIFF
--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -202,6 +202,20 @@
       "displayName": "Microsoft SQL Server",
       "connectionOptions": [
         {
+          "specialValueType": "connectionName",
+          "isIdentity": true,
+          "name": "connectionName",
+          "displayName": "Name (optional)",
+          "description": "Custom name of the connection",
+          "groupName": "Source",
+          "valueType": "string",
+          "defaultValue": null,
+          "objectType": null,
+          "categoryValues": null,
+          "isRequired": false,
+          "isArray": false
+        },
+        {
           "specialValueType": "serverName",
           "isIdentity": true,
           "name": "server",

--- a/src/sql/parts/connection/common/connectionProfile.ts
+++ b/src/sql/parts/connection/common/connectionProfile.ts
@@ -145,6 +145,7 @@ export class ConnectionProfile extends ProviderConnectionInfo implements interfa
 
 	public toIConnectionProfile(): interfaces.IConnectionProfile {
 		let result: interfaces.IConnectionProfile = {
+			connectionName: this.connectionName,
 			serverName: this.serverName,
 			databaseName: this.databaseName,
 			authenticationType: this.authenticationType,

--- a/src/sql/parts/connection/common/providerConnectionInfo.ts
+++ b/src/sql/parts/connection/common/providerConnectionInfo.ts
@@ -194,7 +194,9 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 		let idNames = [];
 		if (this._serverCapabilities) {
 			idNames = this._serverCapabilities.connectionOptions.map(o => {
-				if ((o.specialValueType || o.isIdentity) && o.specialValueType !== ConnectionOptionSpecialType.password) {
+				if ((o.specialValueType || o.isIdentity)
+				&& o.specialValueType !== ConnectionOptionSpecialType.password
+				&& o.specialValueType !== ConnectionOptionSpecialType.connectionName) {
 					return o.name;
 				} else {
 					return undefined;
@@ -202,7 +204,7 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 			});
 		} else {
 			// This should never happen but just incase the serverCapabilities was not ready at this time
-			idNames = ['authenticationType', 'database', 'server', 'user', 'connectionName'];
+			idNames = ['authenticationType', 'database', 'server', 'user'];
 		}
 
 		idNames = idNames.filter(x => x !== undefined);

--- a/src/sql/parts/connection/common/providerConnectionInfo.ts
+++ b/src/sql/parts/connection/common/providerConnectionInfo.ts
@@ -45,6 +45,7 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 				this.databaseName = model.databaseName;
 				this.password = model.password;
 				this.userName = model.userName;
+				this.connectionName = model.connectionName;
 			}
 		}
 	}
@@ -78,6 +79,10 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 		return this._serverCapabilities;
 	}
 
+	public get connectionName(): string {
+		return this.getSpecialTypeOptionValue(ConnectionOptionSpecialType.connectionName);
+	}
+
 	public get serverName(): string {
 		return this.getSpecialTypeOptionValue(ConnectionOptionSpecialType.serverName);
 	}
@@ -96,6 +101,10 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 
 	public get authenticationType(): string {
 		return this.getSpecialTypeOptionValue(ConnectionOptionSpecialType.authType);
+	}
+
+	public set connectionName(value: string) {
+		this.setSpecialTypeOptionName(ConnectionOptionSpecialType.connectionName, value);
 	}
 
 	public set serverName(value: string) {
@@ -127,14 +136,28 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 		this.options[name] = value;
 	}
 
+	private getServerInfo() {
+		let databaseName = this.databaseName ? this.databaseName : '<default>';
+		let userName = this.userName ? this.userName : 'Windows Authentication';
+		return this.serverName + ', ' + databaseName + ' (' + userName + ')';
+	}
+
 	/**
 	 * Returns the title of the connection
 	 */
 	public get title(): string {
-		let databaseName = this.databaseName ? this.databaseName : '<default>';
-		let userName = this.userName ? this.userName : 'Windows Authentication';
-		let label = this.serverName + ', ' + databaseName + ' (' + userName + ')';
+		let label = '';
+
+		if (this.connectionName) {
+			label = this.connectionName;
+		} else {
+			label = this.getServerInfo();
+		}
 		return label;
+	}
+
+	public get serverInfo(): string {
+		return this.getServerInfo();
 	}
 
 	/**
@@ -179,7 +202,7 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 			});
 		} else {
 			// This should never happen but just incase the serverCapabilities was not ready at this time
-			idNames = ['authenticationType', 'database', 'server', 'user'];
+			idNames = ['authenticationType', 'database', 'server', 'user', 'connectionName'];
 		}
 
 		idNames = idNames.filter(x => x !== undefined);
@@ -267,6 +290,7 @@ export class ProviderConnectionInfo extends Disposable implements sqlops.Connect
 				element.specialValueType !== ConnectionOptionSpecialType.databaseName &&
 				element.specialValueType !== ConnectionOptionSpecialType.authType &&
 				element.specialValueType !== ConnectionOptionSpecialType.password &&
+				element.specialValueType !== ConnectionOptionSpecialType.connectionName &&
 				element.isIdentity && element.valueType === ServiceOptionType.string) {
 				let value = this.getOptionValue(element.name);
 				if (value) {

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -43,6 +43,7 @@ export class ConnectionWidget {
 	private _serverGroupSelectBox: SelectBox;
 	private _previousGroupOption: string;
 	private _serverGroupOptions: IConnectionProfileGroup[];
+	private _connectionNameInputBox: InputBox;
 	private _serverNameInputBox: InputBox;
 	private _databaseNameInputBox: Dropdown;
 	private _userNameInputBox: InputBox;
@@ -154,6 +155,12 @@ export class ConnectionWidget {
 	}
 
 	private fillInConnectionForm(): void {
+		// User server name
+		let connectionNameOption = this._optionsMaps[ConnectionOptionSpecialType.connectionName];
+		let connectionNameBuilder = DialogHelper.appendRow(this._tableContainer, connectionNameOption.displayName, 'connection-label', 'connection-input');
+		this._connectionNameInputBox = new InputBox(connectionNameBuilder.getHTMLElement(), this._contextViewService, { ariaLabel: connectionNameOption.displayName });
+
+		// Server name
 		let serverNameOption = this._optionsMaps[ConnectionOptionSpecialType.serverName];
 		let serverNameBuilder = DialogHelper.appendRow(this._tableContainer, serverNameOption.displayName, 'connection-label', 'connection-input');
 		this._serverNameInputBox = new InputBox(serverNameBuilder.getHTMLElement(), this._contextViewService, {
@@ -170,11 +177,13 @@ export class ConnectionWidget {
 			ariaLabel: serverNameOption.displayName
 		});
 
+		// Authentication type
 		if (this._optionsMaps[ConnectionOptionSpecialType.authType]) {
 			let authTypeBuilder = DialogHelper.appendRow(this._tableContainer, this._optionsMaps[ConnectionOptionSpecialType.authType].displayName, 'connection-label', 'connection-input');
 			DialogHelper.appendInputSelectBox(authTypeBuilder, this._authTypeSelectBox);
 		}
 
+		// Username
 		let self = this;
 		let userNameOption = this._optionsMaps[ConnectionOptionSpecialType.userName];
 		let userNameBuilder = DialogHelper.appendRow(this._tableContainer, userNameOption.displayName, 'connection-label', 'connection-input');
@@ -185,15 +194,18 @@ export class ConnectionWidget {
 			ariaLabel: userNameOption.displayName
 		});
 
+		// Password
 		let passwordOption = this._optionsMaps[ConnectionOptionSpecialType.password];
 		let passwordBuilder = DialogHelper.appendRow(this._tableContainer, passwordOption.displayName, 'connection-label', 'connection-input');
 		this._passwordInputBox = new InputBox(passwordBuilder.getHTMLElement(), this._contextViewService, { ariaLabel: passwordOption.displayName });
 		this._passwordInputBox.inputElement.type = 'password';
 		this._password = '';
 
+		// Remember password
 		let rememberPasswordLabel = localize('rememberPassword', 'Remember password');
 		this._rememberPasswordCheckBox = this.appendCheckbox(this._tableContainer, rememberPasswordLabel, 'connection-checkbox', 'connection-input', false);
 
+		// Database
 		let databaseOption = this._optionsMaps[ConnectionOptionSpecialType.databaseName];
 		let databaseNameBuilder = DialogHelper.appendRow(this._tableContainer, databaseOption.displayName, 'connection-label', 'connection-input');
 
@@ -206,6 +218,7 @@ export class ConnectionWidget {
 			actionLabel: localize('connectionWidget.toggleDatabaseNameDropdown', 'Select Database Toggle Dropdown')
 		});
 
+		// Server group
 		let serverGroupLabel = localize('serverGroup', 'Server group');
 		let serverGroupBuilder = DialogHelper.appendRow(this._tableContainer, serverGroupLabel, 'connection-label', 'connection-input');
 		DialogHelper.appendInputSelectBox(serverGroupBuilder, this._serverGroupSelectBox);
@@ -257,6 +270,7 @@ export class ConnectionWidget {
 		// Theme styler
 		this._toDispose.push(attachInputBoxStyler(this._serverNameInputBox, this._themeService));
 		this._toDispose.push(attachEditableDropdownStyler(this._databaseNameInputBox, this._themeService));
+		this._toDispose.push(attachInputBoxStyler(this._connectionNameInputBox, this._themeService));
 		this._toDispose.push(attachInputBoxStyler(this._userNameInputBox, this._themeService));
 		this._toDispose.push(attachInputBoxStyler(this._passwordInputBox, this._themeService));
 		this._toDispose.push(styler.attachSelectBoxStyler(this._serverGroupSelectBox, this._themeService));
@@ -385,7 +399,7 @@ export class ConnectionWidget {
 
 	public focusOnOpen(): void {
 		this._handleClipboard();
-		this._serverNameInputBox.focus();
+		this._connectionNameInputBox.focus();
 		this.focusPasswordIfNeeded();
 		this.clearValidationMessages();
 	}
@@ -403,6 +417,7 @@ export class ConnectionWidget {
 		if (connectionInfo) {
 			this._serverNameInputBox.value = this.getModelValue(connectionInfo.serverName);
 			this._databaseNameInputBox.value = this.getModelValue(connectionInfo.databaseName);
+			this._connectionNameInputBox.value = this.getModelValue(connectionInfo.connectionName);
 			this._userNameInputBox.value = this.getModelValue(connectionInfo.userName);
 			this._passwordInputBox.value = connectionInfo.password ? Constants.passwordChars : '';
 			this._password = this.getModelValue(connectionInfo.password);
@@ -507,6 +522,10 @@ export class ConnectionWidget {
 		}
 	}
 
+	public get connectionName(): string {
+		return this._connectionNameInputBox.value;
+	}
+
 	public get serverName(): string {
 		return this._serverNameInputBox.value;
 	}
@@ -550,6 +569,7 @@ export class ConnectionWidget {
 	public connect(model: IConnectionProfile): boolean {
 		let validInputs = this.validateInputs();
 		if (validInputs) {
+			model.connectionName = this.connectionName;
 			model.serverName = this.serverName;
 			model.databaseName = this.databaseName;
 			model.userName = this.userName;

--- a/src/sql/parts/connection/connectionDialog/connectionWidget.ts
+++ b/src/sql/parts/connection/connectionDialog/connectionWidget.ts
@@ -155,7 +155,7 @@ export class ConnectionWidget {
 	}
 
 	private fillInConnectionForm(): void {
-		// User server name
+		// Connection name
 		let connectionNameOption = this._optionsMaps[ConnectionOptionSpecialType.connectionName];
 		let connectionNameBuilder = DialogHelper.appendRow(this._tableContainer, connectionNameOption.displayName, 'connection-label', 'connection-input');
 		this._connectionNameInputBox = new InputBox(connectionNameBuilder.getHTMLElement(), this._contextViewService, { ariaLabel: connectionNameOption.displayName });

--- a/src/sql/parts/objectExplorer/viewlet/connectionTreeAction.ts
+++ b/src/sql/parts/objectExplorer/viewlet/connectionTreeAction.ts
@@ -144,6 +144,7 @@ export class AddServerAction extends Action {
 
 	public run(element: ConnectionProfileGroup): TPromise<boolean> {
 		let connection: IConnectionProfile = element === undefined ? undefined : {
+			connectionName: undefined,
 			serverName: undefined,
 			databaseName: undefined,
 			userName: undefined,

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeRenderer.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeRenderer.ts
@@ -160,7 +160,7 @@ export class ServerTreeRenderer implements IRenderer {
 		}
 
 		templateData.label.textContent = label;
-		templateData.root.title = label;
+		templateData.root.title = connection.serverInfo;
 		templateData.connectionProfile = connection;
 	}
 

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -195,6 +195,7 @@ declare module 'sqlops' {
 	}
 
 	export interface IConnectionProfile extends ConnectionInfo {
+		connectionName: string;
 		serverName: string;
 		databaseName: string;
 		userName: string;
@@ -349,6 +350,7 @@ declare module 'sqlops' {
 	}
 
 	export enum ConnectionOptionSpecialType {
+		connectionName = 'connectionName',
 		serverName = 'serverName',
 		databaseName = 'databaseName',
 		authType = 'authType',

--- a/src/sql/workbench/api/common/sqlExtHostTypes.ts
+++ b/src/sql/workbench/api/common/sqlExtHostTypes.ts
@@ -18,6 +18,7 @@ export enum ServiceOptionType {
 }
 
 export enum ConnectionOptionSpecialType {
+	connectionName = 'connectionName',
 	serverName = 'serverName',
 	databaseName = 'databaseName',
 	authType = 'authType',

--- a/src/sqltest/common/telemetryUtilities.test.ts
+++ b/src/sqltest/common/telemetryUtilities.test.ts
@@ -18,6 +18,7 @@ suite('SQL Telemetry Utilities tests', () => {
 	let telemetryKey: string = 'tel key';
 
 	let connectionProfile = {
+		connectionName: '',
 		databaseName: '',
 		serverName: '',
 		authenticationType: '',

--- a/src/sqltest/parts/accountManagement/firewallRuleDialogController.test.ts
+++ b/src/sqltest/parts/accountManagement/firewallRuleDialogController.test.ts
@@ -77,6 +77,7 @@ suite('Firewall rule dialog controller tests', () => {
 			.returns(() => mockFirewallRuleDialog.object);
 
 		connectionProfile = {
+			connectionName: 'new name',
 			serverName: 'new server',
 			databaseName: 'database',
 			userName: 'user',

--- a/src/sqltest/parts/connection/connectionManagementService.test.ts
+++ b/src/sqltest/parts/connection/connectionManagementService.test.ts
@@ -50,6 +50,7 @@ suite('SQL ConnectionManagementService tests', () => {
 	let none: void;
 
 	let connectionProfile: IConnectionProfile = {
+		connectionName: 'new name',
 		serverName: 'new server',
 		databaseName: 'database',
 		userName: 'user',

--- a/src/sqltest/parts/connection/connectionProfile.test.ts
+++ b/src/sqltest/parts/connection/connectionProfile.test.ts
@@ -19,6 +19,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 	let capabilitiesService: CapabilitiesTestService;
 
 	let connectionProfile: IConnectionProfile = {
+		connectionName: 'new name',
 		serverName: 'new server',
 		databaseName: 'database',
 		userName: 'user',
@@ -51,6 +52,18 @@ suite('SQL ConnectionProfileInfo tests', () => {
 
 	setup(() => {
 		let connectionProvider: sqlops.ConnectionOption[] = [
+			{
+				name: 'connectionName',
+				displayName: undefined,
+				description: undefined,
+				groupName: undefined,
+				categoryValues: undefined,
+				defaultValue: undefined,
+				isIdentity: true,
+				isRequired: true,
+				specialValueType: ConnectionOptionSpecialType.connectionName,
+				valueType: ServiceOptionType.string
+			},
 			{
 				name: 'serverName',
 				displayName: undefined,

--- a/src/sqltest/parts/connection/connectionProfile.test.ts
+++ b/src/sqltest/parts/connection/connectionProfile.test.ts
@@ -40,6 +40,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 		groupId: 'groupId',
 		id: 'id',
 		options: {
+			connectionName: 'new name',
 			serverName: 'new server',
 			databaseName: 'database',
 			userName: 'user',
@@ -137,6 +138,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 	test('set properties should set the values correctly', () => {
 		let conn = new ConnectionProfile(capabilitiesService, undefined);
 		assert.equal(conn.serverName, undefined);
+		conn.connectionName = connectionProfile.connectionName;
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName;
 		conn.authenticationType = connectionProfile.authenticationType;
@@ -145,6 +147,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 		conn.groupId = connectionProfile.groupId;
 		conn.groupFullName = connectionProfile.groupFullName;
 		conn.savePassword = connectionProfile.savePassword;
+		assert.equal(conn.connectionName, connectionProfile.connectionName);
 		assert.equal(conn.serverName, connectionProfile.serverName);
 		assert.equal(conn.databaseName, connectionProfile.databaseName);
 		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
@@ -158,6 +161,7 @@ suite('SQL ConnectionProfileInfo tests', () => {
 	test('constructor should initialize the options given a valid model', () => {
 		let conn = new ConnectionProfile(capabilitiesService, connectionProfile);
 
+		assert.equal(conn.connectionName, connectionProfile.connectionName);
 		assert.equal(conn.serverName, connectionProfile.serverName);
 		assert.equal(conn.databaseName, connectionProfile.databaseName);
 		assert.equal(conn.authenticationType, connectionProfile.authenticationType);

--- a/src/sqltest/parts/connection/connectionStatusManager.test.ts
+++ b/src/sqltest/parts/connection/connectionStatusManager.test.ts
@@ -17,6 +17,7 @@ let connections: ConnectionStatusManager;
 let capabilitiesService: CapabilitiesTestService;
 let connectionProfileObject: ConnectionProfile;
 let connectionProfile: IConnectionProfile = {
+	connectionName: 'new name',
 	serverName: 'new server',
 	databaseName: 'database',
 	userName: 'user',
@@ -33,6 +34,7 @@ let connectionProfile: IConnectionProfile = {
 	id: undefined
 };
 let editorConnectionProfile: IConnectionProfile = {
+	connectionName: 'new name',
 	serverName: 'new server',
 	databaseName: 'database',
 	userName: 'user',
@@ -49,6 +51,7 @@ let editorConnectionProfile: IConnectionProfile = {
 	id: undefined
 };
 let connectionProfileWithoutDbName: IConnectionProfile = {
+	connectionName: 'new name',
 	serverName: 'new server',
 	databaseName: '',
 	userName: 'user',

--- a/src/sqltest/parts/connection/connectionStore.test.ts
+++ b/src/sqltest/parts/connection/connectionStore.test.ts
@@ -41,6 +41,7 @@ suite('SQL ConnectionStore tests', () => {
 
 	setup(() => {
 		defaultNamedProfile = Object.assign({}, {
+			connectionName: 'new name',
 			serverName: 'namedServer',
 			databaseName: 'bcd',
 			authenticationType: 'SqlLogin',
@@ -58,6 +59,7 @@ suite('SQL ConnectionStore tests', () => {
 		});
 
 		defaultUnnamedProfile = Object.assign({}, {
+			connectionName: 'new name',
 			serverName: 'unnamedServer',
 			databaseName: undefined,
 			authenticationType: 'SqlLogin',
@@ -75,6 +77,7 @@ suite('SQL ConnectionStore tests', () => {
 		});
 
 		profileForProvider2 = Object.assign({}, {
+			connectionName: 'new name',
 			serverName: 'unnamedServer',
 			databaseName: undefined,
 			authenticationType: 'SqlLogin',
@@ -117,6 +120,18 @@ suite('SQL ConnectionStore tests', () => {
 
 		capabilitiesService = new CapabilitiesTestService();
 		let connectionProvider: sqlops.ConnectionOption[] = [
+			{
+				name: 'connectionName',
+				displayName: undefined,
+				description: undefined,
+				groupName: undefined,
+				categoryValues: undefined,
+				defaultValue: undefined,
+				isIdentity: true,
+				isRequired: true,
+				specialValueType: ConnectionOptionSpecialType.connectionName,
+				valueType: ServiceOptionType.string
+			},
 			{
 				name: 'serverName',
 				displayName: undefined,

--- a/src/sqltest/parts/connection/connectionTreeActions.test.ts
+++ b/src/sqltest/parts/connection/connectionTreeActions.test.ts
@@ -85,6 +85,7 @@ suite('SQL Connection Tree Action tests', () => {
 	test('ManageConnectionAction - test if connect is called for manage action if not already connected', (done) => {
 		let isConnectedReturnValue: boolean = false;
 		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -122,6 +123,7 @@ suite('SQL Connection Tree Action tests', () => {
 	test('ManageConnectionAction - test if connect is called for manage action on database node if not already connected', (done) => {
 		let isConnectedReturnValue: boolean = false;
 		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -162,6 +164,7 @@ suite('SQL Connection Tree Action tests', () => {
 	test('DisconnectConnectionAction - test if disconnect is called when profile is connected', (done) => {
 		let isConnectedReturnValue: boolean = true;
 		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -274,6 +277,7 @@ suite('SQL Connection Tree Action tests', () => {
 		let connectionManagementService = createConnectionManagementService(true, undefined);
 
 		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -320,6 +324,7 @@ suite('SQL Connection Tree Action tests', () => {
 		let connectionManagementService = createConnectionManagementService(isConnectedReturnValue, undefined);
 
 		let connection: ConnectionProfile = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -356,6 +361,7 @@ suite('SQL Connection Tree Action tests', () => {
 		capabilitiesService.capabilities['MSSQL'] = { connection: sqlProvider };
 
 		var connection = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -444,6 +450,7 @@ suite('SQL Connection Tree Action tests', () => {
 		capabilitiesService.capabilities['MSSQL'] = { connection: sqlProvider };
 
 		var connection = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'Test',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -132,6 +132,18 @@ suite('SQL Object Explorer Service tests', () => {
 			displayName: 'MSSQL',
 			connectionOptions: [
 				{
+					name: 'connectionName',
+					displayName: undefined,
+					description: undefined,
+					groupName: undefined,
+					categoryValues: undefined,
+					defaultValue: undefined,
+					isIdentity: true,
+					isRequired: true,
+					specialValueType: ConnectionOptionSpecialType.connectionName,
+					valueType: ServiceOptionType.string
+				},
+				{
 					name: 'serverName',
 					displayName: undefined,
 					description: undefined,
@@ -210,6 +222,7 @@ suite('SQL Object Explorer Service tests', () => {
 		capabilitiesService.capabilities['MSSQL'] = { connection: sqlProvider };
 
 		connection = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'newName',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName',
@@ -228,6 +241,7 @@ suite('SQL Object Explorer Service tests', () => {
 		conProfGroup = new ConnectionProfileGroup('testGroup', undefined, 'testGroup', undefined, undefined);
 
 		connectionToFail = new ConnectionProfile(capabilitiesService, {
+			connectionName: 'newName2',
 			savePassword: false,
 			groupFullName: 'testGroup',
 			serverName: 'testServerName2',

--- a/src/sqltest/parts/connection/providerConnectionInfo.test.ts
+++ b/src/sqltest/parts/connection/providerConnectionInfo.test.ts
@@ -142,11 +142,13 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	test('set properties should set the values correctly', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, 'MSSQL');
 		assert.equal(conn.serverName, undefined);
+		conn.connectionName = connectionProfile.connectionName;
 		conn.serverName = connectionProfile.serverName;
 		conn.databaseName = connectionProfile.databaseName;
 		conn.authenticationType = connectionProfile.authenticationType;
 		conn.password = connectionProfile.password;
 		conn.userName = connectionProfile.userName;
+		assert.equal(conn.connectionName, connectionProfile.connectionName);
 		assert.equal(conn.serverName, connectionProfile.serverName);
 		assert.equal(conn.databaseName, connectionProfile.databaseName);
 		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
@@ -172,6 +174,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	test('constructor should initialize the options given a valid model', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
+		assert.equal(conn.connectionName, connectionProfile.connectionName);
 		assert.equal(conn.serverName, connectionProfile.serverName);
 		assert.equal(conn.databaseName, connectionProfile.databaseName);
 		assert.equal(conn.authenticationType, connectionProfile.authenticationType);
@@ -183,6 +186,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let conn = new ProviderConnectionInfo(capabilitiesService, connectionProfile);
 
 		let conn2 = conn.clone();
+		assert.equal(conn.connectionName, conn2.connectionName);
 		assert.equal(conn.serverName, conn2.serverName);
 		assert.equal(conn.databaseName, conn2.databaseName);
 		assert.equal(conn.authenticationType, conn2.authenticationType);
@@ -204,6 +208,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 		let conn2 = Object.assign({}, connectionProfile, { options: options });
 		let conn = new ProviderConnectionInfo(capabilitiesService, conn2);
 
+		assert.equal(conn.connectionName, conn2.connectionName);
 		assert.equal(conn.serverName, conn2.serverName);
 		assert.equal(conn.databaseName, conn2.databaseName);
 		assert.equal(conn.authenticationType, conn2.authenticationType);

--- a/src/sqltest/parts/connection/providerConnectionInfo.test.ts
+++ b/src/sqltest/parts/connection/providerConnectionInfo.test.ts
@@ -19,6 +19,7 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	let capabilitiesService: CapabilitiesTestService;
 
 	let connectionProfile: IConnectionProfile = {
+		connectionName: 'name',
 		serverName: 'new server',
 		databaseName: 'database',
 		userName: 'user',
@@ -38,6 +39,18 @@ suite('SQL ProviderConnectionInfo tests', () => {
 	setup(() => {
 		let capabilities: sqlops.DataProtocolServerCapabilities[] = [];
 		let connectionProvider: sqlops.ConnectionOption[] = [
+			{
+				name: 'connectionName',
+				displayName: undefined,
+				description: undefined,
+				groupName: undefined,
+				categoryValues: undefined,
+				defaultValue: undefined,
+				isIdentity: true,
+				isRequired: true,
+				specialValueType: ConnectionOptionSpecialType.connectionName,
+				valueType: ServiceOptionType.string
+			},
 			{
 				name: 'serverName',
 				displayName: undefined,

--- a/src/sqltest/parts/insights/insightsDialogController.test.ts
+++ b/src/sqltest/parts/insights/insightsDialogController.test.ts
@@ -52,6 +52,7 @@ suite('Insights Dialog Controller Tests', () => {
 		);
 
 		let profile: IConnectionProfile = {
+			connectionName: 'newname',
 			serverName: 'server',
 			databaseName: 'database',
 			userName: 'user',

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -36,6 +36,18 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 				valueType: ServiceOptionType.string
 			},
 			{
+				name: 'serverName',
+				displayName: undefined,
+				description: undefined,
+				groupName: undefined,
+				categoryValues: undefined,
+				defaultValue: undefined,
+				isIdentity: true,
+				isRequired: true,
+				specialValueType: ConnectionOptionSpecialType.serverName,
+				valueType: ServiceOptionType.string
+			},
+			{
 				name: 'databaseName',
 				displayName: undefined,
 				description: undefined,

--- a/src/sqltest/stubs/capabilitiesTestService.ts
+++ b/src/sqltest/stubs/capabilitiesTestService.ts
@@ -24,7 +24,7 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 
 		let connectionProvider: sqlops.ConnectionOption[] = [
 			{
-				name: 'serverName',
+				name: 'connectionName',
 				displayName: undefined,
 				description: undefined,
 				groupName: undefined,
@@ -32,7 +32,7 @@ export class CapabilitiesTestService implements ICapabilitiesService {
 				defaultValue: undefined,
 				isIdentity: true,
 				isRequired: true,
-				specialValueType: ConnectionOptionSpecialType.serverName,
+				specialValueType: ConnectionOptionSpecialType.connectionName,
 				valueType: ServiceOptionType.string
 			},
 			{


### PR DESCRIPTION
Connection names are saved in config and will be loaded on startup.
Server names, db and auth type are shown on hover.
Names are optional and will makes the server tree look like before if no name is given:
![image](https://user-images.githubusercontent.com/11557675/44626093-23841200-a917-11e8-96e7-9068dfe9503d.png)

I liked the third mockup of this: https://github.com/Microsoft/sqlopsstudio/issues/240
Unfortunately I don't think there is support for multiple lines in the treeview at the moment which brought me to the solution above.

Fixes #66