### PR TITLE
Maintain Query State

### DIFF
--- a/src/sql/base/browser/ui/panel/panel.ts
+++ b/src/sql/base/browser/ui/panel/panel.ts
@@ -180,14 +180,16 @@ export class TabbedPanel extends Disposable implements IThemable {
 	}
 
 	public layout(dimension: Dimension): void {
-		this._currentDimensions = dimension;
-		this.$parent.style('height', dimension.height + 'px');
-		this.$parent.style('width', dimension.width + 'px');
-		this.$header.style('width', dimension.width + 'px');
-		this.$body.style('width', dimension.width + 'px');
-		const bodyHeight = dimension.height - (this._headerVisible ? this.headersize : 0);
-		this.$body.style('height', bodyHeight + 'px');
-		this._layoutCurrentTab(new Dimension(dimension.width, bodyHeight));
+		if (dimension) {
+			this._currentDimensions = dimension;
+			this.$parent.style('height', dimension.height + 'px');
+			this.$parent.style('width', dimension.width + 'px');
+			this.$header.style('width', dimension.width + 'px');
+			this.$body.style('width', dimension.width + 'px');
+			const bodyHeight = dimension.height - (this._headerVisible ? this.headersize : 0);
+			this.$body.style('height', bodyHeight + 'px');
+			this._layoutCurrentTab(new Dimension(dimension.width, bodyHeight));
+		}
 	}
 
 	private _layoutCurrentTab(dimension: Dimension): void {

--- a/src/sql/base/browser/ui/scrollableSplitview/scrollableSplitview.ts
+++ b/src/sql/base/browser/ui/scrollableSplitview/scrollableSplitview.ts
@@ -109,6 +109,9 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 	private _onDidSashReset = new Emitter<void>();
 	readonly onDidSashReset = this._onDidSashReset.event;
 
+	private _onScroll = new Emitter<number>();
+	readonly onScroll = this._onScroll.event;
+
 	get length(): number {
 		return this.viewItems.length;
 	}
@@ -124,6 +127,7 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 		debounceEvent(this.scrollable.onScroll, (l, e) => e, 25)(e => {
 			this.render(e.scrollTop, e.height);
 			this.relayout();
+			this._onScroll.fire(e.scrollTop);
 		});
 		let domNode = this.scrollable.getDomNode();
 		dom.addClass(this.el, 'monaco-scroll-split-view');
@@ -328,6 +332,10 @@ export class ScrollableSplitView extends HeightMap implements IDisposable {
 	private relayout(lowPriorityIndex?: number): void {
 		const contentSize = this.viewItems.reduce((r, i) => r + i.size, 0);
 		this.resize(this.viewItems.length - 1, this.size - contentSize, undefined, lowPriorityIndex);
+	}
+
+	public setScrollPosition(position: number) {
+		this.scrollable.setScrollPosition({ scrollTop: position });
 	}
 
 	layout(size: number): void {

--- a/src/sql/base/browser/ui/table/plugins/cellRangeSelector.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellRangeSelector.ts
@@ -1,7 +1,5 @@
 import { mixin } from 'vs/base/common/objects';
 
-require.__$__nodeRequire('slickgrid/plugins/slick.cellrangedecorator');
-
 const defaultOptions: ICellRangeSelectorOptions = {
 	selectionCss: {
 		'border': '2px dashed blue'
@@ -44,6 +42,8 @@ export class CellRangeSelector<T> implements ICellRangeSelector<T> {
 	public onCellRangeSelected = new Slick.Event<{ range: Slick.Range }>();
 
 	constructor(private options: ICellRangeSelectorOptions) {
+		require.__$__nodeRequire('slickgrid/plugins/slick.cellrangedecorator');
+
 		this.options = mixin(this.options, defaultOptions, false);
 	}
 

--- a/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
+++ b/src/sql/base/browser/ui/table/plugins/cellSelectionModel.plugin.ts
@@ -6,8 +6,6 @@ import { isUndefinedOrNull } from 'vs/base/common/types';
 
 import { CellRangeSelector, ICellRangeSelector } from 'sql/base/browser/ui/table/plugins/cellRangeSelector';
 
-require.__$__nodeRequire('slickgrid/plugins/slick.cellrangedecorator');
-
 export interface ICellSelectionModelOptions {
 	cellRangeSelector?: any;
 	selectActiveCell?: boolean;

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component.ts
@@ -10,6 +10,7 @@ import * as TelemetryUtils from 'sql/common/telemetryUtilities';
 import { IInsightsView, IInsightData } from 'sql/parts/dashboard/widgets/insights/interfaces';
 import { memoize, unmemoize } from 'sql/base/common/decorators';
 import { mixin } from 'sql/base/common/objects';
+import { LegendPosition, DataDirection, ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 import * as colors from 'vs/platform/theme/common/colorRegistry';
 import { Color } from 'vs/base/common/color';
@@ -20,29 +21,6 @@ import * as nls from 'vs/nls';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 declare var Chart: any;
-
-export enum ChartType {
-	Bar = 'bar',
-	Doughnut = 'doughnut',
-	HorizontalBar = 'horizontalBar',
-	Line = 'line',
-	Pie = 'pie',
-	TimeSeries = 'timeSeries',
-	Scatter = 'scatter'
-}
-
-export enum DataDirection {
-	Vertical = 'vertical',
-	Horizontal = 'horizontal'
-}
-
-export enum LegendPosition {
-	Top = 'top',
-	Bottom = 'bottom',
-	Left = 'left',
-	Right = 'right',
-	None = 'none'
-}
 
 export function customMixin(destination: any, source: any, overwrite?: boolean): any {
 	if (types.isObject(source)) {

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/interfaces.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/interfaces.ts
@@ -25,3 +25,8 @@ export enum LegendPosition {
 	Right = 'right',
 	None = 'none'
 }
+
+export enum DataType {
+	Number = 'number',
+	Point = 'point'
+}

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/interfaces.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/interfaces.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export enum ChartType {
+	Bar = 'bar',
+	Doughnut = 'doughnut',
+	HorizontalBar = 'horizontalBar',
+	Line = 'line',
+	Pie = 'pie',
+	TimeSeries = 'timeSeries',
+	Scatter = 'scatter'
+}
+
+export enum DataDirection {
+	Vertical = 'vertical',
+	Horizontal = 'horizontal'
+}
+
+export enum LegendPosition {
+	Top = 'top',
+	Bottom = 'bottom',
+	Left = 'left',
+	Right = 'right',
+	None = 'none'
+}

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/barChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/barChart.component.ts
@@ -3,8 +3,9 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChartInsight, ChartType, customMixin, IChartConfig } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
+import { ChartInsight, customMixin, IChartConfig } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import { mixin } from 'sql/base/common/objects';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 import { IColorTheme } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import * as colors from 'vs/platform/theme/common/colorRegistry';

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/doughnutChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/doughnutChart.component.ts
@@ -3,8 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import PieChart from './pieChart.component';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export default class DoughnutChart extends PieChart {
 	protected readonly chartType: ChartType = ChartType.Doughnut;

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/horizontalBarChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/horizontalBarChart.component.ts
@@ -3,8 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import BarChart from './barChart.component';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export default class HorizontalBarChart extends BarChart {
 	protected readonly chartType: ChartType = ChartType.HorizontalBar;

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component.ts
@@ -9,12 +9,7 @@ import { defaultChartConfig, IDataSet, IPointDataSet } from 'sql/parts/dashboard
 import BarChart, { IBarChartConfig } from './barChart.component';
 import { memoize, unmemoize } from 'sql/base/common/decorators';
 import { clone } from 'sql/base/common/objects';
-import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
-
-export enum DataType {
-	Number = 'number',
-	Point = 'point'
-}
+import { ChartType, DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export interface ILineConfig extends IBarChartConfig {
 	dataType?: DataType;

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component.ts
@@ -3,11 +3,13 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChartType, customMixin, defaultChartConfig, IDataSet, IPointDataSet } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
+import { mixin } from 'vs/base/common/objects';
+
+import { defaultChartConfig, IDataSet, IPointDataSet } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import BarChart, { IBarChartConfig } from './barChart.component';
 import { memoize, unmemoize } from 'sql/base/common/decorators';
-import { mixin } from 'vs/base/common/objects';
 import { clone } from 'sql/base/common/objects';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export enum DataType {
 	Number = 'number',

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/pieChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/pieChart.component.ts
@@ -3,7 +3,8 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChartInsight, ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
+import { ChartInsight } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export default class PieChart extends ChartInsight {
 	protected readonly chartType: ChartType = ChartType.Pie;

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/scatterChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/scatterChart.component.ts
@@ -3,11 +3,12 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ChartType, defaultChartConfig } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
+import { defaultChartConfig } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import LineChart, { ILineConfig } from './lineChart.component';
+import { clone } from 'sql/base/common/objects';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 import { mixin } from 'vs/base/common/objects';
-import { clone } from 'sql/base/common/objects';
 
 const defaultScatterConfig = mixin(clone(defaultChartConfig), { dataType: 'point', dataDirection: 'horizontal' }) as ILineConfig;
 

--- a/src/sql/parts/dashboard/widgets/insights/views/charts/types/timeSeriesChart.component.ts
+++ b/src/sql/parts/dashboard/widgets/insights/views/charts/types/timeSeriesChart.component.ts
@@ -3,9 +3,10 @@
  *  Licensed under the Source EULA. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { defaultChartConfig, IPointDataSet, ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
+import { defaultChartConfig, IPointDataSet } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import LineChart, { ILineConfig } from './lineChart.component';
 import { clone } from 'sql/base/common/objects';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 import { mixin } from 'vs/base/common/objects';
 import { Color } from 'vs/base/common/color';

--- a/src/sql/parts/grid/views/query/chartViewer.component.ts
+++ b/src/sql/parts/grid/views/query/chartViewer.component.ts
@@ -16,7 +16,7 @@ import { IGridDataSet } from 'sql/parts/grid/common/interfaces';
 import { IInsightData, IInsightsView, IInsightsConfig } from 'sql/parts/dashboard/widgets/insights/interfaces';
 import { Extensions, IInsightRegistry } from 'sql/platform/dashboard/common/insightRegistry';
 import { QueryEditor } from 'sql/parts/query/editor/queryEditor';
-import { DataType, ILineConfig } from 'sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component';
+import { ILineConfig } from 'sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component';
 import * as PathUtilities from 'sql/common/pathUtilities';
 import { IChartViewActionContext, CopyAction, CreateInsightAction, SaveImageAction } from 'sql/parts/grid/views/query/chartViewerActions';
 import * as WorkbenchUtils from 'sql/workbench/common/sqlWorkbenchUtils';
@@ -24,6 +24,7 @@ import * as Constants from 'sql/parts/query/common/constants';
 import { SelectBox as AngularSelectBox } from 'sql/base/browser/ui/selectBox/selectBox.component';
 import { IQueryModelService } from 'sql/parts/query/execution/queryModel';
 import { IClipboardService } from 'sql/platform/clipboard/common/clipboardService';
+import { LegendPosition, DataDirection, DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 /* Insights */
 import {
@@ -46,7 +47,6 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { LegendPosition, DataDirection } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 const insightRegistry = Registry.as<IInsightRegistry>(Extensions.InsightContribution);
 

--- a/src/sql/parts/grid/views/query/chartViewer.component.ts
+++ b/src/sql/parts/grid/views/query/chartViewer.component.ts
@@ -27,7 +27,7 @@ import { IClipboardService } from 'sql/platform/clipboard/common/clipboardServic
 
 /* Insights */
 import {
-	ChartInsight, DataDirection, LegendPosition
+	ChartInsight
 } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -46,6 +46,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IWindowsService, IWindowService } from 'vs/platform/windows/common/windows';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { LegendPosition, DataDirection } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 const insightRegistry = Registry.as<IInsightRegistry>(Extensions.InsightContribution);
 

--- a/src/sql/parts/query/common/queryResultsInput.ts
+++ b/src/sql/parts/query/common/queryResultsInput.ts
@@ -9,6 +9,11 @@ import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorInput } from 'vs/workbench/common/editor';
 import { Emitter } from 'vs/base/common/event';
+import { GridPanelState } from 'sql/parts/query/editor/gridPanel';
+
+export class ResultsViewState {
+	public gridPanelState: GridPanelState;
+}
 
 /**
  * Input for the QueryResultsEditor. This input helps with logic for the viewing and editing of
@@ -28,6 +33,8 @@ export class QueryResultsInput extends EditorInput {
 
 	public readonly onRestoreViewStateEmitter = new Emitter<void>();
 	public readonly onSaveViewStateEmitter = new Emitter<void>();
+
+	public readonly state = new ResultsViewState();
 
 	constructor(private _uri: string) {
 		super();

--- a/src/sql/parts/query/common/queryResultsInput.ts
+++ b/src/sql/parts/query/common/queryResultsInput.ts
@@ -9,10 +9,21 @@ import { localize } from 'vs/nls';
 import { TPromise } from 'vs/base/common/winjs.base';
 import { EditorInput } from 'vs/workbench/common/editor';
 import { Emitter } from 'vs/base/common/event';
+
 import { GridPanelState } from 'sql/parts/query/editor/gridPanel';
+import { MessagePanelState } from 'sql/parts/query/editor/messagePanel';
+import { QueryPlanState } from 'sql/parts/queryPlan/queryPlan';
+import { ChartState } from 'sql/parts/query/editor/charting/chartView';
 
 export class ResultsViewState {
-	public gridPanelState: GridPanelState;
+	public gridPanelState: GridPanelState = new GridPanelState();
+	public messagePanelState: MessagePanelState = new MessagePanelState();
+	public chartState: ChartState = new ChartState();
+	public queryPlanState: QueryPlanState = new QueryPlanState();
+	public gridPanelSize: number;
+	public messagePanelSize: number;
+	public activeTab: string;
+	public visibleTabs: Set<string> = new Set<string>();
 }
 
 /**

--- a/src/sql/parts/query/editor/charting/chartOptions.ts
+++ b/src/sql/parts/query/editor/charting/chartOptions.ts
@@ -8,10 +8,10 @@
 import { localize } from 'vs/nls';
 import { Registry } from 'vs/platform/registry/common/platform';
 
-import { ChartType, DataDirection, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import { Extensions, IInsightRegistry } from 'sql/platform/dashboard/common/insightRegistry';
 import { DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component';
 import { InsightType, IInsightOptions } from './insights/interfaces';
+import { DataDirection, ChartType, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 const insightRegistry = Registry.as<IInsightRegistry>(Extensions.InsightContribution);
 

--- a/src/sql/parts/query/editor/charting/chartOptions.ts
+++ b/src/sql/parts/query/editor/charting/chartOptions.ts
@@ -9,9 +9,8 @@ import { localize } from 'vs/nls';
 import { Registry } from 'vs/platform/registry/common/platform';
 
 import { Extensions, IInsightRegistry } from 'sql/platform/dashboard/common/insightRegistry';
-import { DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component';
 import { InsightType, IInsightOptions } from './insights/interfaces';
-import { DataDirection, ChartType, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
+import { DataDirection, ChartType, LegendPosition, DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 const insightRegistry = Registry.as<IInsightRegistry>(Extensions.InsightContribution);
 

--- a/src/sql/parts/query/editor/charting/chartTab.ts
+++ b/src/sql/parts/query/editor/charting/chartTab.ts
@@ -15,7 +15,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 
 export class ChartTab implements IPanelTab {
 	public readonly title = localize('chartTabTitle', 'Chart');
-	public readonly identifier = generateUuid();
+	public readonly identifier = 'ChartTab';
 	public readonly view: ChartView;
 
 	constructor(@IInstantiationService instantiationService: IInstantiationService) {

--- a/src/sql/parts/query/editor/charting/chartView.ts
+++ b/src/sql/parts/query/editor/charting/chartView.ts
@@ -12,11 +12,11 @@ import { Insight } from './insights/insight';
 import QueryRunner from 'sql/parts/query/execution/queryRunner';
 import { IInsightData } from 'sql/parts/dashboard/widgets/insights/interfaces';
 import { ChartOptions, IChartOption, ControlType } from './chartOptions';
-import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import { Checkbox } from 'sql/base/browser/ui/checkbox/checkbox';
 import { IInsightOptions } from './insights/interfaces';
 import { CopyAction, SaveImageAction, CreateInsightAction, IChartActionContext } from './actions';
 import { Taskbar } from 'sql/base/browser/ui/taskbar/taskbar';
+import { ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 import { Dimension, $, getContentHeight, getContentWidth } from 'vs/base/browser/dom';
 import { SelectBox } from 'vs/base/browser/ui/selectBox/selectBox';

--- a/src/sql/parts/query/editor/charting/insights/graphInsight.ts
+++ b/src/sql/parts/query/editor/charting/insights/graphInsight.ts
@@ -13,9 +13,9 @@ import * as colors from 'vs/platform/theme/common/colorRegistry';
 import { editorLineNumbers } from 'vs/editor/common/view/editorColorRegistry';
 import { IThemeService, ITheme } from 'vs/platform/theme/common/themeService';
 
-import { ChartType, DataDirection, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import { IInsightData } from 'sql/parts/dashboard/widgets/insights/interfaces';
 import { IInsightOptions, IInsight } from './interfaces';
+import { ChartType, DataDirection, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 const noneLineGraphs = [ChartType.Doughnut, ChartType.Pie];
 

--- a/src/sql/parts/query/editor/charting/insights/insight.ts
+++ b/src/sql/parts/query/editor/charting/insights/insight.ts
@@ -6,15 +6,15 @@
 'use strict';
 
 import { Graph } from './graphInsight';
-import { ChartType, DataDirection } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
 import { IInsightData } from 'sql/parts/dashboard/widgets/insights/interfaces';
-
-import { Builder } from 'vs/base/browser/builder';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { DataDirection, ChartType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 import { ImageInsight } from './imageInsight';
 import { TableInsight } from './tableInsight';
 import { IInsightOptions, IInsight, InsightType, IInsightCtor } from './interfaces';
 import { CountInsight } from './countInsight';
+
+import { Builder } from 'vs/base/browser/builder';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { Dimension } from 'vs/base/browser/dom';
 
 const defaultOptions: IInsightOptions = {

--- a/src/sql/parts/query/editor/charting/insights/interfaces.ts
+++ b/src/sql/parts/query/editor/charting/insights/interfaces.ts
@@ -7,8 +7,7 @@
 import { Dimension } from 'vs/base/browser/dom';
 
 import { IInsightData } from 'sql/parts/dashboard/widgets/insights/interfaces';
-import { DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component';
-import { DataDirection, ChartType, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
+import { DataDirection, ChartType, LegendPosition, DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export interface IInsightOptions {
 	type: InsightType | ChartType;

--- a/src/sql/parts/query/editor/charting/insights/interfaces.ts
+++ b/src/sql/parts/query/editor/charting/insights/interfaces.ts
@@ -4,11 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 'use strict';
+import { Dimension } from 'vs/base/browser/dom';
 
 import { IInsightData } from 'sql/parts/dashboard/widgets/insights/interfaces';
-import { ChartType, LegendPosition, DataDirection } from 'sql/parts/dashboard/widgets/insights/views/charts/chartInsight.component';
-import { Dimension } from 'vs/base/browser/dom';
 import { DataType } from 'sql/parts/dashboard/widgets/insights/views/charts/types/lineChart.component';
+import { DataDirection, ChartType, LegendPosition } from 'sql/parts/dashboard/widgets/insights/views/charts/interfaces';
 
 export interface IInsightOptions {
 	type: InsightType | ChartType;

--- a/src/sql/parts/query/editor/messagePanel.ts
+++ b/src/sql/parts/query/editor/messagePanel.ts
@@ -156,6 +156,7 @@ export class MessagePanel extends ViewletPanel {
 				}
 			});
 		}
+		this.maximumBodySize = this.model.messages.length * 22;
 	}
 
 	private reset() {

--- a/src/sql/parts/query/editor/messagePanel.ts
+++ b/src/sql/parts/query/editor/messagePanel.ts
@@ -59,6 +59,11 @@ const TemplateIds = {
 	ERROR: 'error'
 };
 
+export class MessagePanelState {
+	public scrollPosition: number;
+	public collapsed = false;
+}
+
 export class MessagePanel extends ViewletPanel {
 	private ds = new MessageDataSource();
 	private renderer = new MessageRenderer();
@@ -67,6 +72,7 @@ export class MessagePanel extends ViewletPanel {
 	private container = $('div message-tree').getHTMLElement();
 
 	private queryRunnerDisposables: IDisposable[] = [];
+	private _state: MessagePanelState;
 
 	private tree: ITree;
 
@@ -86,6 +92,16 @@ export class MessagePanel extends ViewletPanel {
 			renderer: this.renderer,
 			controller: this.controller
 		}, { keyboardSupport: false });
+		this.tree.onDidScroll(e => {
+			if (this.state) {
+				this.state.scrollPosition = this.tree.getScrollPosition();
+			}
+		});
+		this.onDidChange(e => {
+			if (this.state) {
+				this.state.collapsed = !this.isExpanded();
+			}
+		});
 	}
 
 	protected renderBody(container: HTMLElement): void {
@@ -99,8 +115,12 @@ export class MessagePanel extends ViewletPanel {
 	protected layoutBody(size: number): void {
 		const previousScrollPosition = this.tree.getScrollPosition();
 		this.tree.layout(size);
-		if (previousScrollPosition === 1) {
-			this.tree.setScrollPosition(1);
+		if (this.state && this.state.scrollPosition) {
+			this.tree.setScrollPosition(this.state.scrollPosition);
+		} else {
+			if (previousScrollPosition === 1) {
+				this.tree.setScrollPosition(1);
+			}
 		}
 	}
 
@@ -124,18 +144,35 @@ export class MessagePanel extends ViewletPanel {
 		if (hasError) {
 			this.setExpanded(true);
 		}
-		const previousScrollPosition = this.tree.getScrollPosition();
-		this.tree.refresh(this.model).then(() => {
-			if (previousScrollPosition === 1) {
+		if (this.state.scrollPosition) {
+			this.tree.refresh(this.model).then(() => {
 				this.tree.setScrollPosition(1);
-			}
-		});
+			});
+		} else {
+			const previousScrollPosition = this.tree.getScrollPosition();
+			this.tree.refresh(this.model).then(() => {
+				if (previousScrollPosition === 1) {
+					this.tree.setScrollPosition(1);
+				}
+			});
+		}
 	}
 
 	private reset() {
 		this.model.messages = [];
 		this.model.totalExecuteMessage = undefined;
 		this.tree.refresh(this.model);
+	}
+
+	public set state(val: MessagePanelState) {
+		this._state = val;
+		if (this.state.scrollPosition) {
+			this.tree.setScrollPosition(this.state.scrollPosition);
+		}
+		this.setExpanded(!this.state.collapsed);
+	}
+	public get state(): MessagePanelState {
+		return this._state;
 	}
 }
 

--- a/src/sql/parts/query/editor/queryResultsView.ts
+++ b/src/sql/parts/query/editor/queryResultsView.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { QueryResultsInput } from 'sql/parts/query/common/queryResultsInput';
+import { QueryResultsInput, ResultsViewState } from 'sql/parts/query/common/queryResultsInput';
 import { TabbedPanel, IPanelTab, IPanelView } from 'sql/base/browser/ui/panel/panel';
 import { IQueryModelService } from '../execution/queryModel';
 import QueryRunner from 'sql/parts/query/execution/queryRunner';
@@ -28,6 +28,7 @@ class ResultsView implements IPanelView {
 	private currentDimension: DOM.Dimension;
 	private isGridRendered = false;
 	private lastGridHeight: number;
+	private _state: ResultsViewState;
 
 	constructor(instantiationService: IInstantiationService) {
 		this.panelViewlet = instantiationService.createInstance(PanelViewlet, 'resultsView', { showHeaderInTitleWhenSingleView: false });
@@ -93,6 +94,11 @@ class ResultsView implements IPanelView {
 	public hideResultHeader() {
 		this.gridPanel.headerVisible = false;
 	}
+
+	public set state(val: ResultsViewState) {
+		this._state = val;
+		this.gridPanel.state = val.gridPanelState;
+	}
 }
 
 class ResultsTab implements IPanelTab {
@@ -132,6 +138,7 @@ export class QueryResultsView {
 
 	public set input(input: QueryResultsInput) {
 		this._input = input;
+		this.resultsTab.view.state = this._input.state;
 		let queryRunner = this.queryModelService._getQueryInfo(input.uri).queryRunner;
 		this.resultsTab.queryRunner = queryRunner;
 		this.chartTab.queryRunner = queryRunner;

--- a/src/sql/parts/query/editor/queryResultsView.ts
+++ b/src/sql/parts/query/editor/queryResultsView.ts
@@ -58,10 +58,10 @@ class ResultsView implements IPanelView {
 					panelSize = 200;
 					this.needsGridResize = true;
 				}
-				this.panelViewlet.addPanels([ { panel: this.gridPanel, index: 0, size: panelSize }]);
+				this.panelViewlet.addPanels([{ panel: this.gridPanel, index: 0, size: panelSize }]);
 			}
 		});
-		let gridResizeList = this.gridPanel.onDidChange(e => {
+		let resizeList = anyEvent(this.gridPanel.onDidChange, this.messagePanel.onDidChange)(() => {
 			let panelSize: number;
 			if (this.state && this.state.gridPanelSize) {
 				panelSize = this.state.gridPanelSize;
@@ -71,18 +71,15 @@ class ResultsView implements IPanelView {
 				panelSize = 200;
 				this.needsGridResize = true;
 			}
-			this.panelViewlet.resizePanel(this.gridPanel, panelSize);
-		});
-		let messageResizeList = this.messagePanel.onDidChange(e => {
 			if (this.state.messagePanelSize) {
 				this.panelViewlet.resizePanel(this.gridPanel, this.state.messagePanelSize);
 			}
-		});
+			this.panelViewlet.resizePanel(this.gridPanel, panelSize);
+		})
 		// once the user changes the sash we should stop trying to resize the grid
 		once(this.panelViewlet.onDidSashChange)(e => {
 			this.needsGridResize = false;
-			gridResizeList.dispose();
-			messageResizeList.dispose();
+			resizeList.dispose();
 		});
 
 		this.panelViewlet.onDidSashChange(e => {
@@ -91,7 +88,7 @@ class ResultsView implements IPanelView {
 					this.state.gridPanelSize = this.panelViewlet.getPanelSize(this.gridPanel);
 				}
 				if (this.messagePanel.isExpanded()) {
-					this.state.messagePanelSize  = this.panelViewlet.getPanelSize(this.messagePanel);
+					this.state.messagePanelSize = this.panelViewlet.getPanelSize(this.messagePanel);
 				}
 			}
 		});

--- a/src/sql/parts/queryPlan/queryPlan.ts
+++ b/src/sql/parts/queryPlan/queryPlan.ts
@@ -13,9 +13,13 @@ import { localize } from 'vs/nls';
 import * as UUID from 'vs/base/common/uuid';
 import { Builder } from 'vs/base/browser/builder';
 
+export class QueryPlanState {
+	xml: string;
+}
+
 export class QueryPlanTab implements IPanelTab {
 	public readonly title = localize('queryPlanTitle', 'Query Plan');
-	public readonly identifier = UUID.generateUuid();
+	public readonly identifier = 'QueryPlanTab';
 	public readonly view: QueryPlanView;
 
 	constructor() {
@@ -27,6 +31,7 @@ export class QueryPlanView implements IPanelView {
 	private qp: QueryPlan;
 	private xml: string;
 	private container = document.createElement('div');
+	private _state: QueryPlanState;
 
 	public render(container: HTMLElement): void {
 		if (!this.qp) {
@@ -47,6 +52,20 @@ export class QueryPlanView implements IPanelView {
 		} else {
 			this.xml = xml;
 		}
+		if (this.state) {
+			this.state.xml = xml;
+		}
+	}
+
+	public set state(val: QueryPlanState) {
+		this._state = val;
+		if (this.state.xml) {
+			this.showPlan(this.state.xml);
+		}
+	}
+
+	public get state(): QueryPlanState {
+		return this._state;
 	}
 }
 

--- a/src/vs/base/browser/ui/splitview/panelview.ts
+++ b/src/vs/base/browser/ui/splitview/panelview.ts
@@ -44,8 +44,7 @@ export abstract class Panel implements IView {
 	private static readonly HEADER_SIZE = 22;
 
 	protected _expanded: boolean;
-	// {{SQL CARBON EDIT}} we need to value in order to properly restore it
-	public expandedSize: number | undefined = undefined;
+	private expandedSize: number | undefined = undefined;
 	private _headerVisible = true;
 	private _minimumBodySize: number;
 	private _maximumBodySize: number;

--- a/src/vs/base/browser/ui/splitview/panelview.ts
+++ b/src/vs/base/browser/ui/splitview/panelview.ts
@@ -44,7 +44,8 @@ export abstract class Panel implements IView {
 	private static readonly HEADER_SIZE = 22;
 
 	protected _expanded: boolean;
-	private expandedSize: number | undefined = undefined;
+	// {{SQL CARBON EDIT}} we need to value in order to properly restore it
+	public expandedSize: number | undefined = undefined;
 	private _headerVisible = true;
 	private _minimumBodySize: number;
 	private _maximumBodySize: number;

--- a/test/all.js
+++ b/test/all.js
@@ -61,7 +61,7 @@ function main() {
 			'bootstrap': `../${ out }/bootstrap`
 		},
 		catchError: true,
-    // {{SQL CARBON EDIT}}
+    	// {{SQL CARBON EDIT}}
 		nodeModules: [
 			'@angular/common',
 			'@angular/core',
@@ -70,6 +70,7 @@ function main() {
 			'@angular/platform-browser-dynamic',
 			'@angular/router',
 			'angular2-grid',
+			'ng2-charts/ng2-charts',
 			'rxjs/add/observable/of',
 			'rxjs/Observable',
 			'rxjs/Subject',

--- a/test/all.js
+++ b/test/all.js
@@ -61,7 +61,7 @@ function main() {
 			'bootstrap': `../${ out }/bootstrap`
 		},
 		catchError: true,
-    	// {{SQL CARBON EDIT}}
+		// {{SQL CARBON EDIT}}
 		nodeModules: [
 			'@angular/common',
 			'@angular/core',


### PR DESCRIPTION
Handles maintaining the query results state during editor changes. I've tested most scenarios I can think of, but this could probably use more testing to catch edge cases I didn't see.

One ("change" or "bug") that i know of that I didn't bother fixing is when changing editor the chart viewer colors will change. I'm not sure this is a big enough bug to block this feature on though.