### PR TITLE
Fixes #2523

### DIFF
--- a/src/sql/parts/modelComponents/componentWithIconBase.ts
+++ b/src/sql/parts/modelComponents/componentWithIconBase.ts
@@ -22,6 +22,8 @@ export class ItemDescriptor<T> {
 	constructor(public descriptor: IComponentDescriptor, public config: T) { }
 }
 
+const ids = new IdGenerator('model-view-component-icon-');
+
 export abstract class ComponentWithIconBase extends ComponentBase {
 
 	protected _iconClass: string;
@@ -42,7 +44,6 @@ export abstract class ComponentWithIconBase extends ComponentBase {
 		if (this.iconPath && this.iconPath !== this._iconPath) {
 			this._iconPath = this.iconPath;
 			if (!this._iconClass) {
-				const ids = new IdGenerator('model-view-component-icon-' + Math.round(Math.random() * 1000));
 				this._iconClass = ids.nextId();
 			}
 


### PR DESCRIPTION
(resubmitting as PR after accidental merge). The IdGenerator was recreated each time and had a high likelihood of conflicts. Invitably after adding dozens or hundreds of icons you'll start seeing the CSS class replaced and overridden.

The solution is to do like elsewhere: have 1 const that is loaded on first import of the file and keeps a global track.

Side note is that it'd be a good idea to cache CSS rules with the same iconPath so we don't create lots of additional rules unnecessarily. If we reuse the same icon a bunch we should cache them - #2524 is tracking this.