### PR TITLE
Enable the support for post-connection behaviors for openConnectionDialog

### DIFF
--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -216,22 +216,25 @@ declare module 'sqlops' {
 		/**
 		 * save the connection to MRU and settings (only save to setting if profile.saveProfile is set to true)
 	 	*/
-		saveTheConnection: boolean;
+		saveConnection: boolean;
 
 		/**
-	 	* open the dashboard after connection is complete
+		 * If true, open the dashboard after connection is complete.
+		 * If undefined / false, dashboard won't be opened after connection completes.
 	 	*/
-		showDashboard: boolean;
+		showDashboard?: boolean;
 
 		/**
-		 * Open the connection dialog if connection fails
+		 * If true, open the connection dialog if connection fails.
+		 * If undefined / false, connection dialog won't be opened even if connection fails.
 		 */
-		showConnectionDialogOnError: boolean;
+		showConnectionDialogOnError?: boolean;
 
 		/**
-		 * Open the connection firewall rule dialog if connection fails
+		 * If true, open the connection firewall rule dialog if connection fails.
+		 * If undefined / false, connection firewall rule dialog won't be opened even if connection fails.
 		 */
-		showFirewallRuleOnError: boolean;
+		showFirewallRuleOnError?: boolean;
 	}
 
 	export interface ConnectionInfoSummary {

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -209,6 +209,31 @@ declare module 'sqlops' {
 		id: string;
 	}
 
+	/**
+ 	* Options for the actions that could happen after connecting is complete
+ 	*/
+	export interface IConnectionCompletionOptions {
+		/**
+		 * save the connection to MRU and settings (only save to setting if profile.saveProfile is set to true)
+	 	*/
+		saveTheConnection: boolean;
+
+		/**
+	 	* open the dashboard after connection is complete
+	 	*/
+		showDashboard: boolean;
+
+		/**
+		 * Open the connection dialog if connection fails
+		 */
+		showConnectionDialogOnError: boolean;
+
+		/**
+		 * Open the connection firewall rule dialog if connection fails
+		 */
+		showFirewallRuleOnError: boolean;
+	}
+
 	export interface ConnectionInfoSummary {
 
 		/**

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -214,25 +214,29 @@ declare module 'sqlops' {
  	*/
 	export interface IConnectionCompletionOptions {
 		/**
-		 * save the connection to MRU and settings (only save to setting if profile.saveProfile is set to true)
+		 * Save the connection to MRU and settings (only save to setting if profile.saveProfile is set to true)
+		 * Default is true.
 	 	*/
 		saveConnection: boolean;
 
 		/**
 		 * If true, open the dashboard after connection is complete.
 		 * If undefined / false, dashboard won't be opened after connection completes.
+		 * Default is false.
 	 	*/
 		showDashboard?: boolean;
 
 		/**
 		 * If undefined / true, open the connection dialog if connection fails.
 		 * If false, connection dialog won't be opened even if connection fails.
+		 * Default is true.
 		 */
 		showConnectionDialogOnError?: boolean;
 
 		/**
 		 * If undefined / true, open the connection firewall rule dialog if connection fails.
 		 * If false, connection firewall rule dialog won't be opened even if connection fails.
+		 * Default is true.
 		 */
 		showFirewallRuleOnError?: boolean;
 	}

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -225,14 +225,14 @@ declare module 'sqlops' {
 		showDashboard?: boolean;
 
 		/**
-		 * If true, open the connection dialog if connection fails.
-		 * If undefined / false, connection dialog won't be opened even if connection fails.
+		 * If undefined / true, open the connection dialog if connection fails.
+		 * If false, connection dialog won't be opened even if connection fails.
 		 */
 		showConnectionDialogOnError?: boolean;
 
 		/**
-		 * If true, open the connection firewall rule dialog if connection fails.
-		 * If undefined / false, connection firewall rule dialog won't be opened even if connection fails.
+		 * If undefined / true, open the connection firewall rule dialog if connection fails.
+		 * If false, connection firewall rule dialog won't be opened even if connection fails.
 		 */
 		showFirewallRuleOnError?: boolean;
 	}

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -1246,6 +1246,6 @@ declare module 'sqlops' {
 		 * returns the connection otherwise returns undefined
 		 * @param callback
 		 */
-		export function openConnectionDialog(provider?: string[], initialConnectionProfile?: IConnectionProfile): Thenable<connection.Connection>;
+		export function openConnectionDialog(providers?: string[], initialConnectionProfile?: IConnectionProfile, connectionCompletionOptions?: IConnectionCompletionOptions): Thenable<connection.Connection>;
 	}
 }

--- a/src/sql/workbench/api/node/extHostConnectionManagement.ts
+++ b/src/sql/workbench/api/node/extHostConnectionManagement.ts
@@ -32,8 +32,8 @@ export class ExtHostConnectionManagement extends ExtHostConnectionManagementShap
 		return this._proxy.$getCredentials(connectionId);
 	}
 
