### PR TITLE
Fix extension installation that broke in merge

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionGalleryService.ts
@@ -605,7 +605,9 @@ export class ExtensionGalleryService implements IExtensionGalleryService {
 				*/
 				const log = (duration: number) => this.telemetryService.publicLog('galleryService:downloadVSIX', assign(data, { duration }));
 
-				const operationParam = operation === InstallOperation.Install ? 'install' : operation === InstallOperation.Update ? 'update' : '';
+				// {{SQL Carbon Edit}} - Don't append install or update on to the URL
+				// const operationParam = operation === InstallOperation.Install ? 'install' : operation === InstallOperation.Update ? 'update' : '';
+				const operationParam = undefined;
 				const downloadAsset = operationParam ? {
 					uri: `${extension.assets.download.uri}&${operationParam}=true`,
 					fallbackUri: `${extension.assets.download.fallbackUri}?${operationParam}=true`


### PR DESCRIPTION
Fixes #2425.

The latest VS Code merge added some code that puts '&install=true' or '&update=true' on the end of URLs when installing extensions, which doesn't work with our extension blob storage