### PR TITLE
edit data issue with column index handling

### DIFF
--- a/src/sql/parts/grid/views/editData/editData.component.ts
+++ b/src/sql/parts/grid/views/editData/editData.component.ts
@@ -166,7 +166,7 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 
 		this.onCellEditEnd = (event: Slick.OnCellChangeEventArgs<any>): void => {
 			// Store the value that was set
-			self.currentEditCellValue = event.item[event.cell - 1];
+			self.currentEditCellValue = event.item[event.cell];
 		};
 
 		this.overrideCellFn = (rowNumber, columnId, value?, data?): string => {
@@ -270,18 +270,18 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 
 				return self.dataService.updateCell(sessionRowId, self.currentCell.column - 1, self.currentEditCellValue)
 					.then(
-					result => {
-						// Cell update was successful, update the flags
-						self.currentEditCellValue = null;
-						self.setCellDirtyState(row, self.currentCell.column, result.cell.isDirty);
-						self.setRowDirtyState(row, result.isRowDirty);
-						return Promise.resolve();
-					},
-					error => {
-						// Cell update failed, jump back to the last cell we were on
-						self.focusCell(self.currentCell.row, self.currentCell.column, true);
-						return Promise.reject(null);
-					}
+						result => {
+							// Cell update was successful, update the flags
+							self.currentEditCellValue = null;
+							self.setCellDirtyState(row, self.currentCell.column, result.cell.isDirty);
+							self.setRowDirtyState(row, result.isRowDirty);
+							return Promise.resolve();
+						},
+						error => {
+							// Cell update failed, jump back to the last cell we were on
+							self.focusCell(self.currentCell.row, self.currentCell.column, true);
+							return Promise.reject(null);
+						}
 					);
 			});
 		}
@@ -377,10 +377,11 @@ export class EditDataComponent extends GridParentComponent implements OnInit, On
 				index => { return {}; }
 			),
 			columnDefinitions: [rowNumberColumn.getColumnDefinition()].concat(resultSet.columnInfo.map((c, i) => {
+				let columnIndex = (i + 1).toString();
 				return {
-					id: i.toString(),
+					id: columnIndex,
 					name: escape(c.columnName),
-					field: i.toString(),
+					field: columnIndex,
 					formatter: Services.textFormatter,
 					isEditable: c.isUpdatable
 				};


### PR DESCRIPTION
Edit data: Value entered in one cell overwrites the next cell when editing/inserting #2576

After August release, we introduced a regression here. the columns information used by data item and grid becomes out of sync. this needs to be corrected inside editData component as the underlying SlickGrid component has no knowledge of the row number column special logic.