### PR TITLE
Update sql-cli.sh so it actually works

### DIFF
--- a/scripts/sql-cli.sh
+++ b/scripts/sql-cli.sh
@@ -18,14 +18,11 @@ function code() {
 		CODE=".build/electron/$NAME"
 	fi
 
-	INTENDED_VERSION="v`node -p "require('./package.json').electronVersion"`"
-	INSTALLED_VERSION=`cat .build/electron/version 2> /dev/null`
-
 	# Node modules
-	test -d node_modules || ./scripts/npm.sh install
+	test -d node_modules || yarn
 
 	# Get electron
-	(test -f "$CODE" && [ $INTENDED_VERSION == $INSTALLED_VERSION ]) || ./node_modules/.bin/gulp electron
+	node build/lib/electron.js || ./node_modules/.bin/gulp electron
 
 	# Build
 	test -d out || ./node_modules/.bin/gulp compile
@@ -35,7 +32,7 @@ function code() {
 	VSCODE_DEV=1 \
 	ELECTRON_ENABLE_LOGGING=1 \
 	ELECTRON_ENABLE_STACK_DUMPING=1 \
-	"$CODE" --debug=5874 "$ROOT/out/cli.js" . "$@"
+	"$CODE" --inspect=5874 "$ROOT/out/cli.js" . "$@"
 }
 
 code "$@"


### PR DESCRIPTION
- This copies up to date contents from code-cli.sh. Alternatively we could remove this file and force use of code-cli.sh always