### PR TITLE
Bug/extension contribution

### DIFF
--- a/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
+++ b/src/sql/parts/dashboard/widgets/tasks/tasksWidget.component.ts
@@ -86,7 +86,7 @@ export class TasksWidget extends DashboardWidget implements IDashboardWidget, On
 			}).filter(i => !!i);
 		}
 
-		this._tasks = tasks.map(i => TaskRegistry.getCommandActionById(i)).filter(v => !!v);
+		this._tasks = tasks.map(i => MenuRegistry.getCommand(i)).filter(v => !!v);
 	}
 
 	ngOnInit() {

--- a/src/sql/platform/tasks/common/tasks.ts
+++ b/src/sql/platform/tasks/common/tasks.ts
@@ -48,9 +48,7 @@ export abstract class Task {
 			id: this.id,
 			handler: (accessor, profile, args) => this.runTask(accessor, profile, args),
 			description: this._description,
-			iconClass: this._iconClass,
-			iconPath: this.opts.iconPath,
-			title: this.title
+			iconClass: this._iconClass
 		};
 	}
 
@@ -62,10 +60,8 @@ export abstract class Task {
 		};
 	}
 
-	public registerTask(showInCommandPalette: boolean = true): IDisposable {
-		if (showInCommandPalette) {
-			MenuRegistry.addCommand(this.toCommandAction());
-		}
+	public registerTask(): IDisposable {
+		MenuRegistry.addCommand(this.toCommandAction());
 		return TaskRegistry.registerTask(this.toITask());
 	}
 
@@ -100,8 +96,6 @@ export interface ITask {
 	precondition?: ContextKeyExpr;
 	description?: ITaskHandlerDescription;
 	iconClass?: string;
-	iconPath?: { dark: string; light?: string; };
-	title?: string;
 }
 
 export interface ITaskRegistry {
@@ -110,7 +104,6 @@ export interface ITaskRegistry {
 	getTasks(): string[];
 	getOrCreateTaskIconClassName(item: ICommandAction): string;
 	onTaskRegistered: Event<string>;
-	getCommandActionById(id: string): ICommandAction;
 }
 
 const ids = new IdGenerator('task-icon-');
@@ -121,7 +114,6 @@ export const TaskRegistry: ITaskRegistry = new class implements ITaskRegistry {
 	private _onTaskRegistered = new Emitter<string>();
 	public readonly onTaskRegistered: Event<string> = this._onTaskRegistered.event;
 	private taskIdToIconClassNameMap: Map<string /* task id */, string /* CSS rule */> = new Map<string, string>();
-	private taskIdToCommandActionMap: Map<string, ICommandAction> = new Map<string, ICommandAction>();
 
 	registerTask(idOrTask: string | ITask, handler?: ITaskHandler): IDisposable {
 		let disposable: IDisposable;
@@ -132,16 +124,6 @@ export const TaskRegistry: ITaskRegistry = new class implements ITaskRegistry {
 		} else {
 			if (idOrTask.iconClass) {
 				this.taskIdToIconClassNameMap.set(idOrTask.id, idOrTask.iconClass);
-			}
-			if (idOrTask.iconPath && idOrTask.title) {
-				this.taskIdToCommandActionMap.set(idOrTask.id, {
-					iconLocation: {
-						dark: URI.parse(idOrTask.iconPath.dark),
-						light: URI.parse(idOrTask.iconPath.light),
-					},
-					id: idOrTask.id,
-					title: idOrTask.title
-				});
 			}
 			disposable = CommandsRegistry.registerCommand(idOrTask);
 			id = idOrTask.id;
@@ -176,9 +158,5 @@ export const TaskRegistry: ITaskRegistry = new class implements ITaskRegistry {
 
 	getTasks(): string[] {
 		return this._tasks.slice(0);
-	}
-
-	getCommandActionById(taskId: string): ICommandAction {
-		return this.taskIdToCommandActionMap.get(taskId);
 	}
 };

--- a/src/sql/workbench/common/actions.contribution.ts
+++ b/src/sql/workbench/common/actions.contribution.ts
@@ -16,8 +16,8 @@ import { ShowCurrentReleaseNotesAction } from 'sql/workbench/update/releaseNotes
 import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
 import { IConfigurationRegistry, Extensions as ConfigExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 
-new Actions.BackupAction().registerTask(false);
-new Actions.RestoreAction().registerTask(false);
+new Actions.BackupAction().registerTask();
+new Actions.RestoreAction().registerTask();
 new Actions.NewQueryAction().registerTask();
 new Actions.ConfigureDashboardAction().registerTask();
 

--- a/src/sql/workbench/common/actions.ts
+++ b/src/sql/workbench/common/actions.ts
@@ -302,6 +302,12 @@ export class BackupAction extends Task {
 	}
 
 	runTask(accessor: ServicesAccessor, profile: IConnectionProfile): TPromise<void> {
+		if (!profile) {
+			let objectExplorerService = accessor.get<IObjectExplorerService>(IObjectExplorerService);
+			let connectionManagementService = accessor.get<IConnectionManagementService>(IConnectionManagementService);
+			let workbenchEditorService = accessor.get<IEditorService>(IEditorService);
+			profile = TaskUtilities.getCurrentGlobalConnection(objectExplorerService, connectionManagementService, workbenchEditorService);
+		}
 		let configurationService = accessor.get<IWorkspaceConfigurationService>(IWorkspaceConfigurationService);
 		let previewFeaturesEnabled: boolean = configurationService.getValue('workbench')['enablePreviewFeatures'];
 		if (!previewFeaturesEnabled) {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/sqlopsstudio/issues/1781 (Backup & Restore actions appear in Command Palette but don't do anything) by getting the current connection context and making those commands work with the context connection.

Reverting https://github.com/Microsoft/sqlopsstudio/pull/2317 which was used to fix the problem stated above but caused https://github.com/Microsoft/sqlopsstudio/issues/2508 (Extensions can longer contribute Task icons to the dashboard) instead.

