### PR TITLE
Fix crash when reverting in edit data with no changes

### DIFF
--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -464,7 +464,7 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 		} else {
 			try {
 				// Perform a revert row operation
-				if (this.currentCell) {
+				if (this.currentCell && this.currentCell.row !== undefined && this.currentCell.row !== null) {
 					await this.dataService.revertRow(this.currentCell.row);
 				}
 			} finally {


### PR DESCRIPTION
Fixes #2565 where Tools Service would crash when reverting a row if you had no changes pending