### PR TITLE
Fix Extension Manager marketplace sorting

### DIFF
--- a/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
+++ b/src/vs/workbench/parts/extensions/electron-browser/extensionTipsService.ts
@@ -408,7 +408,7 @@ export class ExtensionTipsService extends Disposable implements IExtensionTipsSe
 
 	getOtherRecommendations(): TPromise<IExtensionRecommendation[]> {
 		// {{SQL CARBON EDIT}}
-		let recommendations =  Object.keys(this._exeBasedRecommendations);
+		let recommendations = Object.keys(this._exeBasedRecommendations).concat(this._recommendations);
 		shuffle(recommendations, this.sessionSeed);
 		return TPromise.as(recommendations.map(extensionId => {
 			const sources: ExtensionRecommendationSource[] = [];


### PR DESCRIPTION
Fix regression so Recommended extensions sort first in the Extension Manager Marketplace pane.