-	public $openConnectionDialog(providers?: string[], initialConnectionProfile?: sqlops.IConnectionProfile): Thenable<sqlops.connection.Connection> {
-		return this._proxy.$openConnectionDialog(providers, initialConnectionProfile);
+	public $openConnectionDialog(providers?: string[], initialConnectionProfile?: sqlops.IConnectionProfile, connectionCompletionOptions?: sqlops.IConnectionCompletionOptions): Thenable<sqlops.connection.Connection> {
+		return this._proxy.$openConnectionDialog(providers, initialConnectionProfile, connectionCompletionOptions);
 	}
 
 	public $listDatabases(connectionId: string): Thenable<string[]> {

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -63,11 +63,11 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 			// Somehow, connectionProfile.saveProfile is false even if initialConnectionProfile.saveProfile is true, reset the flag here.
 			connectionProfile.saveProfile = initialConnectionProfile.saveProfile;
 			await this._connectionManagementService.connectAndSaveProfile(connectionProfile, undefined, {
-				saveTheConnection: connectionCompletionOptions.saveTheConnection,
-				showDashboard: connectionCompletionOptions.showDashboard,
+				saveTheConnection: connectionCompletionOptions.saveConnection,
+				showDashboard: connectionCompletionOptions.showDashboard ? connectionCompletionOptions.showDashboard : false,
 				params: undefined,
-				showConnectionDialogOnError: connectionCompletionOptions.showConnectionDialogOnError,
-				showFirewallRuleOnError: connectionCompletionOptions.showFirewallRuleOnError
+				showConnectionDialogOnError: connectionCompletionOptions.showConnectionDialogOnError ? connectionCompletionOptions.showConnectionDialogOnError : false,
+				showFirewallRuleOnError: connectionCompletionOptions.showFirewallRuleOnError ? connectionCompletionOptions.showFirewallRuleOnError : false
 			});
 		}
 

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -66,8 +66,8 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 				saveTheConnection: connectionCompletionOptions.saveConnection,
 				showDashboard: connectionCompletionOptions.showDashboard ? connectionCompletionOptions.showDashboard : false,
 				params: undefined,
-				showConnectionDialogOnError: connectionCompletionOptions.showConnectionDialogOnError ? connectionCompletionOptions.showConnectionDialogOnError : false,
-				showFirewallRuleOnError: connectionCompletionOptions.showFirewallRuleOnError ? connectionCompletionOptions.showFirewallRuleOnError : false
+				showConnectionDialogOnError: connectionCompletionOptions.showConnectionDialogOnError ? connectionCompletionOptions.showConnectionDialogOnError : true,
+				showFirewallRuleOnError: connectionCompletionOptions.showFirewallRuleOnError ? connectionCompletionOptions.showFirewallRuleOnError : true
 			});
 		}
 

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -51,7 +51,7 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 	}
 
 
-	public async $openConnectionDialog(providers: string[], initialConnectionProfile?: sqlops.IConnectionProfile, connectionCompletionOptions?: sqlops.IConnectionCompletionOptions): Promise<sqlops.connection.Connection> {
+	public async $openConnectionDialog(providers: string[], initialConnectionProfile?: IConnectionProfile, connectionCompletionOptions?: sqlops.IConnectionCompletionOptions): Promise<sqlops.connection.Connection> {
 		let connectionProfile = await this._connectionDialogService.openDialogAndWait(this._connectionManagementService, { connectionType: 1, providers: providers }, initialConnectionProfile);
 	    const connection = connectionProfile ? {
 			connectionId: connectionProfile.id,

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -14,6 +14,8 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { isUndefined } from 'util';
+import { isUndefinedOrNull } from 'vs/base/common/types';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadConnectionManagement)
 export class MainThreadConnectionManagement implements MainThreadConnectionManagementShape {
@@ -63,11 +65,11 @@ export class MainThreadConnectionManagement implements MainThreadConnectionManag
 			// Somehow, connectionProfile.saveProfile is false even if initialConnectionProfile.saveProfile is true, reset the flag here.
 			connectionProfile.saveProfile = initialConnectionProfile.saveProfile;
 			await this._connectionManagementService.connectAndSaveProfile(connectionProfile, undefined, {
-				saveTheConnection: connectionCompletionOptions.saveConnection,
-				showDashboard: connectionCompletionOptions.showDashboard ? connectionCompletionOptions.showDashboard : false,
+				saveTheConnection: isUndefinedOrNull(connectionCompletionOptions.saveConnection) ? true : connectionCompletionOptions.saveConnection,
+				showDashboard: isUndefinedOrNull(connectionCompletionOptions.showDashboard) ? false : connectionCompletionOptions.showDashboard,
 				params: undefined,
-				showConnectionDialogOnError: connectionCompletionOptions.showConnectionDialogOnError ? connectionCompletionOptions.showConnectionDialogOnError : true,
-				showFirewallRuleOnError: connectionCompletionOptions.showFirewallRuleOnError ? connectionCompletionOptions.showFirewallRuleOnError : true
+				showConnectionDialogOnError: isUndefinedOrNull(connectionCompletionOptions.showConnectionDialogOnError) ? true : connectionCompletionOptions.showConnectionDialogOnError,
+				showFirewallRuleOnError: isUndefinedOrNull(connectionCompletionOptions.showFirewallRuleOnError) ? true : connectionCompletionOptions.showFirewallRuleOnError
 			});
 		}
 

--- a/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
+++ b/src/sql/workbench/api/node/mainThreadConnectionManagement.ts
@@ -14,7 +14,6 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
-import { isUndefined } from 'util';
 import { isUndefinedOrNull } from 'vs/base/common/types';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadConnectionManagement)

--- a/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.api.impl.ts
@@ -114,8 +114,8 @@ export function createApiFactory(
 				getCredentials(connectionId: string): Thenable<{ [name: string]: string }> {
 					return extHostConnectionManagement.$getCredentials(connectionId);
 				},
-				openConnectionDialog(providers?: string[], initialConnectionProfile?: sqlops.IConnectionProfile): Thenable<sqlops.connection.Connection> {
-					return extHostConnectionManagement.$openConnectionDialog(providers, initialConnectionProfile);
+				openConnectionDialog(providers?: string[], initialConnectionProfile?: sqlops.IConnectionProfile, connectionCompletionOptions?: sqlops.IConnectionCompletionOptions): Thenable<sqlops.connection.Connection> {
+					return extHostConnectionManagement.$openConnectionDialog(providers, initialConnectionProfile, connectionCompletionOptions);
 				},
 				listDatabases(connectionId: string): Thenable<string[]> {
 					return extHostConnectionManagement.$listDatabases(connectionId);

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -503,7 +503,7 @@ export interface MainThreadConnectionManagementShape extends IDisposable {
 	$getActiveConnections(): Thenable<sqlops.connection.Connection[]>;
 	$getCurrentConnection(): Thenable<sqlops.connection.Connection>;
 	$getCredentials(connectionId: string): Thenable<{ [name: string]: string }>;
-	$openConnectionDialog(providers: string[], initialConnectionProfile?: sqlops.IConnectionProfile): Thenable<sqlops.connection.Connection>;
+	$openConnectionDialog(providers: string[], initialConnectionProfile?: sqlops.IConnectionProfile, connectionCompletionOptions?: sqlops.IConnectionCompletionOptions): Thenable<sqlops.connection.Connection>;
 	$listDatabases(connectionId: string): Thenable<string[]>;
 	$getConnectionString(connectionId: string, includePassword: boolean): Thenable<string>;
 	$getUriForConnection(connectionId: string): Thenable<string>;


### PR DESCRIPTION
Add parameter connectionCompletionOptions of type IConnectionCompletionOptions to connection.openConnectionDialog.
	export interface IConnectionCompletionOptions {
		saveTheConnection: boolean;
		showDashboard: boolean;
		showConnectionDialogOnError: boolean;
		showFirewallRuleOnError: boolean;
	}