### PR TITLE
Alanren/icon overwrite issue

### DIFF
--- a/src/sql/base/browser/ui/modal/modal.ts
+++ b/src/sql/base/browser/ui/modal/modal.ts
@@ -215,17 +215,17 @@ export abstract class Modal extends Disposable implements IThemable {
 		}
 
 		if (this._modalOptions.isAngular === false && this._modalOptions.hasErrors) {
-			let builder = errorMessagesInFooter ? this._leftFooter : body;
-			builder.div({ class: 'dialogErrorMessage', id: 'dialogErrorMessage' }, (errorMessageContainer) => {
-				errorMessageContainer.div({ class: 'icon error' }, (iconContainer) => {
-					this._errorIconElement = iconContainer.getHTMLElement();
-					this._errorIconElement.style.visibility = 'hidden';
-				});
-				errorMessageContainer.div({ class: 'errorMessage' }, (messageContainer) => {
-					this._errorMessage = messageContainer;
-				});
+		let builder = errorMessagesInFooter ? this._leftFooter : body;
+		builder.div({ class: 'dialogErrorMessage', id: 'dialogErrorMessage' }, (errorMessageContainer) => {
+			errorMessageContainer.div({ class: 'sql icon error' }, (iconContainer) => {
+				this._errorIconElement = iconContainer.getHTMLElement();
+				this._errorIconElement.style.visibility = 'hidden';
 			});
-		}
+			errorMessageContainer.div({ class: 'errorMessage' }, (messageContainer) => {
+				this._errorMessage = messageContainer;
+			});
+		});
+	}
 
 		// The builder builds the dialog. It append header, body and footer sections.
 		this._builder = $().div({ class: builderClass, 'role': 'dialog', 'aria-label': this._title }, (dialogContainer) => {

--- a/src/sql/base/browser/ui/modal/modal.ts
+++ b/src/sql/base/browser/ui/modal/modal.ts
@@ -215,17 +215,17 @@ export abstract class Modal extends Disposable implements IThemable {
 		}
 
 		if (this._modalOptions.isAngular === false && this._modalOptions.hasErrors) {
-		let builder = errorMessagesInFooter ? this._leftFooter : body;
-		builder.div({ class: 'dialogErrorMessage', id: 'dialogErrorMessage' }, (errorMessageContainer) => {
-			errorMessageContainer.div({ class: 'sql icon error' }, (iconContainer) => {
-				this._errorIconElement = iconContainer.getHTMLElement();
-				this._errorIconElement.style.visibility = 'hidden';
+			let builder = errorMessagesInFooter ? this._leftFooter : body;
+			builder.div({ class: 'dialogErrorMessage', id: 'dialogErrorMessage' }, (errorMessageContainer) => {
+				errorMessageContainer.div({ class: 'sql icon error' }, (iconContainer) => {
+					this._errorIconElement = iconContainer.getHTMLElement();
+					this._errorIconElement.style.visibility = 'hidden';
+				});
+				errorMessageContainer.div({ class: 'errorMessage' }, (messageContainer) => {
+					this._errorMessage = messageContainer;
+				});
 			});
-			errorMessageContainer.div({ class: 'errorMessage' }, (messageContainer) => {
-				this._errorMessage = messageContainer;
-			});
-		});
-	}
+		}
 
 		// The builder builds the dialog. It append header, body and footer sections.
 		this._builder = $().div({ class: builderClass, 'role': 'dialog', 'aria-label': this._title }, (dialogContainer) => {

--- a/src/sql/media/icons/common-icons.css
+++ b/src/sql/media/icons/common-icons.css
@@ -63,21 +63,21 @@
 	background: url("globalerror.svg") center center no-repeat;
 }
 
-.vs .icon.error,
-.vs-dark .icon.error,
-.hc-black .icon.error {
+.vs .sql.icon.error,
+.vs-dark .sql.icon.error,
+.hc-black .sql.icon.error {
 	content: url("status_error.svg");
 }
 
-.vs .icon.warning,
-.vs-dark .icon.warning,
-.hc-black .icon.warning {
+.vs .sql.icon.warning,
+.vs-dark .sql.icon.warning,
+.hc-black .sql.icon.warning {
 	content: url("status_warning.svg");
 }
 
-.vs .icon.info,
-.vs-dark .icon.info,
-.hc-black .icon.info {
+.vs .sql.icon.info,
+.vs-dark .sql.icon.info,
+.hc-black .sql.icon.info {
 	content: url("status_info.svg");
 }
 

--- a/src/sql/parts/accountManagement/accountPicker/accountPicker.ts
+++ b/src/sql/parts/accountManagement/accountPicker/accountPicker.ts
@@ -117,7 +117,7 @@ export class AccountPicker extends Disposable {
 
 		// Create refresh account action
 		this._refreshContainer = DOM.append(this._rootElement, DOM.$('div.refresh-container'));
-		DOM.append(this._refreshContainer, DOM.$('div.icon warning'));
+		DOM.append(this._refreshContainer, DOM.$('div.sql icon warning'));
 		let actionBar = new ActionBar(this._refreshContainer, { animated: false });
 		this._refreshAccountAction = this._instantiationService.createInstance(RefreshAccountAction);
 		actionBar.push(this._refreshAccountAction, { icon: false, label: true });

--- a/src/sql/parts/disasterRecovery/backup/backup.component.html
+++ b/src/sql/parts/disasterRecovery/backup/backup.component.html
@@ -65,7 +65,7 @@
 						<div class="option check" #encryptCheckContainer>
 						</div>
 						<div class="option" #encryptWarningContainer>
-							<div class="icon warning">
+							<div class="sql icon warning">
 							</div>
 							<div class="warning-message">
 								{{localizedStrings.NO_ENCRYPTOR_WARNING}}

--- a/src/sql/workbench/errorMessageDialog/errorMessageDialog.ts
+++ b/src/sql/workbench/errorMessageDialog/errorMessageDialog.ts
@@ -108,13 +108,13 @@ export class ErrorMessageDialog extends Modal {
 	private updateIconTitle(): void {
 		switch (this._severity) {
 			case Severity.Error:
-				this.titleIconClassName = 'icon error';
+				this.titleIconClassName = 'sql icon error';
 				break;
 			case Severity.Warning:
-				this.titleIconClassName = 'icon warning';
+				this.titleIconClassName = 'sql icon warning';
 				break;
 			case Severity.Info:
-				this.titleIconClassName = 'icon info';
+				this.titleIconClassName = 'sql icon info';
 				break;
 		}
 	}


### PR DESCRIPTION
#2354 
Root cause: we happen to have conflicts with the VS code for warning, error and info icons. there are 2 ways of fixing this.
1. make the selector more specific in our css by adding sql as a class name. this is the approach I took.
   - comparing to give it a new name, we can still use the .icon modifiers we added

2. reuse the style provided by vscode
  - I don't really want to take an unnecessary dependency, if vs code changes their class name, it is not easy for us to notice that.


testing: searched and tested all the references of the warning, error and info icon.