### PR TITLE
Added text underline CSS for DB NULL values when editing / showing data

### DIFF
--- a/src/sql/parts/grid/media/slick.grid.css
+++ b/src/sql/parts/grid/media/slick.grid.css
@@ -104,6 +104,11 @@ classes should alter those!
 	white-space: nowrap;
 	cursor: default;
 }
+
+.slick-cell .grid-cell-value-container.missing-value {
+	text-decoration: underline;
+}
+
 .slick-cell, .slick-headerrow-column{
 	border-bottom-color: silver;
 }

--- a/src/sql/parts/grid/media/slick.grid.css
+++ b/src/sql/parts/grid/media/slick.grid.css
@@ -106,7 +106,7 @@ classes should alter those!
 }
 
 .slick-cell .grid-cell-value-container.missing-value {
-	text-decoration: underline;
+	font-style: italic;
 }
 
 .slick-cell, .slick-headerrow-column{


### PR DESCRIPTION
Since @anthonydresser has added a way of determining dbnull values in the slickgrid cell we could atleast underline NULL values:
![image](https://user-images.githubusercontent.com/11557675/45585546-72a1df00-b8e6-11e8-951f-314006aa4b57.png)

In my opinion this is a critical feature that we really need now.
If we later want to add a specific dbnull background color for themes we could replace this solution in the future.

#217