### PR TITLE
Revert SlickGrid to 2.3.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.4.0",
     "semver": "4.3.6",
-    "slickgrid": "github:kburtram/SlickGrid#2.32.12",
+
+    "slickgrid": "github:anthonydresser/SlickGrid#2.3.25",
     "spdlog": "0.6.0",
     "sudo-prompt": "^8.0.0",
     "svg.js": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5909,9 +5909,9 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-"slickgrid@github:kburtram/SlickGrid#2.32.12":
-  version "2.3.28"
-  resolved "https://codeload.github.com/kburtram/SlickGrid/tar.gz/c3cd5b0887a116ca4d18de4773e0c599f900f620"
+"slickgrid@github:anthonydresser/SlickGrid#2.3.25":
+  version "2.3.25"
+  resolved "https://codeload.github.com/anthonydresser/SlickGrid/tar.gz/5fa498a3df7ed671958bedeac1863c41352c7825"
   dependencies:
     jquery ">=1.8.0"
     jquery-ui ">=1.8.0"


### PR DESCRIPTION
Reverting to this version of SlickGrid appears to address https://github.com/Microsoft/sqlopsstudio/issues/2372 and https://github.com/Microsoft/sqlopsstudio/issues/1971.

I'll queue a release build with this change so we can assess if this revert introduces other regressions.