### PR TITLE
use latest slickgrid library

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "reflect-metadata": "^0.1.8",
     "rxjs": "5.4.0",
     "semver": "^5.5.0",
-    "slickgrid": "github:anthonydresser/SlickGrid#2.3.25",
+    "slickgrid": "github:anthonydresser/SlickGrid#2.3.27",
     "spdlog": "0.7.1",
     "sudo-prompt": "8.2.0",
     "svg.js": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6111,9 +6111,9 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-"slickgrid@github:anthonydresser/SlickGrid#2.3.25":
-  version "2.3.25"
-  resolved "https://codeload.github.com/anthonydresser/SlickGrid/tar.gz/5fa498a3df7ed671958bedeac1863c41352c7825"
+"slickgrid@github:anthonydresser/SlickGrid#2.3.27":
+  version "2.3.27"
+  resolved "https://codeload.github.com/anthonydresser/SlickGrid/tar.gz/712a59307942c8fdb18708b6d1a501880a74db8d"
   dependencies:
     jquery ">=1.8.0"
     jquery-ui ">=1.8.0"


### PR DESCRIPTION
the referenced package version was changed to 2.3.25 from 2.3.27 when you were doing the vscode merge. 