### PR TITLE
fix the connection issue when opening new query after connection

### DIFF
--- a/src/sql/parts/connection/common/connectionStore.ts
+++ b/src/sql/parts/connection/common/connectionStore.ts
@@ -123,6 +123,7 @@ export class ConnectionStore {
 					.then(savedCred => {
 						if (savedCred) {
 							credentialsItem.password = savedCred.password;
+							credentialsItem.options['password'] = savedCred.password;
 						}
 						resolve({ profile: credentialsItem, savedCred: !!savedCred });
 					},


### PR DESCRIPTION
#2558

later in the connect logic, we use the password property of the options property collection, but it is not set when the connection is newly added. i could force it to use the password property for password option but it might be needed in other scenarios, so i just set both and avoid other potential issues.