### PR TITLE
Add OE node refresh API method

### DIFF
--- a/src/sql/parts/objectExplorer/common/objectExplorerService.ts
+++ b/src/sql/parts/objectExplorer/common/objectExplorerService.ts
@@ -479,12 +479,13 @@ export class ObjectExplorerService implements IObjectExplorerService {
 	}
 
 	public async refreshNodeInView(connectionId: string, nodePath: string): Promise<TreeNode> {
+		// Get the tree node and call refresh from the provider
 		let treeNode = await this.getTreeNode(connectionId, nodePath);
 		await this.refreshTreeNode(treeNode.getSession(), treeNode);
 
 		// Get the new tree node, refresh it in the view, and expand it if needed
 		treeNode = await this.getTreeNode(connectionId, nodePath);
-		this._serverTreeView.refreshElement(treeNode);
+		await this._serverTreeView.refreshElement(treeNode);
 		if (treeNode.children.length > 0) {
 			await treeNode.setExpandedState(TreeItemCollapsibleState.Expanded);
 		}

--- a/src/sql/parts/objectExplorer/common/objectExplorerService.ts
+++ b/src/sql/parts/objectExplorer/common/objectExplorerService.ts
@@ -72,6 +72,8 @@ export interface IObjectExplorerService {
 	getActiveConnectionNodes(): TreeNode[];
 
 	getTreeNode(connectionId: string, nodePath: string): Thenable<TreeNode>;
+
+	refreshNodeInView(connectionId: string, nodePath: string): Thenable<TreeNode>;
 }
 
 interface SessionStatus {
@@ -474,6 +476,19 @@ export class ObjectExplorerService implements IObjectExplorerService {
 
 	public getActiveConnectionNodes(): TreeNode[] {
 		return Object.values(this._activeObjectExplorerNodes);
+	}
+
+	public async refreshNodeInView(connectionId: string, nodePath: string): Promise<TreeNode> {
+		let treeNode = await this.getTreeNode(connectionId, nodePath);
+		await this.refreshTreeNode(treeNode.getSession(), treeNode);
+
+		// Get the new tree node, refresh it in the view, and expand it if needed
+		treeNode = await this.getTreeNode(connectionId, nodePath);
+		this._serverTreeView.refreshElement(treeNode);
+		if (treeNode.children.length > 0) {
+			await treeNode.setExpandedState(TreeItemCollapsibleState.Expanded);
+		}
+		return treeNode;
 	}
 
 	private async setNodeExpandedState(treeNode: TreeNode, expandedState: TreeItemCollapsibleState): Promise<void> {

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
@@ -244,8 +244,8 @@ export class ServerTreeView {
 		TreeUpdateUtils.registeredServerUpdate(this._tree, this._connectionManagementService);
 	}
 
-	public refreshElement(element: any): void {
-		this._tree.refresh(element);
+	public refreshElement(element: any): Thenable<void> {
+		return this._tree.refresh(element);
 	}
 
 	/**

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
@@ -244,6 +244,10 @@ export class ServerTreeView {
 		TreeUpdateUtils.registeredServerUpdate(this._tree, this._connectionManagementService);
 	}
 
+	public refreshElement(element: any): void {
+		this._tree.refresh(element);
+	}
+
 	/**
 	 * Filter connections based on view (recent/active)
 	 */

--- a/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
+++ b/src/sql/parts/objectExplorer/viewlet/serverTreeView.ts
@@ -138,7 +138,7 @@ export class ServerTreeView {
 
 			let expandGroups: boolean = self._configurationService.getValue(SERVER_GROUP_CONFIG)[SERVER_GROUP_AUTOEXPAND_CONFIG];
 			if (expandGroups) {
-				 self._tree.expandAll(ConnectionProfileGroup.getSubgroups(root));
+				self._tree.expandAll(ConnectionProfileGroup.getSubgroups(root));
 			}
 
 			if (root && !root.hasValidConnections) {

--- a/src/sql/sqlops.d.ts
+++ b/src/sql/sqlops.d.ts
@@ -185,6 +185,11 @@ declare module 'sqlops' {
 			 * Get the parent node. Returns undefined if there is none.
 			 */
 			getParent(): Thenable<ObjectExplorerNode>;
+
+			/**
+			 * Refresh the node, expanding it if it has children
+			 */
+			refresh(): Thenable<void>;
 		}
 	}
 

--- a/src/sql/workbench/api/node/extHostObjectExplorer.ts
+++ b/src/sql/workbench/api/node/extHostObjectExplorer.ts
@@ -9,7 +9,7 @@ import { ExtHostObjectExplorerShape, SqlMainContext, MainThreadObjectExplorerSha
 import * as sqlops from 'sqlops';
 import * as vscode from 'vscode';
 
-export class ExtHostObjectExplorer implements ExtHostObjectExplorerShape  {
+export class ExtHostObjectExplorer implements ExtHostObjectExplorerShape {
 
 	private _proxy: MainThreadObjectExplorerShape;
 

--- a/src/sql/workbench/api/node/extHostObjectExplorer.ts
+++ b/src/sql/workbench/api/node/extHostObjectExplorer.ts
@@ -71,4 +71,8 @@ class ExtHostObjectExplorerNode implements sqlops.objectexplorer.ObjectExplorerN
 		}
 		return this._proxy.$getNode(this.connectionId, this.nodePath.slice(0, parentPathEndIndex)).then(nodeInfo => nodeInfo ? new ExtHostObjectExplorerNode(nodeInfo, this.connectionId, this._proxy) : undefined);
 	}
+
+	refresh(): Thenable<void> {
+		return this._proxy.$refresh(this.connectionId, this.nodePath);
+	}
 }

--- a/src/sql/workbench/api/node/extHostObjectExplorer.ts
+++ b/src/sql/workbench/api/node/extHostObjectExplorer.ts
@@ -44,7 +44,7 @@ class ExtHostObjectExplorerNode implements sqlops.objectexplorer.ObjectExplorerN
 	public errorMessage: string;
 
 	constructor(nodeInfo: sqlops.NodeInfo, connectionId: string, private _proxy: MainThreadObjectExplorerShape) {
-		Object.entries(nodeInfo).forEach(([key, value]) => this[key] = value);
+		this.getDetailsFromInfo(nodeInfo);
 		this.connectionId = connectionId;
 	}
 
@@ -73,6 +73,10 @@ class ExtHostObjectExplorerNode implements sqlops.objectexplorer.ObjectExplorerN
 	}
 
 	refresh(): Thenable<void> {
-		return this._proxy.$refresh(this.connectionId, this.nodePath);
+		return this._proxy.$refresh(this.connectionId, this.nodePath).then(nodeInfo => this.getDetailsFromInfo(nodeInfo));
+	}
+
+	private getDetailsFromInfo(nodeInfo: sqlops.NodeInfo): void {
+		Object.entries(nodeInfo).forEach(([key, value]) => this[key] = value);
 	}
 }

--- a/src/sql/workbench/api/node/mainThreadObjectExplorer.ts
+++ b/src/sql/workbench/api/node/mainThreadObjectExplorer.ts
@@ -75,7 +75,7 @@ export class MainThreadObjectExplorer implements MainThreadObjectExplorerShape {
 		return this._objectExplorerService.findNodes(connectionId, type, schema, name, database, parentObjectNames);
 	}
 
-	public $refresh(connectionId: string, nodePath: string): Thenable<void> {
-		return this._objectExplorerService.refreshNodeInView(connectionId, nodePath).then(() => undefined);
+	public $refresh(connectionId: string, nodePath: string): Thenable<sqlops.NodeInfo> {
+		return this._objectExplorerService.refreshNodeInView(connectionId, nodePath).then(node => node.toNodeInfo());
 	}
 }

--- a/src/sql/workbench/api/node/mainThreadObjectExplorer.ts
+++ b/src/sql/workbench/api/node/mainThreadObjectExplorer.ts
@@ -15,6 +15,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import * as TaskUtilities from 'sql/workbench/common/taskUtilities';
 import { IConnectionProfile } from 'sql/parts/connection/common/interfaces';
 import { dispose, IDisposable } from 'vs/base/common/lifecycle';
+import { TreeItemCollapsibleState } from 'sql/parts/objectExplorer/common/treeNode';
 
 @extHostNamedCustomer(SqlMainContext.MainThreadObjectExplorer)
 export class MainThreadObjectExplorer implements MainThreadObjectExplorerShape {
@@ -72,5 +73,9 @@ export class MainThreadObjectExplorer implements MainThreadObjectExplorerShape {
 
 	public $findNodes(connectionId: string, type: string, schema: string, name: string, database: string, parentObjectNames: string[]): Thenable<sqlops.NodeInfo[]> {
 		return this._objectExplorerService.findNodes(connectionId, type, schema, name, database, parentObjectNames);
+	}
+
+	public $refresh(connectionId: string, nodePath: string): Thenable<void> {
+		return this._objectExplorerService.refreshNodeInView(connectionId, nodePath).then(() => undefined);
 	}
 }

--- a/src/sql/workbench/api/node/mainThreadObjectExplorer.ts
+++ b/src/sql/workbench/api/node/mainThreadObjectExplorer.ts
@@ -51,7 +51,7 @@ export class MainThreadObjectExplorer implements MainThreadObjectExplorerShape {
 	public $getActiveConnectionNodes(): Thenable<NodeInfoWithConnection[]> {
 		let connectionNodes = this._objectExplorerService.getActiveConnectionNodes();
 		return Promise.resolve(connectionNodes.map(node => {
-			return {connectionId: node.connection.id, nodeInfo: node.toNodeInfo()};
+			return { connectionId: node.connection.id, nodeInfo: node.toNodeInfo() };
 		}));
 	}
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -663,7 +663,7 @@ export interface MainThreadObjectExplorerShape extends IDisposable {
 	$getChildren(connectionId: string, nodePath: string): Thenable<sqlops.NodeInfo[]>;
 	$isExpanded(connectionId: string, nodePath: string): Thenable<boolean>;
 	$findNodes(connectionId: string, type: string, schema: string, name: string, database: string, parentObjectNames: string[]): Thenable<sqlops.NodeInfo[]>;
-	$refresh(connectionId: string, nodePath: string): Thenable<void>;
+	$refresh(connectionId: string, nodePath: string): Thenable<sqlops.NodeInfo>;
 }
 
 export interface ExtHostModelViewDialogShape {

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -36,7 +36,7 @@ export abstract class ExtHostAccountManagementShape {
 
 export abstract class ExtHostConnectionManagementShape {
 	$onConnectionOpened(handleId: string, connection: sqlops.connection.Connection): void { throw ni; }
- }
+}
 
 export abstract class ExtHostDataProtocolShape {
 

--- a/src/sql/workbench/api/node/sqlExtHost.protocol.ts
+++ b/src/sql/workbench/api/node/sqlExtHost.protocol.ts
@@ -663,6 +663,7 @@ export interface MainThreadObjectExplorerShape extends IDisposable {
 	$getChildren(connectionId: string, nodePath: string): Thenable<sqlops.NodeInfo[]>;
 	$isExpanded(connectionId: string, nodePath: string): Thenable<boolean>;
 	$findNodes(connectionId: string, type: string, schema: string, name: string, database: string, parentObjectNames: string[]): Thenable<sqlops.NodeInfo[]>;
+	$refresh(connectionId: string, nodePath: string): Thenable<void>;
 }
 
 export interface ExtHostModelViewDialogShape {

--- a/src/sqltest/parts/connection/objectExplorerService.test.ts
+++ b/src/sqltest/parts/connection/objectExplorerService.test.ts
@@ -745,7 +745,6 @@ suite('SQL Object Explorer Service tests', () => {
 		await objectExplorerService.createNewSession('MSSQL', connection);
 		objectExplorerService.onSessionCreated(1, objectExplorerSession);
 		serverTreeView.setup(x => x.refreshElement(TypeMoq.It.isAny())).returns(() => Promise.resolve());
-		serverTreeView.setup(x => x.setExpandedState(TypeMoq.It.isAny(), TypeMoq.It.isAny())).returns(() => Promise.resolve());
 		objectExplorerService.registerServerTreeView(serverTreeView.object);
 
 		// Refresh the node
@@ -754,9 +753,8 @@ suite('SQL Object Explorer Service tests', () => {
 
 		// Verify that it was refreshed, expanded, and the refreshed detailed were returned
 		sqlOEProvider.verify(x => x.refreshNode(TypeMoq.It.is(refreshNode => refreshNode.nodePath === nodePath)), TypeMoq.Times.once());
-		serverTreeView.verify(x => x.setExpandedState(TypeMoq.It.is(treeNode => treeNode === refreshedNode), TypeMoq.It.is(expandedState => expandedState === TreeItemCollapsibleState.Expanded)), TypeMoq.Times.once());
 		refreshedNode.children.forEach((childNode, index) => {
-			assert.equal(childNode, objectExplorerExpandInfoRefresh.nodes[index]);
+			assert.equal(childNode.nodePath, objectExplorerExpandInfoRefresh.nodes[index].nodePath);
 		});
 	});
 });


### PR DESCRIPTION
At @ronychatterjee's request I added a way to programmatically refresh object explorer nodes from extensions and from inside Ops Studio