### PR TITLE
Support isDirty flag for model view editors and begin plumb through of save support

### DIFF
--- a/src/sql/parts/modelComponents/modelEditor/modelViewInput.ts
+++ b/src/sql/parts/modelComponents/modelEditor/modelViewInput.ts
@@ -3,16 +3,50 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import * as sqlops from 'sqlops';
+
 import { TPromise } from 'vs/base/common/winjs.base';
 import { IEditorModel } from 'vs/platform/editor/common/editor';
-import { EditorInput } from 'vs/workbench/common/editor';
+import { EditorInput, EditorModel, ConfirmResult } from 'vs/workbench/common/editor';
 import * as DOM from 'vs/base/browser/dom';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IPartService, Parts } from 'vs/workbench/services/part/common/partService';
 
 import { DialogPane } from 'sql/platform/dialog/dialogPane';
+import { Emitter, Event } from 'vs/base/common/event';
 
-import * as sqlops from 'sqlops';
+export type ModeViewSaveHandler = (handle: number) => Thenable<boolean>;
+
+export class ModelViewInputModel extends EditorModel {
+	private dirty: boolean;
+	private readonly _onDidChangeDirty: Emitter<void> = this._register(new Emitter<void>());
+	get onDidChangeDirty(): Event<void> { return this._onDidChangeDirty.event; }
+
+	constructor(public readonly modelViewId, private readonly handle: number, private saveHandler?: ModeViewSaveHandler) {
+		super();
+		this.dirty = false;
+	}
+
+	get isDirty(): boolean {
+		return this.dirty;
+	}
+
+	public setDirty(dirty: boolean): void {
+		if (this.dirty === dirty) {
+			return;
+		}
+
+		this.dirty = dirty;
+		this._onDidChangeDirty.fire();
+	}
+
+	save(): TPromise<boolean> {
+		if (this.saveHandler) {
+			return TPromise.wrap(this.saveHandler(this.handle));
+		}
+		return TPromise.wrap(true);
+	}
+}
 export class ModelViewInput extends EditorInput {
 
 	public static ID: string = 'workbench.editorinputs.ModelViewEditorInput';
@@ -20,14 +54,15 @@ export class ModelViewInput extends EditorInput {
 	private _dialogPaneContainer: HTMLElement;
 	private _dialogPane: DialogPane;
 
-	constructor(private _title: string, private _modelViewId: string,
+	constructor(private _title: string, private _model: ModelViewInputModel,
 		private _options: sqlops.ModelViewEditorOptions,
 		@IInstantiationService private _instantiationService: IInstantiationService,
 		@IPartService private readonly _partService: IPartService
 	) {
 		super();
+		this._model.onDidChangeDirty(() => this._onDidChangeDirty.fire());
 		this._container = document.createElement('div');
-		this._container.id = `modelView-${_modelViewId}`;
+		this._container.id = `modelView-${_model.modelViewId}`;
 		this._partService.getContainer(Parts.EDITOR_PART).appendChild(this._container);
 
 	}
@@ -37,7 +72,7 @@ export class ModelViewInput extends EditorInput {
 	}
 
 	public get modelViewId(): string {
-		return this._modelViewId;
+		return this._model.modelViewId;
 	}
 
 	public getTypeId(): string {
@@ -85,6 +120,31 @@ export class ModelViewInput extends EditorInput {
 		return this._options;
 	}
 
+	/**
+	 * An editor that is dirty will be asked to be saved once it closes.
+	 */
+	isDirty(): boolean {
+		return this._model.isDirty;
+	}
+
+	/**
+	 * Subclasses should bring up a proper dialog for the user if the editor is dirty and return the result.
+	 */
+	confirmSave(): TPromise<ConfirmResult> {
+		// TODO support save on close / confirm save. This is significantly more work
+		// as we need to either integrate with textFileService (seems like this isn't viable)
+		// or register our own complimentary service that handles the lifecycle operations such
+		// as close all, auto save etc.
+		return TPromise.wrap(ConfirmResult.DONT_SAVE);
+	}
+
+	/**
+	 * Saves the editor if it is dirty. Subclasses return a promise with a boolean indicating the success of the operation.
+	 */
+	save(): TPromise<boolean> {
+		return this._model.save();
+	}
+
 	public dispose(): void {
 		if (this._dialogPane) {
 			this._dialogPane.dispose();
@@ -92,6 +152,9 @@ export class ModelViewInput extends EditorInput {
 		if (this._container) {
 			this._container.remove();
 			this._container = undefined;
+		}
+		if (this._model) {
+			this._model.dispose();
 		}
 		super.dispose();
 	}

--- a/src/sql/parts/modelComponents/modelEditor/modelViewInput.ts
+++ b/src/sql/parts/modelComponents/modelEditor/modelViewInput.ts
@@ -131,7 +131,7 @@ export class ModelViewInput extends EditorInput {
 	 * Subclasses should bring up a proper dialog for the user if the editor is dirty and return the result.
 	 */
 	confirmSave(): TPromise<ConfirmResult> {
-		// TODO support save on close / confirm save. This is significantly more work
+		// TODO #2530 support save on close / confirm save. This is significantly more work
 		// as we need to either integrate with textFileService (seems like this isn't viable)
 		// or register our own complimentary service that handles the lifecycle operations such
 		// as close all, auto save etc.

--- a/src/sql/sqlops.proposed.d.ts
+++ b/src/sql/sqlops.proposed.d.ts
@@ -1100,11 +1100,22 @@ declare module 'sqlops' {
 		export function createModelViewEditor(title: string, options?: ModelViewEditorOptions): ModelViewEditor;
 
 		export interface ModelViewEditor extends window.modelviewdialog.ModelViewPanel {
+			/**
+			 * `true` if there are unpersisted changes.
+			 * This is editable to support extensions updating the dirty status.
+			 */
+			isDirty: boolean;
 
 			/**
 			 * Opens the editor
 			 */
 			openEditor(position?: vscode.ViewColumn): Thenable<void>;
+
+			/**
+			 * Registers a save handler for this editor. This will be called if [supportsSave](#ModelViewEditorOptions.supportsSave)
+			 * is set to true and the editor is marked as dirty
+			 */
+			registerSaveHandler(handler: () => Thenable<boolean>);
 		}
 	}
 
@@ -1113,6 +1124,11 @@ declare module 'sqlops' {
 		 * Should the model view editor's context be kept around even when the editor is no longer visible? It is false by default
 		 */
 		readonly retainContextWhenHidden?: boolean;
+
+		/**
+		 * Does this model view editor support save?
+		 */
+		readonly supportsSave?: boolean;
 	}
 
 	export enum DataProviderType {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -672,10 +672,11 @@ export interface ExtHostModelViewDialogShape {
 	$updateWizardPageInfo(handle: number, pageHandles: number[], currentPageIndex: number): void;
 	$validateNavigation(handle: number, info: sqlops.window.modelviewdialog.WizardPageChangeInfo): Thenable<boolean>;
 	$validateDialogClose(handle: number): Thenable<boolean>;
+	$handleSave(handle: number): Thenable<boolean>;
 }
 
 export interface MainThreadModelViewDialogShape extends IDisposable {
-	$openEditor(modelViewId: string, title: string, options?: sqlops.ModelViewEditorOptions, position?: vscode.ViewColumn): Thenable<void>;
+	$openEditor(handle: number, modelViewId: string, title: string, options?: sqlops.ModelViewEditorOptions, position?: vscode.ViewColumn): Thenable<void>;
 	$openDialog(handle: number): Thenable<void>;
 	$closeDialog(handle: number): Thenable<void>;
 	$setDialogDetails(handle: number, details: IModelViewDialogDetails): Thenable<void>;
@@ -688,6 +689,7 @@ export interface MainThreadModelViewDialogShape extends IDisposable {
 	$addWizardPage(wizardHandle: number, pageHandle: number, pageIndex: number): Thenable<void>;
 	$removeWizardPage(wizardHandle: number, pageIndex: number): Thenable<void>;
 	$setWizardPage(wizardHandle: number, pageIndex: number): Thenable<void>;
+	$setDirty(handle: number, isDirty: boolean): void;
 }
 export interface ExtHostQueryEditorShape {
 }


### PR DESCRIPTION
This PR:
- Adds support for the model view editor programmatically setting isDirty flag on editor. 
- Plumbs through support for save over the sqlops API channel.

This does not fully implement save (issue #2529 and #2530) because we will have to make alterations to the textFileService in order to do that correctly. However there's value in getting the isDirty handling into the product, and having save partially integrated will make the next PR simpler.