### PR TITLE
hide the account count badge in linked account dialog

### DIFF
--- a/src/sql/parts/accountManagement/accountDialog/media/accountDialog.css
+++ b/src/sql/parts/accountManagement/accountDialog/media/accountDialog.css
@@ -45,6 +45,8 @@
 
 .account-view .header .count-badge-wrapper {
 	justify-content: flex-end;
+	/* hide the count badge as it is not providing much value and meanwhile not keyboard accessible*/
+	display: none;
 }
 
 .account-view .provider-view .list-row {


### PR DESCRIPTION
This is the issue that Ken brought this morning. 