### PR TITLE
Fix bug around debounced event not being flushed in time

### DIFF
--- a/src/sql/base/common/event.ts
+++ b/src/sql/base/common/event.ts
@@ -5,6 +5,7 @@
 'use strict';
 
 import { Emitter, Event } from 'vs/base/common/event';
+import { IDisposable } from 'vs/base/common/lifecycle';
 
 /**
  * Implementation of vs/base/common/event/echo that is clearable
@@ -37,3 +38,49 @@ export function echo<T>(event: Event<T>, nextTick = false, buffer: T[] = []): { 
 		clear
 	};
 }
+
+export function debounceEvent<T>(event: Event<T>, merger: (last: T, event: T) => T, delay?: number, leading?: boolean): { clear: () => void; event: Event<T> };
+export function debounceEvent<I, O>(event: Event<I>, merger: (last: O, event: I) => O, delay?: number, leading?: boolean): { clear: () => void; event: Event<O> };
+export function debounceEvent<I, O>(event: Event<I>, merger: (last: O, event: I) => O, delay: number = 100, leading = false): { clear: () => void; event: Event<O> } {
+
+	let subscription: IDisposable;
+	let output: O = undefined;
+	let handle: any = undefined;
+	let numDebouncedCalls = 0;
+
+	const clear = () => output = undefined;
+
+	const emitter = new Emitter<O>({
+		onFirstListenerAdd() {
+			subscription = event(cur => {
+				numDebouncedCalls++;
+				output = merger(output, cur);
+
+				if (leading && !handle) {
+					emitter.fire(output);
+				}
+
+				clearTimeout(handle);
+				handle = setTimeout(() => {
+					let _output = output;
+					output = undefined;
+					handle = undefined;
+					if (!leading || numDebouncedCalls > 1) {
+						emitter.fire(_output);
+					}
+
+					numDebouncedCalls = 0;
+				}, delay);
+			});
+		},
+		onLastListenerRemove() {
+			subscription.dispose();
+		}
+	});
+
+	return {
+		event: emitter.event,
+		clear
+	};
+}
+


### PR DESCRIPTION
fixes #2495

The basic problem was that the event that fires for results and messages is debounced 100 ms now for performance reasons. The problem arose when you tried to reexecute a query while there are events still debounced, those events would be fired as if they are part of the new query.

The fix is basically to make a clearable (maybe instead we should flush?) version of the debounce to make sure there aren't any left over events.