### PR TITLE
fix the account not found error when creating firewall rules

### DIFF
--- a/src/sql/workbench/api/node/extHostAccountManagement.ts
+++ b/src/sql/workbench/api/node/extHostAccountManagement.ts
@@ -90,14 +90,16 @@ export class ExtHostAccountManagement extends ExtHostAccountManagementShape {
 	}
 
 	public $getSecurityToken(account: sqlops.Account): Thenable<{}> {
-		for (const handle in this._accounts) {
-			const providerHandle = parseInt(handle);
-			if (this._accounts[handle].findIndex((acct) => acct.key.accountId === account.key.accountId) !== -1) {
-				return this._withProvider(providerHandle, (provider: sqlops.AccountProvider) => provider.getSecurityToken(account));
+		return this.$getAllAccounts().then(() => {
+			for (const handle in this._accounts) {
+				const providerHandle = parseInt(handle);
+				if (this._accounts[handle].findIndex((acct) => acct.key.accountId === account.key.accountId) !== -1) {
+					return this._withProvider(providerHandle, (provider: sqlops.AccountProvider) => provider.getSecurityToken(account));
+				}
 			}
-		}
 
-		throw new Error(`Account ${account.key.accountId} not found.`);
+			throw new Error(`Account ${account.key.accountId} not found.`);
+		});
 	}
 
 	public get onDidChangeAccounts(): Event<sqlops.DidChangeAccountsParams> {


### PR DESCRIPTION
Fix for issue: #2500 

the this._accounts collection is not initialized when we call the getSecurityToken() method, adding the get all accounts operation prior to the getting the security token.