### PR TITLE
Fix Import extension Linux download config

### DIFF
--- a/extensions/import/src/services/config.json
+++ b/extensions/import/src/services/config.json
@@ -1,16 +1,24 @@
 {
-    "downloadUrl": "https://sqlopsextensions.blob.core.windows.net/extensions/import/{#fileName#}",
-    "useDefaultLinuxRuntime": true,
-    "version": "0.0.1",
-    "downloadFileNames": {
-        "Windows_64": "win-x64.zip",
-        "Windows_86": "win-x86.zip",
-        "OSX": "osx.tar.gz",
-        "Linux_64": "linux-x64.tar.gz"
-    },
-    "installDirectory": "flatfileimportservice/{#platform#}/{#version#}",
-    "executableFiles": [
-        "MicrosoftSqlToolsFlatFileImport",
-        "MicrosoftSqlToolsFlatFileImport.exe"
-    ]
+	"downloadUrl": "https://sqlopsextensions.blob.core.windows.net/extensions/import/{#fileName#}",
+	"useDefaultLinuxRuntime": true,
+	"version": "0.0.2",
+	"downloadFileNames": {
+		"Windows_64": "win-x64.zip",
+		"Windows_86": "win-x86.zip",
+		"OSX": "osx.tar.gz",
+		"Linux_64": "linux-x64.tar.gz",
+		"CentOS_7": "linux-x64.tar.gz",
+		"Debian_8": "linux-x64.tar.gz",
+		"Fedora_23": "linux-x64.tar.gz",
+		"OpenSUSE_13_2": "linux-x64.tar.gz",
+		"RHEL_7": "linux-x64.tar.gz",
+		"SLES_12_2": "linux-x64.tar.gz",
+		"Ubuntu_14": "linux-x64.tar.gz",
+		"Ubuntu_16": "linux-x64.tar.gz"
+	},
+	"installDirectory": "flatfileimportservice/{#platform#}/{#version#}",
+	"executableFiles": [
+		"MicrosoftSqlToolsFlatFileImport",
+		"MicrosoftSqlToolsFlatFileImport.exe"
+	]
 }


### PR DESCRIPTION
This is for #2390. There were 2 issues there that prevent the Import extension from working in Linux in the current release. This PR fixes the issue where the config had a single generic Linux download path but that option is not actually part of `service-downloader` yet (it's in Kevin's open PR but never got merged). 

The other issue is that our build was zipping up the Mac build and publishing it as the Linux build, which I've already fixed. In order to force Linux users to redownload the service this change bumps the version number to 0.0.2.