### PR TITLE
Change cursor in message panel to default

### DIFF
--- a/src/sql/parts/query/editor/media/messagePanel.css
+++ b/src/sql/parts/query/editor/media/messagePanel.css
@@ -13,6 +13,10 @@
     word-break: break-all;
 }
 
+.monaco-workbench .message-tree .monaco-tree .monaco-tree-rows>.monaco-tree-row {
+	cursor: default;
+}
+
 .message-tree .time-stamp {
 	width: 100px;
 	display: inline-block;
@@ -26,6 +30,7 @@
 
 .message-tree .batch-start {
 	text-decoration: underline;
+	cursor: pointer;
 }
 
 .message-tree .error-message {


### PR DESCRIPTION
Changes the cursor in the messages panel from being the pointer the entire time, other than on the line link.