### PR TITLE
Remove redundant getChildren method in IModelViewTreeViewDataProvider.

### DIFF
--- a/src/sql/parts/modelComponents/tree/treeViewDataProvider.ts
+++ b/src/sql/parts/modelComponents/tree/treeViewDataProvider.ts
@@ -29,11 +29,6 @@ export class TreeViewDataProvider extends vsTreeView.TreeViewDataProvider implem
 		}
 	}
 
-
 	refresh(itemsToRefreshByHandle: { [treeItemHandle: string]: ITreeComponentItem }) {
-	}
-
-	getChildren(element?: ITreeComponentItem): TPromise<ITreeComponentItem[]> {
-		return undefined;
 	}
 }

--- a/src/sql/workbench/common/views.ts
+++ b/src/sql/workbench/common/views.ts
@@ -3,8 +3,6 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { TPromise } from 'vs/base/common/winjs.base';
-import { Event } from 'vs/base/common/event';
 import { ITreeViewDataProvider, ITreeItem } from 'vs/workbench/common/views';
 
 export interface ITreeComponentItem extends ITreeItem {
@@ -15,8 +13,4 @@ export interface ITreeComponentItem extends ITreeItem {
 
 export interface IModelViewTreeViewDataProvider extends ITreeViewDataProvider {
 	refresh(itemsToRefreshByHandle: { [treeItemHandle: string]: ITreeComponentItem });
-}
-
-export interface IModelViewTreeViewDataProvider {
-	getChildren(element?: ITreeComponentItem): TPromise<ITreeComponentItem[]>;
 }


### PR DESCRIPTION
IModelViewTreeViewDataProvider extends ITreeViewDataProvider, which already has a getChildren method. This new getChildren method was causing undefined promise errors in Item.refreshChildren() in treeModel.ts.