### PR TITLE
Added fix for select all and exports

### DIFF
--- a/src/sql/parts/query/editor/actions.ts
+++ b/src/sql/parts/query/editor/actions.ts
@@ -43,7 +43,7 @@ function mapForNumberColumn(ranges: Slick.Range[]): Slick.Range[] {
 }
 
 function selectedRowsToRange(selectedRows: number[], columns: number): Slick.Range[] {
-	if (selectedRows) {
+	if (selectedRows && selectedRows.length > 0) {
 		return [new Slick.Range(selectedRows[0], 0, selectedRows[selectedRows.length-1], columns)];
 	} else {
 		return undefined;

--- a/src/sql/parts/query/editor/actions.ts
+++ b/src/sql/parts/query/editor/actions.ts
@@ -42,7 +42,7 @@ function mapForNumberColumn(ranges: Slick.Range[]): Slick.Range[] {
 	}
 }
 
-function selectedRowsToRanges(selectedRows: number[], columns: number): Slick.Range[] {
+function selectedRowsToRange(selectedRows: number[], columns: number): Slick.Range[] {
 	if (selectedRows) {
 		return [new Slick.Range(selectedRows[0], 0, selectedRows[selectedRows.length-1], columns)];
 	} else {
@@ -122,7 +122,7 @@ export class SelectAllGridAction extends Action {
 
 	public run(context: IGridActionContext): TPromise<boolean> {
 		context.table.setSelectedRows(true);
-		context.selection = selectedRowsToRanges(context.table.getSelectedRows(), context.table.columns.length);
+		context.selection = selectedRowsToRange(context.table.getSelectedRows(), context.table.columns.length);
 		return TPromise.as(true);
 	}
 }

--- a/src/sql/parts/query/editor/actions.ts
+++ b/src/sql/parts/query/editor/actions.ts
@@ -42,6 +42,14 @@ function mapForNumberColumn(ranges: Slick.Range[]): Slick.Range[] {
 	}
 }
 
+function selectedRowsToRanges(selectedRows: number[], columns: number): Slick.Range[] {
+	if (selectedRows) {
+		return [new Slick.Range(selectedRows[0], 0, selectedRows[selectedRows.length-1], columns)];
+	} else {
+		return undefined;
+	}
+}
+
 export class SaveResultAction extends Action {
 	public static SAVECSV_ID = 'grid.saveAsCsv';
 	public static SAVECSV_LABEL = localize('saveAsCsv', 'Save As CSV');
@@ -114,6 +122,7 @@ export class SelectAllGridAction extends Action {
 
 	public run(context: IGridActionContext): TPromise<boolean> {
 		context.table.setSelectedRows(true);
+		context.selection = selectedRowsToRanges(context.table.getSelectedRows(), context.table.columns.length);
 		return TPromise.as(true);
 	}
 }


### PR DESCRIPTION
Added fixes for all combinations of Selection and Save as Results. Tested the following scenarios -
- [x] Ctrl + A -> right click -> Save as
- [x] Ctrl + A -> Save as button
- [x] Right click -> Select All -> right click -> Save as
- [x] Right click -> Select All -> Save as button
- [x] Mouse drag selection -> Right Click -> Save as
- [x] No selection -> Save as button

Accompanying PR in slickgrid here - https://github.com/anthonydresser/SlickGrid/pull/24

Fixes -
https://github.com/Microsoft/sqlopsstudio/issues/2372
https://github.com/Microsoft/sqlopsstudio/issues/931
https://github.com/Microsoft/sqlopsstudio/issues/2482