### PR TITLE
Fix sizing error when switching windows

### DIFF
--- a/src/sql/parts/query/editor/queryResultsView.ts
+++ b/src/sql/parts/query/editor/queryResultsView.ts
@@ -42,32 +42,32 @@ class ResultsView implements IPanelView {
 			]);
 		});
 		this.gridPanel.onDidChange(e => {
-				let size = this.gridPanel.maximumBodySize;
-				if (this.isGridRendered) {
-					if (size < 1) {
-						this.lastGridHeight = this.panelViewlet.getPanelSize(this.gridPanel);
-						this.panelViewlet.removePanels([this.gridPanel]);
-						// tell the panel is has been removed.
-						this.gridPanel.layout(0);
-						this.isGridRendered = false;
-					}
-				} else {
-					if (this.currentDimension) {
-						this.needsGridResize = false;
-						if (size > 0) {
-							this.panelViewlet.addPanels([
-								{ panel: this.gridPanel, index: 0, size: this.lastGridHeight || Math.round(this.currentDimension.height * .7) }
-							]);
-							this.isGridRendered = true;
-						}
-					} else {
+			let size = this.gridPanel.maximumBodySize;
+			if (this.isGridRendered) {
+				if (size < 1) {
+					this.lastGridHeight = this.panelViewlet.getPanelSize(this.gridPanel);
+					this.panelViewlet.removePanels([this.gridPanel]);
+					// tell the panel is has been removed.
+					this.gridPanel.layout(0);
+					this.isGridRendered = false;
+				}
+			} else {
+				if (this.currentDimension) {
+					this.needsGridResize = false;
+					if (size > 0) {
 						this.panelViewlet.addPanels([
-							{ panel: this.gridPanel, index: 0, size: this.lastGridHeight || 200 }
+							{ panel: this.gridPanel, index: 0, size: this.lastGridHeight || Math.round(this.currentDimension.height * .7) }
 						]);
 						this.isGridRendered = true;
-						this.needsGridResize = true;
 					}
+				} else {
+					this.panelViewlet.addPanels([
+						{ panel: this.gridPanel, index: 0, size: this.lastGridHeight || 200 }
+					]);
+					this.isGridRendered = true;
+					this.needsGridResize = true;
 				}
+			}
 		});
 		let gridResizeList = this.gridPanel.onDidChange(e => {
 			if (this.currentDimension) {


### PR DESCRIPTION
fixes #2542

This is a work around for an inefficiency of our query editor, since it creates a new results view on every set input.

Once we refactor the query editor to be more efficient this code shouldn't be needed anymore.