### PR TITLE
Fix grid changes that broke profiler

### DIFF
--- a/src/sql/base/browser/ui/table/table.ts
+++ b/src/sql/base/browser/ui/table/table.ts
@@ -67,13 +67,13 @@ export class Table<T extends Slick.SlickData> extends Widget implements IThemabl
 
 	constructor(parent: HTMLElement, configuration?: ITableConfiguration<T>, options?: Slick.GridOptions<T>) {
 		super();
-		if (!configuration || isArray(configuration.dataProvider)) {
+		if (!configuration || !configuration.dataProvider || isArray(configuration.dataProvider)) {
 			this._data = new TableDataView<T>(configuration && configuration.dataProvider as Array<T>);
 		} else {
 			this._data = configuration.dataProvider;
 		}
 
-		if (configuration.columns) {
+		if (configuration && configuration.columns) {
 			this._columns = configuration.columns;
 		} else {
 			this._columns = new Array<Slick.Column<T>>();
@@ -105,7 +105,7 @@ export class Table<T extends Slick.SlickData> extends Widget implements IThemabl
 		this._grid = new Slick.Grid<T>(this._tableContainer, this._data, this._columns, newOptions);
 		this.idPrefix = this._tableContainer.classList[0];
 		DOM.addClass(this._container, this.idPrefix);
-		if (configuration.sorter) {
+		if (configuration && configuration.sorter) {
 			this._sorter = configuration.sorter;
 			this._grid.onSort.subscribe((e, args) => {
 				this._sorter.sort(args);

--- a/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
+++ b/src/sql/parts/profiler/editor/controller/profilerTableEditor.ts
@@ -72,7 +72,16 @@ export class ProfilerTableEditor extends BaseEditor implements IProfilerControll
 		this._overlay.style.zIndex = '4';
 		parent.appendChild(this._overlay);
 
-		this._profilerTable = new Table(parent);
+		this._profilerTable = new Table(parent, {
+			sorter: {
+				sort: (args) => {
+					let input = this.input as ProfilerInput;
+					if (input && input.data) {
+						input.data.sort(args);
+					}
+				}
+			}
+		});
 		this._profilerTable.setSelectionModel(new RowSelectionModel());
 		attachTableStyler(this._profilerTable, this._themeService);
 


### PR DESCRIPTION
The recent grid refactoring added an optional configuration option when creating a table but needed some null checks. I also added some logic for sorting since it looks like that logic got pushed out to whatever code creates the table