### PR TITLE
Turn-off Git missing prompt

### DIFF
--- a/extensions/git/src/main.ts
+++ b/extensions/git/src/main.ts
@@ -98,28 +98,29 @@ export async function activate(context: ExtensionContext): Promise<API> {
 			throw err;
 		}
 
-		const config = workspace.getConfiguration('git');
-		const shouldIgnore = config.get<boolean>('ignoreMissingGitWarning') === true;
+		// {{SQL CARBON EDIT}} turn-off Git missing prompt
+		//const config = workspace.getConfiguration('git');
+		//const shouldIgnore = config.get<boolean>('ignoreMissingGitWarning') === true;
 
-		if (!shouldIgnore) {
-			console.warn(err.message);
-			outputChannel.appendLine(err.message);
-			outputChannel.show();
+		// if (!shouldIgnore) {
+		// 	console.warn(err.message);
+		// 	outputChannel.appendLine(err.message);
+		// 	outputChannel.show();
 
-			const download = localize('downloadgit', "Download Git");
-			const neverShowAgain = localize('neverShowAgain', "Don't Show Again");
-			const choice = await window.showWarningMessage(
-				localize('notfound', "Git not found. Install it or configure it using the 'git.path' setting."),
-				download,
-				neverShowAgain
-			);
+		// 	const download = localize('downloadgit', "Download Git");
+		// 	const neverShowAgain = localize('neverShowAgain', "Don't Show Again");
+		// 	const choice = await window.showWarningMessage(
+		// 		localize('notfound', "Git not found. Install it or configure it using the 'git.path' setting."),
+		// 		download,
+		// 		neverShowAgain
+		// 	);
 
-			if (choice === download) {
-				commands.executeCommand('vscode.open', Uri.parse('https://git-scm.com/'));
-			} else if (choice === neverShowAgain) {
-				await config.update('ignoreMissingGitWarning', true, true);
-			}
-		}
+		// 	if (choice === download) {
+		// 		commands.executeCommand('vscode.open', Uri.parse('https://git-scm.com/'));
+		// 	} else if (choice === neverShowAgain) {
+		// 		await config.update('ignoreMissingGitWarning', true, true);
+		// 	}
+		// }
 
 		return new NoopAPIImpl();
 	}


### PR DESCRIPTION
Removes the "Git not found" notification since source control integration is not a critical scenario for many users.  This reduces pop-up noise on 1st-launch.

![image](https://user-images.githubusercontent.com/599935/45396205-ebefb800-b5ee-11e8-8cde-cc268b70d89a.png)
