### PR TITLE
Fix/bump dependency versions

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "azure-storage": "^2.1.0",
     "decompress": "^4.2.0",
     "documentdb": "1.13.0",
-    "service-downloader": "github:anthonydresser/service-downloader#0.1.2",
+    "service-downloader": "github:anthonydresser/service-downloader#0.1.5",
     "fs-extra-promise": "^1.0.1",
     "mime": "^1.3.4",
     "minimist": "^1.2.0",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -1002,7 +1002,7 @@ hoek@4.x.x:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
 
-http-proxy-agent@^2.0.0:
+http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
   dependencies:
@@ -1025,7 +1025,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-https-proxy-agent@^2.1.1:
+https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
@@ -1843,14 +1843,14 @@ semver@^5.4.1:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-"service-downloader@github:anthonydresser/service-downloader#0.1.2":
-  version "0.1.2"
-  resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/2aa9b336b6442e17e24693ddc907030575539798"
+"service-downloader@github:anthonydresser/service-downloader#0.1.5":
+  version "0.1.5"
+  resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/6ebb0465573cc140e461a22f334260f55ef45546"
   dependencies:
     decompress "^4.2.0"
     eventemitter2 "^5.0.1"
-    http-proxy-agent "^2.0.0"
-    https-proxy-agent "^2.1.1"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
     mkdirp "^0.5.1"
     tmp "^0.0.33"
 

--- a/extensions/import/package.json
+++ b/extensions/import/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.2.7",
     "opener": "^1.4.3",
-    "service-downloader": "github:anthonydresser/service-downloader#0.1.4",
+    "service-downloader": "github:anthonydresser/service-downloader#0.1.5",
     "vscode-extension-telemetry": "^0.0.5",
     "vscode-nls": "^3.2.1"
   },

--- a/extensions/import/yarn.lock
+++ b/extensions/import/yarn.lock
@@ -177,14 +177,14 @@ graceful-fs@^4.1.10:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-http-proxy-agent@^2.0.0:
+http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
   dependencies:
     agent-base "4"
     debug "3.1.0"
 
-https-proxy-agent@^2.1.1:
+https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
@@ -297,14 +297,14 @@ seek-bzip@^1.0.5:
   dependencies:
     commander "~2.8.1"
 
-"service-downloader@github:anthonydresser/service-downloader#0.1.4":
-  version "0.1.4"
-  resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/3c0abdf8603aca85d2eacfac3c547173e41bf0c7"
+"service-downloader@github:anthonydresser/service-downloader#0.1.5":
+  version "0.1.5"
+  resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/6ebb0465573cc140e461a22f334260f55ef45546"
   dependencies:
     decompress "^4.2.0"
     eventemitter2 "^5.0.1"
-    http-proxy-agent "^2.0.0"
-    https-proxy-agent "^2.1.1"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
     mkdirp "^0.5.1"
     tmp "^0.0.33"
 

--- a/extensions/mssql/package.json
+++ b/extensions/mssql/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "dataprotocol-client": "github:Microsoft/sqlops-dataprotocolclient#0.2.8",
     "opener": "^1.4.3",
-    "service-downloader": "github:anthonydresser/service-downloader#0.1.4",
+    "service-downloader": "github:anthonydresser/service-downloader#0.1.5",
     "vscode-extension-telemetry": "^0.0.15"
   },
   "devDependencies": {

--- a/extensions/mssql/yarn.lock
+++ b/extensions/mssql/yarn.lock
@@ -191,14 +191,14 @@ graceful-fs@^4.1.10:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-http-proxy-agent@^2.0.0:
+http-proxy-agent@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
   dependencies:
     agent-base "4"
     debug "3.1.0"
 
-https-proxy-agent@^2.1.1:
+https-proxy-agent@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
   dependencies:
@@ -315,14 +315,14 @@ semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
-"service-downloader@github:anthonydresser/service-downloader#0.1.4":
-  version "0.1.4"
-  resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/3c0abdf8603aca85d2eacfac3c547173e41bf0c7"
+"service-downloader@github:anthonydresser/service-downloader#0.1.5":
+  version "0.1.5"
+  resolved "https://codeload.github.com/anthonydresser/service-downloader/tar.gz/6ebb0465573cc140e461a22f334260f55ef45546"
   dependencies:
     decompress "^4.2.0"
     eventemitter2 "^5.0.1"
-    http-proxy-agent "^2.0.0"
-    https-proxy-agent "^2.1.1"
+    http-proxy-agent "^2.1.0"
+    https-proxy-agent "^2.2.1"
     mkdirp "^0.5.1"
     tmp "^0.0.33"
 

--- a/package.json
+++ b/package.json
@@ -167,5 +167,8 @@
     "windows-foreground-love": "0.1.0",
     "windows-mutex": "^0.2.0",
     "windows-process-tree": "0.2.2"
+  },
+  "resolutions": {
+    "rc": "1.2.8"
   }
 }

--- a/samples/extensionSamples/package-lock.json
+++ b/samples/extensionSamples/package-lock.json
@@ -10,11 +10,11 @@
             "integrity": "sha512-ciiioYMLdo16ShmfHBXJBOFm3xPC4AuwO4xeRpFeHz7WK9PYsWCmigagG2XyzZpubK4a3qNKoUBDhbzHfa50LQ==",
             "dev": true,
             "requires": {
-                "acorn": "5.7.1",
-                "css": "2.2.3",
-                "normalize-path": "2.1.1",
-                "source-map": "0.6.1",
-                "through2": "2.0.3"
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.6.0",
+                "through2": "^2.0.3"
             },
             "dependencies": {
                 "source-map": {
@@ -31,8 +31,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "2.1.1",
-                "through2": "2.0.3"
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
             }
         },
         "@types/handlebars": {
@@ -65,10 +65,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "align-text": {
@@ -76,9 +76,9 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -92,7 +92,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -146,8 +146,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -168,16 +168,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -186,7 +186,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -206,13 +206,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -221,7 +221,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -230,7 +230,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -239,7 +239,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -248,7 +248,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -259,7 +259,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -268,7 +268,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -279,9 +279,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -298,8 +298,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -308,7 +308,7 @@
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "2.0.4"
+                                "is-plain-object": "^2.0.4"
                             }
                         }
                     }
@@ -319,14 +319,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -335,7 +335,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -344,7 +344,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -355,10 +355,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -367,7 +367,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -378,7 +378,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -387,7 +387,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -396,9 +396,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -407,7 +407,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -416,7 +416,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -439,19 +439,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -462,7 +462,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "archy": {
@@ -477,7 +477,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -494,8 +494,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-filter": {
@@ -504,7 +504,7 @@
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.1"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-flatten": {
@@ -519,7 +519,7 @@
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.1"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-union": {
@@ -546,8 +546,8 @@
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
             "dev": true,
             "requires": {
-                "array-slice": "1.1.0",
-                "is-number": "4.0.0"
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "array-slice": {
@@ -570,7 +570,7 @@
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -593,9 +593,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "1.0.0",
-                "get-value": "2.0.6",
-                "kind-of": "5.1.0"
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -612,7 +612,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -639,14 +639,8 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
-        },
-        "assert-plus": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -665,10 +659,10 @@
             "integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0",
-                "process-nextick-args": "1.0.7",
-                "stream-exhaust": "1.0.2"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^1.0.7",
+                "stream-exhaust": "^1.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -691,7 +685,7 @@
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
             "dev": true,
             "requires": {
-                "async-done": "1.3.1"
+                "async-done": "^1.2.2"
             }
         },
         "asynckit": {
@@ -706,12 +700,6 @@
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
         },
-        "aws-sign2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-            "dev": true
-        },
         "aws4": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
@@ -724,15 +712,15 @@
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
             "dev": true,
             "requires": {
-                "arr-filter": "1.1.2",
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "array-each": "1.0.1",
-                "array-initial": "1.1.0",
-                "array-last": "1.3.0",
-                "async-done": "1.3.1",
-                "async-settle": "1.0.0",
-                "now-and-later": "2.0.0"
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "balanced-match": {
@@ -747,13 +735,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -762,7 +750,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -771,7 +759,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -780,7 +768,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -789,9 +777,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -815,7 +803,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -836,7 +824,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boolbase": {
@@ -845,22 +833,13 @@
             "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
             "dev": true
         },
-        "boom": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "dev": true,
-            "requires": {
-                "hoek": "2.16.3"
-            }
-        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -870,9 +849,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.3"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -911,15 +890,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -936,20 +915,14 @@
             "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
             "optional": true
         },
-        "caseless": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-            "dev": true
-        },
         "center-align": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -958,11 +931,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "cheerio": {
@@ -971,12 +944,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash": "4.17.10",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "child-process-promise": {
@@ -985,9 +958,9 @@
             "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
             "dev": true,
             "requires": {
-                "cross-spawn": "4.0.2",
-                "node-version": "1.2.0",
-                "promise-polyfill": "6.1.0"
+                "cross-spawn": "^4.0.2",
+                "node-version": "^1.0.0",
+                "promise-polyfill": "^6.0.1"
             }
         },
         "chokidar": {
@@ -996,19 +969,19 @@
             "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.2",
-                "fsevents": "1.2.4",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "lodash.debounce": "4.0.8",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.1.0"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.2.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
             },
             "dependencies": {
                 "array-unique": {
@@ -1023,16 +996,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     }
                 },
                 "extend-shallow": {
@@ -1041,7 +1014,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "fill-range": {
@@ -1050,10 +1023,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     }
                 },
                 "is-glob": {
@@ -1062,7 +1035,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -1071,7 +1044,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -1094,10 +1067,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "arr-union": {
@@ -1112,7 +1085,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "isobject": {
@@ -1129,8 +1102,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -1166,9 +1139,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "co": {
@@ -1189,9 +1162,9 @@
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
             "dev": true,
             "requires": {
-                "arr-map": "2.0.2",
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -1200,7 +1173,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -1211,8 +1184,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-support": {
@@ -1233,7 +1206,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -1260,10 +1233,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "convert-source-map": {
@@ -1284,8 +1257,8 @@
             "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
             "dev": true,
             "requires": {
-                "each-props": "1.3.2",
-                "is-plain-object": "2.0.4"
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
             }
         },
         "core-util-is": {
@@ -1300,17 +1273,8 @@
             "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "which": "1.3.1"
-            }
-        },
-        "cryptiles": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "dev": true,
-            "requires": {
-                "boom": "2.10.1"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             }
         },
         "css": {
@@ -1319,10 +1283,10 @@
             "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "source-map": "0.1.43",
-                "source-map-resolve": "0.5.2",
-                "urix": "0.1.0"
+                "inherits": "^2.0.1",
+                "source-map": "^0.1.38",
+                "source-map-resolve": "^0.5.1",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -1331,7 +1295,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -1342,10 +1306,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-what": {
@@ -1360,7 +1324,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.46"
+                "es5-ext": "^0.10.9"
             }
         },
         "dashdash": {
@@ -1369,7 +1333,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1401,9 +1365,9 @@
             "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "memoizee": "0.4.14",
-                "object-assign": "4.1.1"
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
             }
         },
         "decamelize": {
@@ -1423,7 +1387,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "default-compare": {
@@ -1432,7 +1396,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "5.1.0"
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1455,7 +1419,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "1.0.12"
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -1464,8 +1428,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -1474,7 +1438,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1483,7 +1447,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1492,9 +1456,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -1517,12 +1481,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -1561,8 +1525,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1585,7 +1549,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1594,8 +1558,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -1610,7 +1574,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -1625,10 +1589,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1645,10 +1609,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "each-props": {
@@ -1657,8 +1621,8 @@
             "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
             "dev": true,
             "requires": {
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0"
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -1668,8 +1632,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -1678,7 +1642,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "entities": {
@@ -1693,7 +1657,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es5-ext": {
@@ -1702,9 +1666,9 @@
             "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1",
-                "next-tick": "1.0.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
             }
         },
         "es6-iterator": {
@@ -1713,9 +1677,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.46",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-symbol": {
@@ -1724,8 +1688,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.46"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-weak-map": {
@@ -1734,10 +1698,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.46",
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-string-regexp": {
@@ -1752,8 +1716,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.46"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "event-stream": {
@@ -1762,13 +1726,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -1777,7 +1741,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -1786,7 +1750,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "expand-tilde": {
@@ -1795,7 +1759,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
@@ -1810,7 +1774,7 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -1827,7 +1791,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -1850,9 +1814,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -1873,7 +1837,7 @@
             "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -1888,11 +1852,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.1.0",
-                "repeat-element": "1.1.3",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "find-up": {
@@ -1901,8 +1865,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -1911,10 +1875,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1935,16 +1899,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1953,7 +1917,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1973,13 +1937,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1988,7 +1952,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -1997,7 +1961,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -2006,7 +1970,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -2015,7 +1979,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -2026,7 +1990,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -2035,7 +1999,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -2046,9 +2010,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -2065,8 +2029,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -2075,7 +2039,7 @@
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "2.0.4"
+                                "is-plain-object": "^2.0.4"
                             }
                         }
                     }
@@ -2086,14 +2050,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -2102,7 +2066,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -2111,7 +2075,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -2122,10 +2086,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -2134,7 +2098,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -2145,7 +2109,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -2154,7 +2118,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -2163,9 +2127,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -2174,7 +2138,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2183,7 +2147,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2206,19 +2170,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -2229,11 +2193,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -2254,8 +2218,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "for-in": {
@@ -2270,7 +2234,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -2279,24 +2243,13 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
             "dev": true
         },
-        "form-data": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-            "dev": true,
-            "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.19"
-            }
-        },
         "fragment-cache": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -2310,9 +2263,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -2321,8 +2274,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "through2": "2.0.3"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -2338,8 +2291,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.10.0"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -2365,8 +2318,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -2379,7 +2332,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2443,7 +2396,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -2458,14 +2411,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -2474,12 +2427,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -2494,7 +2447,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -2503,7 +2456,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -2512,8 +2465,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2532,7 +2485,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -2546,7 +2499,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2559,8 +2512,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -2569,7 +2522,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -2592,9 +2545,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2603,16 +2556,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -2621,8 +2574,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -2637,8 +2590,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -2647,10 +2600,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2669,7 +2622,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2690,8 +2643,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2712,10 +2665,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2732,13 +2685,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -2747,7 +2700,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2790,9 +2743,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -2801,7 +2754,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -2809,7 +2762,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2824,13 +2777,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2845,7 +2798,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2866,10 +2819,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -2877,21 +2830,6 @@
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
-        },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-            "dev": true
-        },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "1.0.2"
-            }
         },
         "get-caller-file": {
             "version": "1.0.3",
@@ -2911,7 +2849,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2928,12 +2866,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2942,8 +2880,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -2952,7 +2890,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2967,7 +2905,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2978,8 +2916,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -2988,14 +2926,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.2",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -3004,11 +2942,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -3023,10 +2961,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3041,8 +2979,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -3053,10 +2991,10 @@
             "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "dev": true,
             "requires": {
-                "async-done": "1.3.1",
-                "chokidar": "2.0.4",
-                "just-debounce": "1.0.0",
-                "object.defaults": "1.1.0"
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -3065,9 +3003,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -3076,11 +3014,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.1"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -3089,11 +3027,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -3110,7 +3048,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -3130,10 +3068,10 @@
             "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "dev": true,
             "requires": {
-                "glob-watcher": "5.0.1",
-                "gulp-cli": "2.0.1",
-                "undertaker": "1.2.0",
-                "vinyl-fs": "3.0.3"
+                "glob-watcher": "^5.0.0",
+                "gulp-cli": "^2.0.0",
+                "undertaker": "^1.0.0",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -3148,9 +3086,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "clone": {
@@ -3171,16 +3109,16 @@
                     "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.2",
-                        "glob": "7.1.2",
-                        "glob-parent": "3.1.0",
-                        "is-negated-glob": "1.0.0",
-                        "ordered-read-streams": "1.0.1",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-trailing-separator": "1.1.0",
-                        "to-absolute-glob": "2.0.2",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^7.1.1",
+                        "glob-parent": "^3.1.0",
+                        "is-negated-glob": "^1.0.0",
+                        "ordered-read-streams": "^1.0.0",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.1.5",
+                        "remove-trailing-separator": "^1.0.1",
+                        "to-absolute-glob": "^2.0.0",
+                        "unique-stream": "^2.0.2"
                     }
                 },
                 "gulp-cli": {
@@ -3189,24 +3127,24 @@
                     "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "archy": "1.0.0",
-                        "array-sort": "1.0.0",
-                        "color-support": "1.1.3",
-                        "concat-stream": "1.6.2",
-                        "copy-props": "2.0.4",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "interpret": "1.1.0",
-                        "isobject": "3.0.1",
-                        "liftoff": "2.5.0",
-                        "matchdep": "2.0.0",
-                        "mute-stdout": "1.0.1",
-                        "pretty-hrtime": "1.0.3",
-                        "replace-homedir": "1.0.0",
-                        "semver-greatest-satisfied-range": "1.1.0",
-                        "v8flags": "3.1.1",
-                        "yargs": "7.1.0"
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^2.5.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3227,7 +3165,7 @@
                     "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.3.6"
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "to-absolute-glob": {
@@ -3236,8 +3174,8 @@
                     "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
                     "dev": true,
                     "requires": {
-                        "is-absolute": "1.0.0",
-                        "is-negated-glob": "1.0.0"
+                        "is-absolute": "^1.0.0",
+                        "is-negated-glob": "^1.0.0"
                     }
                 },
                 "vinyl": {
@@ -3246,12 +3184,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 },
                 "vinyl-fs": {
@@ -3260,23 +3198,23 @@
                     "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
                     "dev": true,
                     "requires": {
-                        "fs-mkdirp-stream": "1.0.0",
-                        "glob-stream": "6.1.0",
-                        "graceful-fs": "4.1.11",
-                        "is-valid-glob": "1.0.0",
-                        "lazystream": "1.0.0",
-                        "lead": "1.0.0",
-                        "object.assign": "4.1.0",
-                        "pumpify": "1.5.1",
-                        "readable-stream": "2.3.6",
-                        "remove-bom-buffer": "3.0.0",
-                        "remove-bom-stream": "1.2.0",
-                        "resolve-options": "1.1.0",
-                        "through2": "2.0.3",
-                        "to-through": "2.0.0",
-                        "value-or-function": "3.0.0",
-                        "vinyl": "2.2.0",
-                        "vinyl-sourcemap": "1.1.0"
+                        "fs-mkdirp-stream": "^1.0.0",
+                        "glob-stream": "^6.1.0",
+                        "graceful-fs": "^4.0.0",
+                        "is-valid-glob": "^1.0.0",
+                        "lazystream": "^1.0.0",
+                        "lead": "^1.0.0",
+                        "object.assign": "^4.0.4",
+                        "pumpify": "^1.3.5",
+                        "readable-stream": "^2.3.3",
+                        "remove-bom-buffer": "^3.0.0",
+                        "remove-bom-stream": "^1.2.0",
+                        "resolve-options": "^1.1.0",
+                        "through2": "^2.0.0",
+                        "to-through": "^2.0.0",
+                        "value-or-function": "^3.0.0",
+                        "vinyl": "^2.0.0",
+                        "vinyl-sourcemap": "^1.1.0"
                     }
                 },
                 "yargs": {
@@ -3285,19 +3223,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 }
             }
@@ -3308,9 +3246,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-color": {
@@ -3325,9 +3263,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -3336,8 +3274,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -3352,10 +3290,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3370,78 +3308,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-remote-src": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
-            "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "clone-stats": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "2.79.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.3.2"
-                    }
-                },
-                "vinyl": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
-                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -3452,11 +3320,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.88.0",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -3477,12 +3345,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -3493,17 +3361,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.0.2",
-                "@gulp-sourcemaps/map-sources": "1.0.0",
-                "acorn": "5.7.1",
-                "convert-source-map": "1.5.1",
-                "css": "2.2.3",
-                "debug-fabulous": "1.1.0",
-                "detect-newline": "2.1.0",
-                "graceful-fs": "4.1.11",
-                "source-map": "0.6.1",
-                "strip-bom-string": "1.0.0",
-                "through2": "2.0.3"
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
             },
             "dependencies": {
                 "source-map": {
@@ -3520,10 +3388,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-tslint": {
@@ -3532,9 +3400,9 @@
             "integrity": "sha1-cq02j0JEXyqs+v0vd/oZFm7eeVg=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "map-stream": "0.1.0",
-                "through": "2.3.8"
+                "gulp-util": "~3.0.7",
+                "map-stream": "~0.1.0",
+                "through": "~2.3.8"
             }
         },
         "gulp-typescript": {
@@ -3543,10 +3411,10 @@
             "integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "source-map": "0.5.7",
-                "through2": "2.0.3",
-                "vinyl-fs": "2.4.4"
+                "gulp-util": "~3.0.7",
+                "source-map": "~0.5.3",
+                "through2": "~2.0.1",
+                "vinyl-fs": "~2.4.3"
             },
             "dependencies": {
                 "source-map": {
@@ -3563,11 +3431,11 @@
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -3576,24 +3444,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -3626,8 +3494,8 @@
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -3639,13 +3507,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.5.0",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
@@ -3666,7 +3534,7 @@
                     "integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "vinyl": {
@@ -3675,12 +3543,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -3691,7 +3559,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "handlebars": {
@@ -3699,10 +3567,10 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             }
         },
         "har-schema": {
@@ -3711,25 +3579,13 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
             "dev": true
         },
-        "har-validator": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-            "dev": true,
-            "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.17.1",
-                "is-my-json-valid": "2.19.0",
-                "pinkie-promise": "2.0.1"
-            }
-        },
         "has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -3744,7 +3600,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -3759,9 +3615,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -3778,8 +3634,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -3788,7 +3644,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -3797,7 +3653,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -3808,21 +3664,9 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
-            }
-        },
-        "hawk": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "dev": true,
-            "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
             }
         },
         "he": {
@@ -3831,19 +3675,13 @@
             "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
             "dev": true
         },
-        "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-            "dev": true
-        },
         "homedir-polyfill": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -3858,23 +3696,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.5.1",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
-            }
-        },
-        "http-signature": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-            "dev": true,
-            "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "inflight": {
@@ -3883,8 +3710,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -3923,8 +3750,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -3933,7 +3760,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-arrayish": {
@@ -3948,7 +3775,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -3962,7 +3789,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -3971,7 +3798,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-descriptor": {
@@ -3980,9 +3807,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4005,7 +3832,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -4026,7 +3853,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -4035,26 +3862,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
-            }
-        },
-        "is-my-ip-valid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
-            "dev": true
-        },
-        "is-my-json-valid": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-            "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
-            "dev": true,
-            "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-negated-glob": {
@@ -4069,7 +3877,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -4090,7 +3898,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -4099,7 +3907,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -4108,7 +3916,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -4137,19 +3945,13 @@
             "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
             "dev": true
         },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-            "dev": true
-        },
         "is-relative": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-stream": {
@@ -4170,7 +3972,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -4243,7 +4045,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -4257,19 +4059,13 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
-        },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
             "dev": true
         },
         "jsprim": {
@@ -4303,7 +4099,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "last-run": {
@@ -4312,8 +4108,8 @@
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
             "dev": true,
             "requires": {
-                "default-resolution": "2.0.0",
-                "es6-weak-map": "2.0.2"
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
             }
         },
         "lazy-cache": {
@@ -4328,7 +4124,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -4337,7 +4133,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "lead": {
@@ -4346,7 +4142,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.3"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "liftoff": {
@@ -4355,14 +4151,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.2",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.8.1"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "linkify-it": {
@@ -4371,7 +4167,7 @@
             "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
             "dev": true,
             "requires": {
-                "uc.micro": "1.0.5"
+                "uc.micro": "^1.0.1"
             }
         },
         "load-json-file": {
@@ -4380,11 +4176,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -4467,7 +4263,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -4494,9 +4290,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -4511,15 +4307,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -4528,8 +4324,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "longest": {
@@ -4543,8 +4339,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -4553,7 +4349,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.46"
+                "es5-ext": "~0.10.2"
             }
         },
         "make-dir": {
@@ -4562,7 +4358,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-iterator": {
@@ -4571,7 +4367,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4600,7 +4396,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-it": {
@@ -4609,11 +4405,11 @@
             "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "entities": "1.1.1",
-                "linkify-it": "2.0.3",
-                "mdurl": "1.0.1",
-                "uc.micro": "1.0.5"
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
             }
         },
         "matchdep": {
@@ -4622,9 +4418,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "2.0.0",
-                "micromatch": "3.1.10",
-                "resolve": "1.8.1",
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
                 "stack-trace": "0.0.10"
             },
             "dependencies": {
@@ -4646,16 +4442,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.3",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4664,7 +4460,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4684,13 +4480,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4699,7 +4495,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -4708,7 +4504,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -4717,7 +4513,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4726,7 +4522,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4737,7 +4533,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -4746,7 +4542,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -4757,9 +4553,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -4776,8 +4572,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     },
                     "dependencies": {
                         "is-extendable": {
@@ -4786,7 +4582,7 @@
                             "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                             "dev": true,
                             "requires": {
-                                "is-plain-object": "2.0.4"
+                                "is-plain-object": "^2.0.4"
                             }
                         }
                     }
@@ -4797,14 +4593,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -4813,7 +4609,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -4822,7 +4618,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4833,10 +4629,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -4845,7 +4641,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -4856,7 +4652,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4865,7 +4661,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4874,9 +4670,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -4885,7 +4681,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4894,7 +4690,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -4917,19 +4713,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -4952,14 +4748,14 @@
             "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.46",
-                "es6-weak-map": "2.0.2",
-                "event-emitter": "0.3.5",
-                "is-promise": "2.1.0",
-                "lru-queue": "0.1.0",
-                "next-tick": "1.0.0",
-                "timers-ext": "0.1.5"
+                "d": "1",
+                "es5-ext": "^0.10.45",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.5"
             }
         },
         "merge-stream": {
@@ -4968,7 +4764,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -4977,19 +4773,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -4998,7 +4794,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "is-extglob": {
@@ -5013,7 +4809,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -5036,7 +4832,7 @@
             "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
             "dev": true,
             "requires": {
-                "mime-db": "1.35.0"
+                "mime-db": "~1.35.0"
             }
         },
         "minimatch": {
@@ -5045,7 +4841,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -5059,8 +4855,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5069,7 +4865,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5121,7 +4917,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -5138,10 +4934,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -5178,17 +4974,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -5209,8 +5005,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -5219,7 +5015,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 },
                 "kind-of": {
@@ -5248,7 +5044,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-package-data": {
@@ -5257,10 +5053,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.1",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -5269,7 +5065,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "now-and-later": {
@@ -5278,7 +5074,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "nth-check": {
@@ -5287,19 +5083,13 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
-        "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
             "dev": true
         },
         "object-assign": {
@@ -5314,9 +5104,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -5325,7 +5115,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -5342,7 +5132,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -5359,10 +5149,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.3",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.12"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -5371,10 +5161,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "array-slice": {
@@ -5389,7 +5179,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "isobject": {
@@ -5406,8 +5196,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -5416,7 +5206,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -5427,8 +5217,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -5437,7 +5227,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -5454,8 +5244,8 @@
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -5464,7 +5254,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -5475,7 +5265,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "optimist": {
@@ -5483,8 +5273,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "ordered-read-streams": {
@@ -5493,8 +5283,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.6"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "os-homedir": {
@@ -5509,7 +5299,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -5524,8 +5314,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-map": {
@@ -5540,9 +5330,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -5551,10 +5341,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -5569,7 +5359,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -5580,7 +5370,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.2"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -5595,7 +5385,7 @@
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
-                "semver": "5.5.1"
+                "semver": "^5.1.0"
             }
         },
         "parse5": {
@@ -5604,7 +5394,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.69"
+                "@types/node": "*"
             }
         },
         "pascalcase": {
@@ -5625,7 +5415,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -5652,7 +5442,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -5667,9 +5457,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5686,7 +5476,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -5719,7 +5509,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -5728,11 +5518,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
         },
         "posix-character-classes": {
@@ -5789,8 +5579,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -5799,21 +5589,15 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-            "dev": true
-        },
-        "qs": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
             "dev": true
         },
         "querystringify": {
@@ -5828,7 +5612,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -5837,9 +5621,9 @@
             "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -5862,7 +5646,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -5871,9 +5655,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -5882,8 +5666,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -5892,13 +5676,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -5907,10 +5691,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -5919,7 +5703,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.8.1"
+                "resolve": "^1.1.6"
             }
         },
         "regex-cache": {
@@ -5928,7 +5712,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -5937,8 +5721,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5947,8 +5731,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -5957,7 +5741,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5968,8 +5752,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -5978,9 +5762,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.2",
-                "through2": "2.0.3"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -6012,9 +5796,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "is-absolute": "1.0.0",
-                "remove-trailing-separator": "1.1.0"
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
             }
         },
         "request": {
@@ -6023,26 +5807,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.1.0",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.19",
-                "oauth-sign": "0.9.0",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.4.3",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6069,9 +5853,9 @@
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.19"
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-validator": {
@@ -6080,8 +5864,8 @@
                     "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.3.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "http-signature": {
@@ -6090,9 +5874,9 @@
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.2"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "oauth-sign": {
@@ -6113,8 +5897,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "1.1.29",
-                        "punycode": "1.4.1"
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -6123,7 +5907,7 @@
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -6152,7 +5936,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -6161,8 +5945,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-options": {
@@ -6171,7 +5955,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -6192,7 +5976,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -6201,7 +5985,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -6216,7 +6000,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -6237,7 +6021,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "1.5.0"
+                "sver-compat": "^1.5.0"
             }
         },
         "set-blocking": {
@@ -6258,10 +6042,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6270,7 +6054,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6281,11 +6065,11 @@
             "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
             "dev": true,
             "requires": {
-                "should-equal": "2.0.0",
-                "should-format": "3.0.3",
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0",
-                "should-util": "1.0.0"
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
             }
         },
         "should-equal": {
@@ -6294,7 +6078,7 @@
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0"
+                "should-type": "^1.4.0"
             }
         },
         "should-format": {
@@ -6303,8 +6087,8 @@
             "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0"
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
             }
         },
         "should-type": {
@@ -6319,8 +6103,8 @@
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-util": "1.0.0"
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
             }
         },
         "should-util": {
@@ -6335,14 +6119,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -6360,7 +6144,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -6369,7 +6153,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "source-map": {
@@ -6386,9 +6170,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -6397,7 +6181,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6406,7 +6190,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -6415,7 +6199,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -6424,9 +6208,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -6449,16 +6233,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
-            }
-        },
-        "sntp": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "dev": true,
-            "requires": {
-                "hoek": "2.16.3"
+                "kind-of": "^3.2.0"
             }
         },
         "source-map": {
@@ -6466,7 +6241,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
         },
         "source-map-resolve": {
@@ -6475,11 +6250,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -6488,8 +6263,8 @@
             "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6518,8 +6293,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -6534,8 +6309,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -6550,7 +6325,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -6559,7 +6334,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6568,8 +6343,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -6578,7 +6353,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -6590,23 +6365,24 @@
             "dev": true
         },
         "sqlops": {
-            "version": "github:anthonydresser/sqlops-extension-sqlops#dac501bbaa03a25239c060c6371dfdcf06707599",
+            "version": "github:anthonydresser/sqlops-extension-sqlops#439a29228eb8f4cd0109ab538e84f0b548c5f054",
+            "from": "github:anthonydresser/sqlops-extension-sqlops",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.88.0",
-                "semver": "5.5.1",
-                "source-map-support": "0.5.9",
-                "url-parse": "1.4.3",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "sshpk": {
@@ -6615,15 +6391,15 @@
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6652,8 +6428,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6662,7 +6438,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -6673,7 +6449,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-exhaust": {
@@ -6694,7 +6470,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -6709,9 +6485,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -6720,14 +6496,8 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
-        },
-        "stringstream": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-            "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -6735,7 +6505,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -6744,7 +6514,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -6753,8 +6523,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-bom-string": {
@@ -6775,8 +6545,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "tar": {
@@ -6785,9 +6555,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "temp-dir": {
@@ -6802,12 +6572,12 @@
             "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "is-stream": "1.1.0",
-                "make-dir": "1.3.0",
-                "pify": "3.0.0",
-                "temp-dir": "1.0.0",
-                "uuid": "3.3.2"
+                "graceful-fs": "^4.1.2",
+                "is-stream": "^1.1.0",
+                "make-dir": "^1.0.0",
+                "pify": "^3.0.0",
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.0.1"
             }
         },
         "through": {
@@ -6822,8 +6592,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -6832,8 +6602,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -6848,8 +6618,8 @@
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.46",
-                "next-tick": "1.0.0"
+                "es5-ext": "~0.10.14",
+                "next-tick": "1"
             }
         },
         "tmp": {
@@ -6858,7 +6628,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -6867,7 +6637,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6876,7 +6646,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6887,7 +6657,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -6896,10 +6666,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6908,8 +6678,8 @@
                     "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
                     "dev": true,
                     "requires": {
-                        "assign-symbols": "1.0.0",
-                        "is-extendable": "1.0.1"
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
                     }
                 },
                 "is-extendable": {
@@ -6918,7 +6688,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -6929,8 +6699,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -6939,7 +6709,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -6950,16 +6720,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
-            }
-        },
-        "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-            "dev": true,
-            "requires": {
-                "punycode": "1.4.1"
+                "through2": "^2.0.3"
             }
         },
         "tslint": {
@@ -6968,13 +6729,13 @@
             "integrity": "sha1-2hZcqT2P3CwIa1EWXuG6y0jJjqU=",
             "dev": true,
             "requires": {
-                "colors": "1.3.2",
-                "diff": "2.2.3",
-                "findup-sync": "0.3.0",
-                "glob": "7.1.2",
-                "optimist": "0.6.1",
-                "resolve": "1.8.1",
-                "underscore.string": "3.3.4"
+                "colors": "^1.1.2",
+                "diff": "^2.2.1",
+                "findup-sync": "~0.3.0",
+                "glob": "^7.0.3",
+                "optimist": "~0.6.0",
+                "resolve": "^1.1.7",
+                "underscore.string": "^3.3.4"
             },
             "dependencies": {
                 "diff": {
@@ -6989,7 +6750,7 @@
                     "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
                     "dev": true,
                     "requires": {
-                        "glob": "5.0.15"
+                        "glob": "~5.0.0"
                     },
                     "dependencies": {
                         "glob": {
@@ -6998,11 +6759,11 @@
                             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                             "dev": true,
                             "requires": {
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.4",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         }
                     }
@@ -7013,12 +6774,6 @@
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
             "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-            "dev": true
-        },
-        "tunnel-agent": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
             "dev": true
         },
         "tweetnacl": {
@@ -7050,9 +6805,9 @@
             "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "lodash": "4.17.10",
-                "postinstall-build": "5.0.2"
+                "circular-json": "^0.3.1",
+                "lodash": "^4.17.4",
+                "postinstall-build": "^5.0.1"
             }
         },
         "typescript": {
@@ -7073,9 +6828,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -7110,8 +6865,8 @@
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
             }
         },
         "undertaker": {
@@ -7120,15 +6875,15 @@
             "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "bach": "1.2.0",
-                "collection-map": "1.0.0",
-                "es6-weak-map": "2.0.2",
-                "last-run": "1.1.1",
-                "object.defaults": "1.1.0",
-                "object.reduce": "1.0.1",
-                "undertaker-registry": "1.0.1"
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
             }
         },
         "undertaker-registry": {
@@ -7143,10 +6898,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "arr-union": {
@@ -7161,7 +6916,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -7170,10 +6925,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -7184,8 +6939,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "universalify": {
@@ -7199,8 +6954,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -7209,9 +6964,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7263,8 +7018,8 @@
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "use": {
@@ -7291,7 +7046,7 @@
             "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "vali-date": {
@@ -7306,8 +7061,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "value-or-function": {
@@ -7322,9 +7077,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -7341,8 +7096,8 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
@@ -7351,23 +7106,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.6",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -7382,11 +7137,11 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "replace-ext": {
@@ -7401,8 +7156,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7414,8 +7169,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             }
         },
         "vinyl-sourcemap": {
@@ -7424,13 +7179,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.2.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             },
             "dependencies": {
                 "clone": {
@@ -7451,12 +7206,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -7467,23 +7222,23 @@
             "integrity": "sha512-LiQjHdoaXOHKdk/PRN5OWWeEm/4w7tnFLf8EM+pzvlz/8uk7uJiqtMjVYAYawnU7c8KbMSz9nE9M6nCTV4ZSQA==",
             "dev": true,
             "requires": {
-                "cheerio": "1.0.0-rc.2",
-                "commander": "2.17.1",
-                "denodeify": "1.2.1",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "markdown-it": "8.4.2",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "osenv": "0.1.5",
-                "parse-semver": "1.1.1",
-                "read": "1.0.7",
-                "semver": "5.5.1",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^2.8.1",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "lodash": "^4.15.0",
+                "markdown-it": "^8.3.1",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
                 "tmp": "0.0.29",
-                "url-join": "1.1.0",
-                "vso-node-api": "6.5.0",
-                "yauzl": "2.10.0",
-                "yazl": "2.4.3"
+                "url-join": "^1.1.0",
+                "vso-node-api": "^6.1.2-preview",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
             }
         },
         "vscode": {
@@ -7492,20 +7247,20 @@
             "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.88.0",
-                "semver": "5.5.1",
-                "source-map-support": "0.5.9",
-                "url-parse": "1.4.3",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -7520,11 +7275,11 @@
                     "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
                     "dev": true,
                     "requires": {
-                        "event-stream": "3.3.4",
-                        "streamifier": "0.1.1",
-                        "tar": "2.2.1",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "event-stream": "~3.3.4",
+                        "streamifier": "~0.1.1",
+                        "tar": "^2.2.1",
+                        "through2": "~2.0.3",
+                        "vinyl": "^1.2.0"
                     }
                 },
                 "replace-ext": {
@@ -7539,8 +7294,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7558,7 +7313,7 @@
             "dev": true,
             "requires": {
                 "tunnel": "0.0.4",
-                "typed-rest-client": "0.12.0",
+                "typed-rest-client": "^0.12.0",
                 "underscore": "1.8.3"
             }
         },
@@ -7568,7 +7323,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -7594,8 +7349,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -7628,9 +7383,9 @@
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "optional": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             }
         },
@@ -7640,7 +7395,7 @@
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7657,8 +7412,8 @@
             "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.1.0"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
@@ -7667,7 +7422,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/samples/serverReports/package-lock.json
+++ b/samples/serverReports/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "server-report",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -10,11 +10,11 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "css": "2.2.1",
-                "normalize-path": "2.1.1",
-                "source-map": "0.5.7",
-                "through2": "2.0.3"
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.5.6",
+                "through2": "^2.0.3"
             },
             "dependencies": {
                 "source-map": {
@@ -31,8 +31,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "2.1.1",
-                "through2": "2.0.3"
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
             }
         },
         "@types/handlebars": {
@@ -64,10 +64,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "align-text": {
@@ -75,9 +75,9 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -91,7 +91,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -139,8 +139,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.9",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             }
         },
         "append-buffer": {
@@ -149,7 +149,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "archy": {
@@ -164,7 +164,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -187,7 +187,7 @@
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.0"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-flatten": {
@@ -201,7 +201,7 @@
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.0"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-union": {
@@ -227,8 +227,8 @@
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
             "dev": true,
             "requires": {
-                "array-slice": "1.1.0",
-                "is-number": "4.0.0"
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -245,7 +245,7 @@
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -268,9 +268,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "1.0.0",
-                "get-value": "2.0.6",
-                "kind-of": "5.1.0"
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -286,7 +286,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -313,7 +313,8 @@
         "assert-plus": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -332,10 +333,10 @@
             "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0",
-                "process-nextick-args": "1.0.7",
-                "stream-exhaust": "1.0.2"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^1.0.7",
+                "stream-exhaust": "^1.0.1"
             }
         },
         "async-each": {
@@ -350,7 +351,7 @@
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
             "dev": true,
             "requires": {
-                "async-done": "1.2.4"
+                "async-done": "^1.2.2"
             }
         },
         "asynckit": {
@@ -367,7 +368,8 @@
         "aws-sign2": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
         },
         "aws4": {
             "version": "1.6.0",
@@ -380,15 +382,15 @@
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
             "dev": true,
             "requires": {
-                "arr-filter": "1.1.2",
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "array-each": "1.0.1",
-                "array-initial": "1.1.0",
-                "array-last": "1.3.0",
-                "async-done": "1.2.4",
-                "async-settle": "1.0.0",
-                "now-and-later": "2.0.0"
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "balanced-match": {
@@ -402,13 +404,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -417,7 +419,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -428,7 +430,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -447,7 +449,7 @@
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boolbase": {
@@ -460,8 +462,9 @@
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -469,7 +472,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -479,18 +482,18 @@
             "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "kind-of": "6.0.2",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "kind-of": "^6.0.2",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -499,7 +502,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -508,7 +511,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -547,15 +550,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "camelcase": {
@@ -567,7 +570,8 @@
         "caseless": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
         },
         "center-align": {
             "version": "0.1.3",
@@ -575,8 +579,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -584,11 +588,11 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "cheerio": {
@@ -597,12 +601,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash": "4.17.5",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "child-process-promise": {
@@ -611,9 +615,9 @@
             "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
             "dev": true,
             "requires": {
-                "cross-spawn": "4.0.2",
-                "node-version": "1.1.0",
-                "promise-polyfill": "6.1.0"
+                "cross-spawn": "^4.0.2",
+                "node-version": "^1.0.0",
+                "promise-polyfill": "^6.0.1"
             }
         },
         "chokidar": {
@@ -622,18 +626,18 @@
             "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.1",
-                "fsevents": "1.2.2",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.0.4"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             }
         },
         "circular-json": {
@@ -648,10 +652,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -660,7 +664,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -669,7 +673,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -678,7 +682,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -689,7 +693,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -698,7 +702,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -709,9 +713,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -728,8 +732,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -761,9 +765,9 @@
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.1.tgz",
             "integrity": "sha512-DNNEq6JdqBFPzS29TaoqZFPNLn5Xn3XyPFqLIhyBT8Xou4lHQEWzD6FinXoJUfhIfWX3aE1JkRa3cbWCHFbt1g==",
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -790,9 +794,9 @@
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
             "dev": true,
             "requires": {
-                "arr-map": "2.0.2",
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "collection-visit": {
@@ -801,8 +805,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-support": {
@@ -821,7 +825,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -846,9 +850,9 @@
             "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "convert-source-map": {
@@ -868,8 +872,8 @@
             "integrity": "sha1-Zl/DIEbKhKiYq6o8WUXn8kjMugA=",
             "dev": true,
             "requires": {
-                "each-props": "1.3.1",
-                "is-plain-object": "2.0.4"
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
             }
         },
         "core-util-is": {
@@ -883,16 +887,17 @@
             "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "css": {
@@ -901,10 +906,10 @@
             "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "source-map": "0.1.43",
-                "source-map-resolve": "0.3.1",
-                "urix": "0.1.0"
+                "inherits": "^2.0.1",
+                "source-map": "^0.1.38",
+                "source-map-resolve": "^0.3.0",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "atob": {
@@ -919,7 +924,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "source-map-resolve": {
@@ -928,10 +933,10 @@
                     "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
                     "dev": true,
                     "requires": {
-                        "atob": "1.1.3",
-                        "resolve-url": "0.2.1",
-                        "source-map-url": "0.3.0",
-                        "urix": "0.1.0"
+                        "atob": "~1.1.0",
+                        "resolve-url": "~0.2.1",
+                        "source-map-url": "~0.3.0",
+                        "urix": "~0.1.0"
                     }
                 },
                 "source-map-url": {
@@ -948,10 +953,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-what": {
@@ -966,7 +971,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.40"
+                "es5-ext": "^0.10.9"
             }
         },
         "dashdash": {
@@ -974,7 +979,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1004,9 +1009,9 @@
             "integrity": "sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "memoizee": "0.4.12",
-                "object-assign": "4.1.1"
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
             },
             "dependencies": {
                 "debug": {
@@ -1036,7 +1041,7 @@
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "default-compare": {
@@ -1045,7 +1050,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "5.1.0"
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1068,8 +1073,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -1078,8 +1083,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             }
         },
         "del": {
@@ -1088,12 +1093,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -1130,8 +1135,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1154,7 +1159,7 @@
             "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1163,8 +1168,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -1177,7 +1182,7 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -1190,10 +1195,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1208,10 +1213,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
             "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "each-props": {
@@ -1220,8 +1225,8 @@
             "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
             "dev": true,
             "requires": {
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0"
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -1230,7 +1235,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -1238,7 +1243,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "entities": {
@@ -1253,7 +1258,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es5-ext": {
@@ -1262,8 +1267,8 @@
             "integrity": "sha512-S9Fh3oya5OOvYSNGvPZJ+vyrs6VYpe1IXPowVe3N1OhaiwVaGlwfn3Zf5P5klYcWOA0toIwYQW8XEv/QqhdHvQ==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1"
             }
         },
         "es6-iterator": {
@@ -1272,9 +1277,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-symbol": {
@@ -1283,8 +1288,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-weak-map": {
@@ -1293,10 +1298,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40",
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-string-regexp": {
@@ -1310,8 +1315,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "event-stream": {
@@ -1319,13 +1324,13 @@
             "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -1334,13 +1339,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1349,7 +1354,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1358,7 +1363,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1367,7 +1372,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1376,7 +1381,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1387,7 +1392,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1396,7 +1401,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1407,9 +1412,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -1425,7 +1430,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -1433,11 +1438,11 @@
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                     "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^1.1.3",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -1445,7 +1450,7 @@
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -1464,7 +1469,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
@@ -1478,8 +1483,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1488,7 +1493,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1499,14 +1504,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1515,7 +1520,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -1524,7 +1529,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1539,9 +1544,9 @@
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -1559,7 +1564,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -1573,10 +1578,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1585,7 +1590,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1596,8 +1601,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -1606,10 +1611,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.9",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "is-glob": {
@@ -1618,7 +1623,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -1629,11 +1634,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -1653,8 +1658,8 @@
             "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "for-in": {
@@ -1668,7 +1673,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -1686,10 +1691,11 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -1698,7 +1704,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -1711,9 +1717,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -1722,8 +1728,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "through2": "2.0.3"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -1738,8 +1744,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.9.1"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.9.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1765,8 +1771,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -1779,7 +1785,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1843,7 +1849,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -1858,14 +1864,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -1874,12 +1880,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -1894,7 +1900,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -1903,7 +1909,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -1912,8 +1918,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -1932,7 +1938,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -1946,7 +1952,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -1959,8 +1965,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -1969,7 +1975,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -1992,9 +1998,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -2003,16 +2009,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.6",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -2021,8 +2027,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -2037,8 +2043,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -2047,10 +2053,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2069,7 +2075,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2090,8 +2096,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2112,10 +2118,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2132,13 +2138,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -2147,7 +2153,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2190,9 +2196,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -2201,7 +2207,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -2209,7 +2215,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2224,13 +2230,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -2245,7 +2251,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2265,10 +2271,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -2280,14 +2286,16 @@
         "generate-function": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
         },
         "generate-object-property": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -2307,7 +2315,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2322,12 +2330,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2335,8 +2343,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -2344,7 +2352,7 @@
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2357,7 +2365,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2367,8 +2375,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -2376,7 +2384,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2387,16 +2395,16 @@
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "7.1.2",
-                "glob-parent": "3.1.0",
-                "is-negated-glob": "1.0.0",
-                "ordered-read-streams": "1.0.1",
-                "pumpify": "1.4.0",
-                "readable-stream": "2.3.5",
-                "remove-trailing-separator": "1.1.0",
-                "to-absolute-glob": "2.0.2",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
@@ -2405,10 +2413,10 @@
             "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "dev": true,
             "requires": {
-                "async-done": "1.2.4",
-                "chokidar": "2.0.2",
-                "just-debounce": "1.0.0",
-                "object.defaults": "1.1.0"
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2417,9 +2425,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -2428,11 +2436,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.0"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -2441,11 +2449,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -2461,7 +2469,7 @@
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -2480,10 +2488,10 @@
             "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "dev": true,
             "requires": {
-                "glob-watcher": "5.0.1",
-                "gulp-cli": "2.0.1",
-                "undertaker": "1.2.0",
-                "vinyl-fs": "3.0.2"
+                "glob-watcher": "^5.0.0",
+                "gulp-cli": "^2.0.0",
+                "undertaker": "^1.0.0",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2498,9 +2506,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "gulp-cli": {
@@ -2509,24 +2517,24 @@
                     "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "archy": "1.0.0",
-                        "array-sort": "1.0.0",
-                        "color-support": "1.1.3",
-                        "concat-stream": "1.6.1",
-                        "copy-props": "2.0.1",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "interpret": "1.1.0",
-                        "isobject": "3.0.1",
-                        "liftoff": "2.5.0",
-                        "matchdep": "2.0.0",
-                        "mute-stdout": "1.0.0",
-                        "pretty-hrtime": "1.0.3",
-                        "replace-homedir": "1.0.0",
-                        "semver-greatest-satisfied-range": "1.1.0",
-                        "v8flags": "3.0.2",
-                        "yargs": "7.1.0"
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^2.5.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
                     }
                 },
                 "yargs": {
@@ -2535,19 +2543,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 }
             }
@@ -2557,9 +2565,9 @@
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-color": {
@@ -2573,9 +2581,9 @@
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -2583,8 +2591,8 @@
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -2607,10 +2615,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -2623,8 +2631,8 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -2632,8 +2640,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -2642,60 +2650,76 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
             "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+            "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "~3.3.4",
+                "node.extend": "~1.1.2",
+                "request": "~2.79.0",
+                "through2": "~2.0.3",
+                "vinyl": "~2.0.1"
             },
             "dependencies": {
                 "clone": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
                 },
                 "request": {
                     "version": "2.79.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.18",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.2.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "vinyl": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.1",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^1.0.0",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "is-stream": "^1.1.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
+            }
+        },
+        "gulp-remote-src-vscode": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
+            "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
+            "requires": {
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             }
         },
         "gulp-sourcemaps": {
@@ -2704,17 +2728,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.0.1",
-                "@gulp-sourcemaps/map-sources": "1.0.0",
-                "acorn": "5.5.3",
-                "convert-source-map": "1.5.1",
-                "css": "2.2.1",
-                "debug-fabulous": "1.0.0",
-                "detect-newline": "2.1.0",
-                "graceful-fs": "4.1.11",
-                "source-map": "0.6.1",
-                "strip-bom-string": "1.0.0",
-                "through2": "2.0.3"
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
             },
             "dependencies": {
                 "source-map": {
@@ -2730,10 +2754,10 @@
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2741,7 +2765,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -2754,9 +2778,9 @@
                     "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -2774,7 +2798,7 @@
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -2782,7 +2806,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -2790,7 +2814,7 @@
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -2798,11 +2822,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -2810,14 +2834,14 @@
                     "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -2825,10 +2849,10 @@
                             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -2836,8 +2860,8 @@
                             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -2847,11 +2871,11 @@
                     "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2864,7 +2888,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -2882,19 +2906,19 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -2902,8 +2926,8 @@
                     "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -2921,7 +2945,7 @@
                     "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl": {
@@ -2929,8 +2953,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -2939,23 +2963,23 @@
                     "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -2966,9 +2990,9 @@
             "integrity": "sha1-cq02j0JEXyqs+v0vd/oZFm7eeVg=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "map-stream": "0.1.0",
-                "through": "2.3.8"
+                "gulp-util": "~3.0.7",
+                "map-stream": "~0.1.0",
+                "through": "~2.3.8"
             }
         },
         "gulp-typescript": {
@@ -2977,10 +3001,10 @@
             "integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "source-map": "0.5.7",
-                "through2": "2.0.3",
-                "vinyl-fs": "2.4.4"
+                "gulp-util": "~3.0.7",
+                "source-map": "~0.5.3",
+                "through2": "~2.0.1",
+                "vinyl-fs": "~2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2989,7 +3013,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3004,9 +3028,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3027,7 +3051,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3036,7 +3060,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3045,7 +3069,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3054,11 +3078,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3067,14 +3091,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3083,10 +3107,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3095,8 +3119,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3107,11 +3131,11 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -3126,7 +3150,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3147,19 +3171,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3168,8 +3192,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -3196,7 +3220,7 @@
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl": {
@@ -3205,8 +3229,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -3216,23 +3240,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -3242,11 +3266,11 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -3254,24 +3278,24 @@
             "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -3304,8 +3328,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -3316,13 +3340,13 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3330,7 +3354,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3343,9 +3367,9 @@
                     "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3363,7 +3387,7 @@
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3371,7 +3395,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3379,7 +3403,7 @@
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3387,11 +3411,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3399,14 +3423,14 @@
                     "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3414,10 +3438,10 @@
                             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3425,8 +3449,8 @@
                             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3436,11 +3460,11 @@
                     "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     },
                     "dependencies": {
                         "vinyl": {
@@ -3448,8 +3472,8 @@
                             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                             "requires": {
-                                "clone": "1.0.3",
-                                "clone-stats": "0.0.1",
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
                                 "replace-ext": "0.0.1"
                             }
                         }
@@ -3465,7 +3489,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3483,19 +3507,19 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3503,8 +3527,8 @@
                     "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "queue": {
@@ -3512,7 +3536,7 @@
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "replace-ext": {
@@ -3530,7 +3554,7 @@
                     "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl-fs": {
@@ -3538,23 +3562,23 @@
                     "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     },
                     "dependencies": {
                         "vinyl": {
@@ -3562,8 +3586,8 @@
                             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                             "requires": {
-                                "clone": "1.0.3",
-                                "clone-stats": "0.0.1",
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
                                 "replace-ext": "0.0.1"
                             }
                         }
@@ -3576,7 +3600,7 @@
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "handlebars": {
@@ -3584,10 +3608,10 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             }
         },
         "har-schema": {
@@ -3599,11 +3623,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.11.0",
-                "is-my-json-valid": "2.17.2",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -3611,7 +3636,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -3624,7 +3649,7 @@
             "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -3639,9 +3664,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -3650,8 +3675,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3660,7 +3685,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3669,11 +3694,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -3684,7 +3710,8 @@
         "hoek": {
             "version": "2.16.3",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
         },
         "homedir-polyfill": {
             "version": "1.0.1",
@@ -3692,7 +3719,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -3707,22 +3734,23 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.1",
-                "domutils": "1.5.1",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-signature": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -3730,8 +3758,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -3768,8 +3796,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -3778,7 +3806,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3801,7 +3829,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -3815,7 +3843,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -3824,7 +3852,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3841,9 +3869,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3864,7 +3892,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -3883,7 +3911,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -3892,24 +3920,26 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-my-ip-valid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+            "dev": true
         },
         "is-my-json-valid": {
             "version": "2.17.2",
             "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
             "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+            "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-negated-glob": {
@@ -3923,7 +3953,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -3937,7 +3967,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -3960,7 +3990,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -3969,7 +3999,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -3978,7 +4008,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -4000,7 +4030,8 @@
         "is-property": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
         },
         "is-relative": {
             "version": "1.0.0",
@@ -4008,7 +4039,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-stream": {
@@ -4027,7 +4058,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -4090,7 +4121,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -4103,7 +4134,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -4114,7 +4145,8 @@
         "jsonpointer": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
         },
         "jsprim": {
             "version": "1.4.1",
@@ -4145,7 +4177,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "last-run": {
@@ -4154,8 +4186,8 @@
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
             "dev": true,
             "requires": {
-                "default-resolution": "2.0.0",
-                "es6-weak-map": "2.0.2"
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
             }
         },
         "lazy-cache": {
@@ -4169,7 +4201,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -4178,7 +4210,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "lead": {
@@ -4187,7 +4219,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.2"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "liftoff": {
@@ -4196,14 +4228,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.5.0"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "linkify-it": {
@@ -4212,7 +4244,7 @@
             "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
             "dev": true,
             "requires": {
-                "uc.micro": "1.0.5"
+                "uc.micro": "^1.0.1"
             }
         },
         "load-json-file": {
@@ -4221,11 +4253,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -4292,7 +4324,7 @@
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -4315,9 +4347,9 @@
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -4330,15 +4362,15 @@
             "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -4346,8 +4378,8 @@
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "longest": {
@@ -4361,8 +4393,8 @@
             "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -4371,7 +4403,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.40"
+                "es5-ext": "~0.10.2"
             }
         },
         "make-dir": {
@@ -4380,7 +4412,7 @@
             "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-iterator": {
@@ -4389,7 +4421,7 @@
             "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.1.0"
             }
         },
         "map-cache": {
@@ -4409,7 +4441,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-it": {
@@ -4418,11 +4450,11 @@
             "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "entities": "1.1.1",
-                "linkify-it": "2.0.3",
-                "mdurl": "1.0.1",
-                "uc.micro": "1.0.5"
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
             }
         },
         "matchdep": {
@@ -4431,9 +4463,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "2.0.0",
-                "micromatch": "3.1.9",
-                "resolve": "1.5.0",
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
                 "stack-trace": "0.0.10"
             }
         },
@@ -4449,14 +4481,14 @@
             "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40",
-                "es6-weak-map": "2.0.2",
-                "event-emitter": "0.3.5",
-                "is-promise": "2.1.0",
-                "lru-queue": "0.1.0",
-                "next-tick": "1.0.0",
-                "timers-ext": "0.1.5"
+                "d": "1",
+                "es5-ext": "^0.10.30",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.2"
             }
         },
         "merge-stream": {
@@ -4464,7 +4496,7 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -4473,19 +4505,19 @@
             "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.1",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -4512,7 +4544,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "minimatch": {
@@ -4520,7 +4552,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -4534,8 +4566,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4544,7 +4576,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4594,7 +4626,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -4609,10 +4641,10 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -4648,18 +4680,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -4687,7 +4719,7 @@
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-package-data": {
@@ -4696,10 +4728,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -4707,7 +4739,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "now-and-later": {
@@ -4716,7 +4748,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "nth-check": {
@@ -4725,7 +4757,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "number-is-nan": {
@@ -4750,9 +4782,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -4761,7 +4793,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -4770,7 +4802,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -4779,7 +4811,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -4788,9 +4820,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -4815,7 +4847,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -4824,10 +4856,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.11"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -4836,10 +4868,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "object.map": {
@@ -4848,8 +4880,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.omit": {
@@ -4857,8 +4889,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-own": {
@@ -4866,7 +4898,7 @@
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
                     "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -4877,7 +4909,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "object.reduce": {
@@ -4886,8 +4918,8 @@
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "once": {
@@ -4895,7 +4927,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "optimist": {
@@ -4903,8 +4935,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "ordered-read-streams": {
@@ -4913,7 +4945,7 @@
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "os-homedir": {
@@ -4928,7 +4960,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -4943,8 +4975,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-map": {
@@ -4959,9 +4991,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -4969,10 +5001,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -4985,7 +5017,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -4996,7 +5028,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -5011,7 +5043,7 @@
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.1.0"
             }
         },
         "parse5": {
@@ -5020,7 +5052,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.56"
+                "@types/node": "*"
             }
         },
         "pascalcase": {
@@ -5040,7 +5072,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -5066,7 +5098,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -5081,9 +5113,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5099,7 +5131,7 @@
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -5121,14 +5153,16 @@
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -5136,11 +5170,11 @@
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -5148,8 +5182,8 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -5167,7 +5201,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -5224,8 +5258,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -5234,9 +5268,9 @@
             "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -5253,7 +5287,8 @@
         "qs": {
             "version": "6.3.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
         },
         "querystringify": {
             "version": "1.0.0",
@@ -5265,7 +5300,7 @@
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -5273,8 +5308,8 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5282,7 +5317,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5293,7 +5328,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -5302,9 +5337,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -5313,8 +5348,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -5322,13 +5357,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
             "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -5344,10 +5379,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.5",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -5356,7 +5391,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.5.0"
+                "resolve": "^1.1.6"
             }
         },
         "regex-cache": {
@@ -5364,7 +5399,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -5373,8 +5408,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "remove-bom-buffer": {
@@ -5383,8 +5418,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -5393,9 +5428,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.1",
-                "through2": "2.0.3"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -5424,9 +5459,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "is-absolute": "1.0.0",
-                "remove-trailing-separator": "1.1.0"
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
             }
         },
         "request": {
@@ -5434,28 +5469,28 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
             "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5473,7 +5508,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "caseless": {
@@ -5486,7 +5521,7 @@
                     "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -5494,7 +5529,7 @@
                             "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "requires": {
-                                "hoek": "4.2.1"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -5504,9 +5539,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-validator": {
@@ -5514,8 +5549,8 @@
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "hawk": {
@@ -5523,10 +5558,10 @@
                     "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.1",
-                        "sntp": "2.1.0"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -5539,9 +5574,9 @@
                     "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "qs": {
@@ -5554,7 +5589,7 @@
                     "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
                     "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "tunnel-agent": {
@@ -5562,7 +5597,7 @@
                     "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -5590,7 +5625,7 @@
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -5599,8 +5634,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-options": {
@@ -5609,7 +5644,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -5630,7 +5665,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -5638,7 +5673,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -5652,7 +5687,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "semver": {
@@ -5666,7 +5701,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "1.5.0"
+                "sver-compat": "^1.5.0"
             }
         },
         "set-blocking": {
@@ -5687,10 +5722,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -5699,7 +5734,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -5710,11 +5745,11 @@
             "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
             "dev": true,
             "requires": {
-                "should-equal": "2.0.0",
-                "should-format": "3.0.3",
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0",
-                "should-util": "1.0.0"
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
             }
         },
         "should-equal": {
@@ -5723,7 +5758,7 @@
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0"
+                "should-type": "^1.4.0"
             }
         },
         "should-format": {
@@ -5732,8 +5767,8 @@
             "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0"
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
             }
         },
         "should-type": {
@@ -5748,8 +5783,8 @@
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-util": "1.0.0"
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
             }
         },
         "should-util": {
@@ -5764,14 +5799,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -5780,7 +5815,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -5789,7 +5824,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5798,7 +5833,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5807,7 +5842,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5818,7 +5853,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5827,7 +5862,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5838,9 +5873,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -5863,9 +5898,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -5874,7 +5909,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -5885,15 +5920,16 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -5901,7 +5937,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
         },
         "source-map-resolve": {
@@ -5910,11 +5946,11 @@
             "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "2.0.3",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -5922,7 +5958,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
             "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -5949,8 +5985,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -5965,8 +6001,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -5980,7 +6016,7 @@
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -5989,7 +6025,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -5999,22 +6035,23 @@
             "dev": true
         },
         "sqlops": {
-            "version": "github:anthonydresser/sqlops-extension-sqlops#dac501bbaa03a25239c060c6371dfdcf06707599",
+            "version": "github:anthonydresser/sqlops-extension-sqlops#439a29228eb8f4cd0109ab538e84f0b548c5f054",
+            "from": "github:anthonydresser/sqlops-extension-sqlops",
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.3",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "sshpk": {
@@ -6022,14 +6059,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6056,8 +6093,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6066,7 +6103,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6075,7 +6112,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6084,7 +6121,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6095,7 +6132,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6104,7 +6141,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6115,9 +6152,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -6133,7 +6170,7 @@
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-exhaust": {
@@ -6152,7 +6189,7 @@
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -6166,9 +6203,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -6176,7 +6213,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -6189,7 +6226,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -6197,7 +6234,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -6205,8 +6242,8 @@
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-bom-string": {
@@ -6226,8 +6263,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "tar": {
@@ -6235,9 +6272,9 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "temp-dir": {
@@ -6252,12 +6289,12 @@
             "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "is-stream": "1.1.0",
-                "make-dir": "1.2.0",
-                "pify": "3.0.0",
-                "temp-dir": "1.0.0",
-                "uuid": "3.2.1"
+                "graceful-fs": "^4.1.2",
+                "is-stream": "^1.1.0",
+                "make-dir": "^1.0.0",
+                "pify": "^3.0.0",
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.0.1"
             }
         },
         "through": {
@@ -6270,8 +6307,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -6279,8 +6316,8 @@
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -6294,8 +6331,8 @@
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.40",
-                "next-tick": "1.0.0"
+                "es5-ext": "~0.10.14",
+                "next-tick": "1"
             }
         },
         "tmp": {
@@ -6304,7 +6341,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -6313,8 +6350,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "is-negated-glob": "1.0.0"
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-object-path": {
@@ -6323,7 +6360,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -6332,10 +6369,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -6344,8 +6381,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "to-through": {
@@ -6354,7 +6391,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
@@ -6362,7 +6399,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tslint": {
@@ -6371,13 +6408,13 @@
             "integrity": "sha1-2hZcqT2P3CwIa1EWXuG6y0jJjqU=",
             "dev": true,
             "requires": {
-                "colors": "1.2.1",
-                "diff": "2.2.3",
-                "findup-sync": "0.3.0",
-                "glob": "7.1.2",
-                "optimist": "0.6.1",
-                "resolve": "1.5.0",
-                "underscore.string": "3.3.4"
+                "colors": "^1.1.2",
+                "diff": "^2.2.1",
+                "findup-sync": "~0.3.0",
+                "glob": "^7.0.3",
+                "optimist": "~0.6.0",
+                "resolve": "^1.1.7",
+                "underscore.string": "^3.3.4"
             },
             "dependencies": {
                 "diff": {
@@ -6392,7 +6429,7 @@
                     "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
                     "dev": true,
                     "requires": {
-                        "glob": "5.0.15"
+                        "glob": "~5.0.0"
                     },
                     "dependencies": {
                         "glob": {
@@ -6401,11 +6438,11 @@
                             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                             "dev": true,
                             "requires": {
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.4",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         }
                     }
@@ -6421,7 +6458,8 @@
         "tunnel-agent": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
         },
         "tweetnacl": {
             "version": "0.14.5",
@@ -6451,9 +6489,9 @@
             "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "lodash": "4.17.5",
-                "postinstall-build": "5.0.1"
+                "circular-json": "^0.3.1",
+                "lodash": "^4.17.4",
+                "postinstall-build": "^5.0.1"
             }
         },
         "typescript": {
@@ -6474,9 +6512,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6511,8 +6549,8 @@
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
             }
         },
         "undertaker": {
@@ -6521,15 +6559,15 @@
             "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "bach": "1.2.0",
-                "collection-map": "1.0.0",
-                "es6-weak-map": "2.0.2",
-                "last-run": "1.1.1",
-                "object.defaults": "1.1.0",
-                "object.reduce": "1.0.1",
-                "undertaker-registry": "1.0.1"
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
             }
         },
         "undertaker-registry": {
@@ -6544,10 +6582,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6556,7 +6594,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -6565,10 +6603,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -6578,8 +6616,8 @@
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "universalify": {
@@ -6593,8 +6631,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -6603,9 +6641,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -6650,8 +6688,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
             "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             }
         },
         "use": {
@@ -6660,7 +6698,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -6687,7 +6725,7 @@
             "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "vali-date": {
@@ -6701,8 +6739,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "value-or-function": {
@@ -6716,9 +6754,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6733,12 +6771,12 @@
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
             "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
             "requires": {
-                "clone": "2.1.1",
-                "clone-buffer": "1.0.0",
-                "clone-stats": "1.0.0",
-                "cloneable-readable": "1.1.1",
-                "remove-trailing-separator": "1.1.0",
-                "replace-ext": "1.0.0"
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
             }
         },
         "vinyl-fs": {
@@ -6747,23 +6785,23 @@
             "integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
             "dev": true,
             "requires": {
-                "fs-mkdirp-stream": "1.0.0",
-                "glob-stream": "6.1.0",
-                "graceful-fs": "4.1.11",
-                "is-valid-glob": "1.0.0",
-                "lazystream": "1.0.0",
-                "lead": "1.0.0",
-                "object.assign": "4.1.0",
-                "pumpify": "1.4.0",
-                "readable-stream": "2.3.5",
-                "remove-bom-buffer": "3.0.0",
-                "remove-bom-stream": "1.2.0",
-                "resolve-options": "1.1.0",
-                "through2": "2.0.3",
-                "to-through": "2.0.0",
-                "value-or-function": "3.0.0",
-                "vinyl": "2.1.0",
-                "vinyl-sourcemap": "1.1.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             }
         },
         "vinyl-source-stream": {
@@ -6771,8 +6809,8 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -6790,8 +6828,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -6802,13 +6840,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.1.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             }
         },
         "vsce": {
@@ -6817,23 +6855,23 @@
             "integrity": "sha512-LiQjHdoaXOHKdk/PRN5OWWeEm/4w7tnFLf8EM+pzvlz/8uk7uJiqtMjVYAYawnU7c8KbMSz9nE9M6nCTV4ZSQA==",
             "dev": true,
             "requires": {
-                "cheerio": "1.0.0-rc.2",
-                "commander": "2.11.0",
-                "denodeify": "1.2.1",
-                "glob": "7.1.2",
-                "lodash": "4.17.5",
-                "markdown-it": "8.4.1",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "osenv": "0.1.5",
-                "parse-semver": "1.1.1",
-                "read": "1.0.7",
-                "semver": "5.5.0",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^2.8.1",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "lodash": "^4.15.0",
+                "markdown-it": "^8.3.1",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
                 "tmp": "0.0.29",
-                "url-join": "1.1.0",
-                "vso-node-api": "6.1.2-preview",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "url-join": "^1.1.0",
+                "vso-node-api": "^6.1.2-preview",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
             }
         },
         "vscode": {
@@ -6842,20 +6880,20 @@
             "integrity": "sha512-WpHxNfZoxT/JjJbfNNTmXHV9up03yjo3I+jZcYvDvukvYgHtNsvAC98RLz18qmoLwJTncEKrLoxwd4A+VHMmlA==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.3",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src": "^0.4.3",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "browser-stdout": {
@@ -6903,7 +6941,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -6919,10 +6957,10 @@
             "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
             "dev": true,
             "requires": {
-                "q": "1.5.1",
+                "q": "^1.0.1",
                 "tunnel": "0.0.4",
-                "typed-rest-client": "0.9.0",
-                "underscore": "1.8.3"
+                "typed-rest-client": "^0.9.0",
+                "underscore": "^1.8.3"
             }
         },
         "which": {
@@ -6931,7 +6969,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -6957,8 +6995,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -6989,9 +7027,9 @@
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "optional": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             }
         },
@@ -7001,7 +7039,7 @@
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7017,8 +7055,8 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -7026,7 +7064,7 @@
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/samples/sp_whoIsActive/package-lock.json
+++ b/samples/sp_whoIsActive/package-lock.json
@@ -10,11 +10,11 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "css": "2.2.1",
-                "normalize-path": "2.1.1",
-                "source-map": "0.5.7",
-                "through2": "2.0.3"
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.5.6",
+                "through2": "^2.0.3"
             },
             "dependencies": {
                 "source-map": {
@@ -31,8 +31,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "2.1.1",
-                "through2": "2.0.3"
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
             }
         },
         "@types/handlebars": {
@@ -64,10 +64,10 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "align-text": {
@@ -75,9 +75,9 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -91,7 +91,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -139,8 +139,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.9",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             }
         },
         "append-buffer": {
@@ -149,7 +149,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "archy": {
@@ -164,7 +164,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -187,7 +187,7 @@
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.0"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-flatten": {
@@ -201,7 +201,7 @@
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.0"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-union": {
@@ -227,8 +227,8 @@
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
             "dev": true,
             "requires": {
-                "array-slice": "1.1.0",
-                "is-number": "4.0.0"
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -245,7 +245,7 @@
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -268,9 +268,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "1.0.0",
-                "get-value": "2.0.6",
-                "kind-of": "5.1.0"
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -286,7 +286,7 @@
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -313,7 +313,8 @@
         "assert-plus": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -332,10 +333,10 @@
             "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0",
-                "process-nextick-args": "1.0.7",
-                "stream-exhaust": "1.0.2"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^1.0.7",
+                "stream-exhaust": "^1.0.1"
             }
         },
         "async-each": {
@@ -350,7 +351,7 @@
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
             "dev": true,
             "requires": {
-                "async-done": "1.2.4"
+                "async-done": "^1.2.2"
             }
         },
         "asynckit": {
@@ -367,7 +368,8 @@
         "aws-sign2": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
         },
         "aws4": {
             "version": "1.6.0",
@@ -380,15 +382,15 @@
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
             "dev": true,
             "requires": {
-                "arr-filter": "1.1.2",
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "array-each": "1.0.1",
-                "array-initial": "1.1.0",
-                "array-last": "1.3.0",
-                "async-done": "1.2.4",
-                "async-settle": "1.0.0",
-                "now-and-later": "2.0.0"
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "balanced-match": {
@@ -402,13 +404,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -417,7 +419,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -428,7 +430,7 @@
             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -447,7 +449,7 @@
             "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boolbase": {
@@ -460,8 +462,9 @@
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -469,7 +472,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -479,18 +482,18 @@
             "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "kind-of": "6.0.2",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "kind-of": "^6.0.2",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -499,7 +502,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -508,7 +511,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -547,15 +550,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "camelcase": {
@@ -567,7 +570,8 @@
         "caseless": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
         },
         "center-align": {
             "version": "0.1.3",
@@ -575,8 +579,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -584,11 +588,11 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "cheerio": {
@@ -597,12 +601,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash": "4.17.5",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "child-process-promise": {
@@ -611,9 +615,9 @@
             "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
             "dev": true,
             "requires": {
-                "cross-spawn": "4.0.2",
-                "node-version": "1.1.0",
-                "promise-polyfill": "6.1.0"
+                "cross-spawn": "^4.0.2",
+                "node-version": "^1.0.0",
+                "promise-polyfill": "^6.0.1"
             }
         },
         "chokidar": {
@@ -622,18 +626,18 @@
             "integrity": "sha512-l32Hw3wqB0L2kGVmSbK/a+xXLDrUEsc84pSgMkmwygHvD7ubRsP/vxxHa5BtB6oix1XLLVCHyYMsckRXxThmZw==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.1",
-                "fsevents": "1.2.0",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.0.4"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             }
         },
         "chownr": {
@@ -655,10 +659,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -667,7 +671,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -676,7 +680,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -685,7 +689,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -696,7 +700,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -705,7 +709,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -716,9 +720,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -735,8 +739,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "optional": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -768,9 +772,9 @@
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.1.tgz",
             "integrity": "sha512-DNNEq6JdqBFPzS29TaoqZFPNLn5Xn3XyPFqLIhyBT8Xou4lHQEWzD6FinXoJUfhIfWX3aE1JkRa3cbWCHFbt1g==",
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -797,9 +801,9 @@
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
             "dev": true,
             "requires": {
-                "arr-map": "2.0.2",
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "collection-visit": {
@@ -808,8 +812,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-support": {
@@ -828,7 +832,7 @@
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -853,9 +857,9 @@
             "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "convert-source-map": {
@@ -875,8 +879,8 @@
             "integrity": "sha1-Zl/DIEbKhKiYq6o8WUXn8kjMugA=",
             "dev": true,
             "requires": {
-                "each-props": "1.3.1",
-                "is-plain-object": "2.0.4"
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
             }
         },
         "core-util-is": {
@@ -890,16 +894,17 @@
             "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "css": {
@@ -908,10 +913,10 @@
             "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "source-map": "0.1.43",
-                "source-map-resolve": "0.3.1",
-                "urix": "0.1.0"
+                "inherits": "^2.0.1",
+                "source-map": "^0.1.38",
+                "source-map-resolve": "^0.3.0",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "atob": {
@@ -926,7 +931,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "source-map-resolve": {
@@ -935,10 +940,10 @@
                     "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
                     "dev": true,
                     "requires": {
-                        "atob": "1.1.3",
-                        "resolve-url": "0.2.1",
-                        "source-map-url": "0.3.0",
-                        "urix": "0.1.0"
+                        "atob": "~1.1.0",
+                        "resolve-url": "~0.2.1",
+                        "source-map-url": "~0.3.0",
+                        "urix": "~0.1.0"
                     }
                 },
                 "source-map-url": {
@@ -955,10 +960,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-what": {
@@ -973,7 +978,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.40"
+                "es5-ext": "^0.10.9"
             }
         },
         "dashdash": {
@@ -981,7 +986,7 @@
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1011,9 +1016,9 @@
             "integrity": "sha512-dsd50qQ1atDeurcxL7XOjPp4nZCGZzWIONDujDXzl1atSyC3hMbZD+v6440etw+Vt0Pr8ce4TQzHfX3KZM05Mw==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "memoizee": "0.4.12",
-                "object-assign": "4.1.1"
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
             },
             "dependencies": {
                 "debug": {
@@ -1043,7 +1048,7 @@
             "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "default-compare": {
@@ -1052,7 +1057,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "5.1.0"
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1075,8 +1080,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -1085,8 +1090,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             }
         },
         "del": {
@@ -1095,12 +1100,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.0",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             }
         },
         "delayed-stream": {
@@ -1137,8 +1142,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1161,7 +1166,7 @@
             "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1170,8 +1175,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -1184,7 +1189,7 @@
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -1197,10 +1202,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1215,10 +1220,10 @@
             "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
             "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "each-props": {
@@ -1227,8 +1232,8 @@
             "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
             "dev": true,
             "requires": {
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0"
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -1237,7 +1242,7 @@
             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -1245,7 +1250,7 @@
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "entities": {
@@ -1260,7 +1265,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es5-ext": {
@@ -1269,8 +1274,8 @@
             "integrity": "sha512-S9Fh3oya5OOvYSNGvPZJ+vyrs6VYpe1IXPowVe3N1OhaiwVaGlwfn3Zf5P5klYcWOA0toIwYQW8XEv/QqhdHvQ==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1"
             }
         },
         "es6-iterator": {
@@ -1279,9 +1284,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-symbol": {
@@ -1290,8 +1295,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-weak-map": {
@@ -1300,10 +1305,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40",
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-string-regexp": {
@@ -1317,8 +1322,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "event-stream": {
@@ -1326,13 +1331,13 @@
             "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -1341,13 +1346,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1356,7 +1361,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1365,7 +1370,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1374,7 +1379,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1383,7 +1388,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1394,7 +1399,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1403,7 +1408,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1414,9 +1419,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -1432,7 +1437,7 @@
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -1440,11 +1445,11 @@
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                     "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^1.1.3",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -1452,7 +1457,7 @@
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -1471,7 +1476,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
@@ -1485,8 +1490,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1495,7 +1500,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1506,14 +1511,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1522,7 +1527,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -1531,7 +1536,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1546,9 +1551,9 @@
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -1566,7 +1571,7 @@
             "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -1580,10 +1585,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1592,7 +1597,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1603,8 +1608,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -1613,10 +1618,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.9",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "is-glob": {
@@ -1625,7 +1630,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -1636,11 +1641,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -1660,8 +1665,8 @@
             "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "for-in": {
@@ -1675,7 +1680,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -1693,10 +1698,11 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -1705,7 +1711,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -1718,9 +1724,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-minipass": {
@@ -1730,7 +1736,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
             }
         },
         "fs-mkdirp-stream": {
@@ -1739,8 +1745,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "through2": "2.0.3"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -1755,8 +1761,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.9.1"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.9.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -1769,8 +1775,8 @@
                     "version": "4.11.8",
                     "bundled": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -1790,8 +1796,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -1823,28 +1829,28 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
                     "version": "0.0.9",
                     "bundled": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
                     "version": "2.10.1",
                     "bundled": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
                     "version": "1.1.7",
                     "bundled": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1869,7 +1875,7 @@
                     "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -1889,14 +1895,14 @@
                     "version": "2.0.5",
                     "bundled": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
                     "version": "1.14.1",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -1939,7 +1945,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -1958,9 +1964,9 @@
                     "version": "2.1.4",
                     "bundled": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "fs.realpath": {
@@ -1971,19 +1977,19 @@
                     "version": "1.0.11",
                     "bundled": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
                     "version": "1.0.5",
                     "bundled": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -1992,21 +1998,21 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
                     "version": "0.1.7",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2019,12 +2025,12 @@
                     "version": "7.1.2",
                     "bundled": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -2039,8 +2045,8 @@
                     "version": "4.2.1",
                     "bundled": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "has-unicode": {
@@ -2053,10 +2059,10 @@
                     "version": "3.1.3",
                     "bundled": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -2067,17 +2073,17 @@
                     "version": "1.1.1",
                     "bundled": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2095,7 +2101,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -2115,7 +2121,7 @@
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -2131,7 +2137,7 @@
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -2166,14 +2172,14 @@
                     "version": "2.1.15",
                     "bundled": true,
                     "requires": {
-                        "mime-db": "1.27.0"
+                        "mime-db": "~1.27.0"
                     }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2198,16 +2204,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     },
                     "dependencies": {
                         "safe-buffer": {
@@ -2224,13 +2230,13 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "chownr": "1.0.1",
-                                "fs-minipass": "1.2.5",
-                                "minipass": "2.2.4",
-                                "minizlib": "1.1.0",
-                                "mkdirp": "0.5.1",
-                                "safe-buffer": "5.1.1",
-                                "yallist": "3.0.2"
+                                "chownr": "^1.0.1",
+                                "fs-minipass": "^1.2.5",
+                                "minipass": "^2.2.4",
+                                "minizlib": "^1.1.0",
+                                "mkdirp": "^0.5.0",
+                                "safe-buffer": "^5.1.1",
+                                "yallist": "^3.0.2"
                             }
                         }
                     }
@@ -2241,8 +2247,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npmlog": {
@@ -2251,10 +2257,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2276,7 +2282,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2297,8 +2303,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2327,10 +2333,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2345,48 +2351,48 @@
                     "version": "2.2.9",
                     "bundled": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
                     "version": "2.81.0",
                     "bundled": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
                     "version": "2.6.1",
                     "bundled": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2415,22 +2421,22 @@
                     "version": "1.0.9",
                     "bundled": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
                     "version": "1.13.0",
                     "bundled": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2444,16 +2450,16 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
                     "version": "1.0.1",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -2465,7 +2471,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2478,37 +2484,37 @@
                     "version": "2.2.1",
                     "bundled": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
                     "version": "3.4.0",
                     "bundled": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
                     "version": "2.3.2",
                     "bundled": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
                     "version": "0.6.0",
                     "bundled": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -2541,7 +2547,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2562,10 +2568,10 @@
             "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -2577,14 +2583,16 @@
         "generate-function": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
         },
         "generate-object-property": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -2604,7 +2612,7 @@
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2619,12 +2627,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2632,8 +2640,8 @@
             "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -2641,7 +2649,7 @@
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2654,7 +2662,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2664,8 +2672,8 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -2673,7 +2681,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2684,16 +2692,16 @@
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "7.1.2",
-                "glob-parent": "3.1.0",
-                "is-negated-glob": "1.0.0",
-                "ordered-read-streams": "1.0.1",
-                "pumpify": "1.4.0",
-                "readable-stream": "2.3.5",
-                "remove-trailing-separator": "1.1.0",
-                "to-absolute-glob": "2.0.2",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
@@ -2702,10 +2710,10 @@
             "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "dev": true,
             "requires": {
-                "async-done": "1.2.4",
-                "chokidar": "2.0.2",
-                "just-debounce": "1.0.0",
-                "object.defaults": "1.1.0"
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2714,9 +2722,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -2725,11 +2733,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.0"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -2738,11 +2746,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -2758,7 +2766,7 @@
             "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -2777,10 +2785,10 @@
             "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "dev": true,
             "requires": {
-                "glob-watcher": "5.0.1",
-                "gulp-cli": "2.0.1",
-                "undertaker": "1.2.0",
-                "vinyl-fs": "3.0.2"
+                "glob-watcher": "^5.0.0",
+                "gulp-cli": "^2.0.0",
+                "undertaker": "^1.0.0",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2795,9 +2803,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "gulp-cli": {
@@ -2806,24 +2814,24 @@
                     "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "archy": "1.0.0",
-                        "array-sort": "1.0.0",
-                        "color-support": "1.1.3",
-                        "concat-stream": "1.6.1",
-                        "copy-props": "2.0.1",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "interpret": "1.1.0",
-                        "isobject": "3.0.1",
-                        "liftoff": "2.5.0",
-                        "matchdep": "2.0.0",
-                        "mute-stdout": "1.0.0",
-                        "pretty-hrtime": "1.0.3",
-                        "replace-homedir": "1.0.0",
-                        "semver-greatest-satisfied-range": "1.1.0",
-                        "v8flags": "3.0.2",
-                        "yargs": "7.1.0"
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^2.5.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
                     }
                 },
                 "yargs": {
@@ -2832,19 +2840,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 }
             }
@@ -2854,9 +2862,9 @@
             "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-color": {
@@ -2870,9 +2878,9 @@
             "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -2880,8 +2888,8 @@
             "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -2904,10 +2912,10 @@
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -2920,8 +2928,8 @@
                     "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -2929,8 +2937,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -2939,60 +2947,76 @@
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
             "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+            "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "~3.3.4",
+                "node.extend": "~1.1.2",
+                "request": "~2.79.0",
+                "through2": "~2.0.3",
+                "vinyl": "~2.0.1"
             },
             "dependencies": {
                 "clone": {
                     "version": "1.0.3",
                     "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
                 },
                 "request": {
                     "version": "2.79.0",
                     "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.18",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.2.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "vinyl": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.1",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^1.0.0",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "is-stream": "^1.1.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
+            }
+        },
+        "gulp-remote-src-vscode": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.0.tgz",
+            "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
+            "requires": {
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             }
         },
         "gulp-sourcemaps": {
@@ -3001,17 +3025,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.0.1",
-                "@gulp-sourcemaps/map-sources": "1.0.0",
-                "acorn": "5.5.3",
-                "convert-source-map": "1.5.1",
-                "css": "2.2.1",
-                "debug-fabulous": "1.0.0",
-                "detect-newline": "2.1.0",
-                "graceful-fs": "4.1.11",
-                "source-map": "0.6.1",
-                "strip-bom-string": "1.0.0",
-                "through2": "2.0.3"
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
             },
             "dependencies": {
                 "source-map": {
@@ -3027,10 +3051,10 @@
             "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3038,7 +3062,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3051,9 +3075,9 @@
                     "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3071,7 +3095,7 @@
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3079,7 +3103,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3087,7 +3111,7 @@
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3095,11 +3119,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3107,14 +3131,14 @@
                     "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3122,10 +3146,10 @@
                             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3133,8 +3157,8 @@
                             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3144,11 +3168,11 @@
                     "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -3161,7 +3185,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3179,19 +3203,19 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3199,8 +3223,8 @@
                     "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -3218,7 +3242,7 @@
                     "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl": {
@@ -3226,8 +3250,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -3236,23 +3260,23 @@
                     "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -3263,9 +3287,9 @@
             "integrity": "sha1-cq02j0JEXyqs+v0vd/oZFm7eeVg=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "map-stream": "0.1.0",
-                "through": "2.3.8"
+                "gulp-util": "~3.0.7",
+                "map-stream": "~0.1.0",
+                "through": "~2.3.8"
             }
         },
         "gulp-typescript": {
@@ -3274,10 +3298,10 @@
             "integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "source-map": "0.5.7",
-                "through2": "2.0.3",
-                "vinyl-fs": "2.4.4"
+                "gulp-util": "~3.0.7",
+                "source-map": "~0.5.3",
+                "through2": "~2.0.1",
+                "vinyl-fs": "~2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3286,7 +3310,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3301,9 +3325,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3324,7 +3348,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3333,7 +3357,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3342,7 +3366,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3351,11 +3375,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3364,14 +3388,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3380,10 +3404,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3392,8 +3416,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3404,11 +3428,11 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -3423,7 +3447,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3444,19 +3468,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3465,8 +3489,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -3493,7 +3517,7 @@
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl": {
@@ -3502,8 +3526,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -3513,23 +3537,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -3539,11 +3563,11 @@
             "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -3551,24 +3575,24 @@
             "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -3601,8 +3625,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "requires": {
-                        "clone": "1.0.3",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -3613,13 +3637,13 @@
             "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3627,7 +3651,7 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3640,9 +3664,9 @@
                     "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3660,7 +3684,7 @@
                     "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3668,7 +3692,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3676,7 +3700,7 @@
                     "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3684,11 +3708,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3696,14 +3720,14 @@
                     "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3711,10 +3735,10 @@
                             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3722,8 +3746,8 @@
                             "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3733,11 +3757,11 @@
                     "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     },
                     "dependencies": {
                         "vinyl": {
@@ -3745,8 +3769,8 @@
                             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                             "requires": {
-                                "clone": "1.0.3",
-                                "clone-stats": "0.0.1",
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
                                 "replace-ext": "0.0.1"
                             }
                         }
@@ -3762,7 +3786,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3780,19 +3804,19 @@
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3800,8 +3824,8 @@
                     "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "queue": {
@@ -3809,7 +3833,7 @@
                     "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "replace-ext": {
@@ -3827,7 +3851,7 @@
                     "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl-fs": {
@@ -3835,23 +3859,23 @@
                     "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     },
                     "dependencies": {
                         "vinyl": {
@@ -3859,8 +3883,8 @@
                             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
                             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                             "requires": {
-                                "clone": "1.0.3",
-                                "clone-stats": "0.0.1",
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
                                 "replace-ext": "0.0.1"
                             }
                         }
@@ -3873,7 +3897,7 @@
             "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "handlebars": {
@@ -3881,10 +3905,10 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             }
         },
         "har-schema": {
@@ -3896,11 +3920,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.11.0",
-                "is-my-json-valid": "2.17.2",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -3908,7 +3933,7 @@
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -3921,7 +3946,7 @@
             "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -3936,9 +3961,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -3947,8 +3972,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3957,7 +3982,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3966,11 +3991,12 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -3981,7 +4007,8 @@
         "hoek": {
             "version": "2.16.3",
             "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
         },
         "homedir-polyfill": {
             "version": "1.0.1",
@@ -3989,7 +4016,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -4004,22 +4031,23 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.1",
-                "domutils": "1.5.1",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-signature": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
@@ -4029,7 +4057,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "^2.1.0"
             }
         },
         "ignore-walk": {
@@ -4039,7 +4067,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.4"
             }
         },
         "inflight": {
@@ -4047,8 +4075,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -4085,8 +4113,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -4095,7 +4123,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4118,7 +4146,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -4132,7 +4160,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -4141,7 +4169,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4158,9 +4186,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4181,7 +4209,7 @@
             "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -4200,7 +4228,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -4209,24 +4237,26 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-my-ip-valid": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+            "dev": true
         },
         "is-my-json-valid": {
             "version": "2.17.2",
             "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
             "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+            "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-negated-glob": {
@@ -4240,7 +4270,7 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -4254,7 +4284,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -4277,7 +4307,7 @@
             "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -4286,7 +4316,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -4295,7 +4325,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -4317,7 +4347,8 @@
         "is-property": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
         },
         "is-relative": {
             "version": "1.0.0",
@@ -4325,7 +4356,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-stream": {
@@ -4344,7 +4375,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -4407,7 +4438,7 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -4420,7 +4451,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -4431,7 +4462,8 @@
         "jsonpointer": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
         },
         "jsprim": {
             "version": "1.4.1",
@@ -4462,7 +4494,7 @@
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "last-run": {
@@ -4471,8 +4503,8 @@
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
             "dev": true,
             "requires": {
-                "default-resolution": "2.0.0",
-                "es6-weak-map": "2.0.2"
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
             }
         },
         "lazy-cache": {
@@ -4486,7 +4518,7 @@
             "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -4495,7 +4527,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "lead": {
@@ -4504,7 +4536,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.2"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "liftoff": {
@@ -4513,14 +4545,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.5.0"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "linkify-it": {
@@ -4529,7 +4561,7 @@
             "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
             "dev": true,
             "requires": {
-                "uc.micro": "1.0.5"
+                "uc.micro": "^1.0.1"
             }
         },
         "load-json-file": {
@@ -4538,11 +4570,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -4609,7 +4641,7 @@
             "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -4632,9 +4664,9 @@
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -4647,15 +4679,15 @@
             "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -4663,8 +4695,8 @@
             "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "longest": {
@@ -4678,8 +4710,8 @@
             "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -4688,7 +4720,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.40"
+                "es5-ext": "~0.10.2"
             }
         },
         "make-dir": {
@@ -4697,7 +4729,7 @@
             "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-iterator": {
@@ -4706,7 +4738,7 @@
             "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.1.0"
             }
         },
         "map-cache": {
@@ -4726,7 +4758,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-it": {
@@ -4735,11 +4767,11 @@
             "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "entities": "1.1.1",
-                "linkify-it": "2.0.3",
-                "mdurl": "1.0.1",
-                "uc.micro": "1.0.5"
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
             }
         },
         "matchdep": {
@@ -4748,9 +4780,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "2.0.0",
-                "micromatch": "3.1.9",
-                "resolve": "1.5.0",
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
                 "stack-trace": "0.0.10"
             }
         },
@@ -4766,14 +4798,14 @@
             "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.40",
-                "es6-weak-map": "2.0.2",
-                "event-emitter": "0.3.5",
-                "is-promise": "2.1.0",
-                "lru-queue": "0.1.0",
-                "next-tick": "1.0.0",
-                "timers-ext": "0.1.5"
+                "d": "1",
+                "es5-ext": "^0.10.30",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.2"
             }
         },
         "merge-stream": {
@@ -4781,7 +4813,7 @@
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -4790,19 +4822,19 @@
             "integrity": "sha512-SlIz6sv5UPaAVVFRKodKjCg48EbNoIhgetzfK/Cy0v5U52Z6zB136M8tp0UC9jM53LYbmIRihJszvvqpKkfm9g==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.1",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -4829,7 +4861,7 @@
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "minimatch": {
@@ -4837,7 +4869,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -4851,8 +4883,8 @@
             "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1",
-                "yallist": "3.0.2"
+                "safe-buffer": "^5.1.1",
+                "yallist": "^3.0.0"
             },
             "dependencies": {
                 "yallist": {
@@ -4870,7 +4902,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "minipass": "2.2.4"
+                "minipass": "^2.2.1"
             }
         },
         "mixin-deep": {
@@ -4879,8 +4911,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -4889,7 +4921,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -4939,7 +4971,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -4954,10 +4986,10 @@
             "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -4993,18 +5025,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -5022,9 +5054,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "debug": "2.6.9",
-                "iconv-lite": "0.4.21",
-                "sax": "1.2.4"
+                "debug": "^2.1.2",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
             }
         },
         "next-tick": {
@@ -5044,7 +5076,7 @@
             "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-package-data": {
@@ -5053,10 +5085,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -5064,7 +5096,7 @@
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "now-and-later": {
@@ -5073,7 +5105,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "npm-bundled": {
@@ -5090,8 +5122,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "ignore-walk": "3.0.1",
-                "npm-bundled": "1.0.3"
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1"
             }
         },
         "nth-check": {
@@ -5100,7 +5132,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "number-is-nan": {
@@ -5125,9 +5157,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -5136,7 +5168,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5145,7 +5177,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -5154,7 +5186,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -5163,9 +5195,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5190,7 +5222,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -5199,10 +5231,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.11"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -5211,10 +5243,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "object.map": {
@@ -5223,8 +5255,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.omit": {
@@ -5232,8 +5264,8 @@
             "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-own": {
@@ -5241,7 +5273,7 @@
                     "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
                     "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -5252,7 +5284,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "object.reduce": {
@@ -5261,8 +5293,8 @@
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "once": {
@@ -5270,7 +5302,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "openurl": {
@@ -5283,8 +5315,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "ordered-read-streams": {
@@ -5293,7 +5325,7 @@
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "os-homedir": {
@@ -5308,7 +5340,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -5323,8 +5355,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-map": {
@@ -5339,9 +5371,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -5349,10 +5381,10 @@
             "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -5365,7 +5397,7 @@
                     "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -5376,7 +5408,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -5391,7 +5423,7 @@
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.1.0"
             }
         },
         "parse5": {
@@ -5400,7 +5432,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.56"
+                "@types/node": "*"
             }
         },
         "pascalcase": {
@@ -5420,7 +5452,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -5446,7 +5478,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -5461,9 +5493,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -5479,7 +5511,7 @@
             "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -5501,14 +5533,16 @@
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -5516,11 +5550,11 @@
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -5528,8 +5562,8 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -5547,7 +5581,7 @@
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -5604,8 +5638,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -5614,9 +5648,9 @@
             "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -5633,7 +5667,8 @@
         "qs": {
             "version": "6.3.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
         },
         "querystringify": {
             "version": "1.0.0",
@@ -5645,7 +5680,7 @@
             "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -5653,8 +5688,8 @@
             "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5662,7 +5697,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5673,7 +5708,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -5682,9 +5717,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -5693,8 +5728,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -5702,13 +5737,13 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
             "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -5724,10 +5759,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.5",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -5736,7 +5771,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.5.0"
+                "resolve": "^1.1.6"
             }
         },
         "regex-cache": {
@@ -5744,7 +5779,7 @@
             "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -5753,8 +5788,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "remove-bom-buffer": {
@@ -5763,8 +5798,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -5773,9 +5808,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.1",
-                "through2": "2.0.3"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -5804,9 +5839,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "is-absolute": "1.0.0",
-                "remove-trailing-separator": "1.1.0"
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
             }
         },
         "request": {
@@ -5814,28 +5849,28 @@
             "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
             "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -5853,7 +5888,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "caseless": {
@@ -5866,7 +5901,7 @@
                     "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -5874,7 +5909,7 @@
                             "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "requires": {
-                                "hoek": "4.2.1"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -5884,9 +5919,9 @@
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
                     "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
                     "requires": {
-                        "asynckit": "0.4.0",
+                        "asynckit": "^0.4.0",
                         "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-validator": {
@@ -5894,8 +5929,8 @@
                     "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "hawk": {
@@ -5903,10 +5938,10 @@
                     "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.1",
-                        "sntp": "2.1.0"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -5919,9 +5954,9 @@
                     "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "qs": {
@@ -5934,7 +5969,7 @@
                     "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
                     "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "tunnel-agent": {
@@ -5942,7 +5977,7 @@
                     "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 }
             }
@@ -5970,7 +6005,7 @@
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -5979,8 +6014,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-options": {
@@ -5989,7 +6024,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -6010,7 +6045,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -6018,7 +6053,7 @@
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -6032,7 +6067,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -6060,7 +6095,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "1.5.0"
+                "sver-compat": "^1.5.0"
             }
         },
         "set-blocking": {
@@ -6081,10 +6116,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6093,7 +6128,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6104,11 +6139,11 @@
             "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
             "dev": true,
             "requires": {
-                "should-equal": "2.0.0",
-                "should-format": "3.0.3",
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0",
-                "should-util": "1.0.0"
+                "should-equal": "^2.0.0",
+                "should-format": "^3.0.3",
+                "should-type": "^1.4.0",
+                "should-type-adaptors": "^1.0.1",
+                "should-util": "^1.0.0"
             }
         },
         "should-equal": {
@@ -6117,7 +6152,7 @@
             "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0"
+                "should-type": "^1.4.0"
             }
         },
         "should-format": {
@@ -6126,8 +6161,8 @@
             "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-type-adaptors": "1.1.0"
+                "should-type": "^1.3.0",
+                "should-type-adaptors": "^1.0.1"
             }
         },
         "should-type": {
@@ -6142,8 +6177,8 @@
             "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
             "dev": true,
             "requires": {
-                "should-type": "1.4.0",
-                "should-util": "1.0.0"
+                "should-type": "^1.3.0",
+                "should-util": "^1.0.0"
             }
         },
         "should-util": {
@@ -6158,14 +6193,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6174,7 +6209,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -6183,7 +6218,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6192,7 +6227,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6201,7 +6236,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6212,7 +6247,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6221,7 +6256,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6232,9 +6267,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -6257,9 +6292,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -6268,7 +6303,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -6279,15 +6314,16 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -6295,7 +6331,7 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
             "requires": {
-                "amdefine": "1.0.1"
+                "amdefine": ">=0.0.4"
             }
         },
         "source-map-resolve": {
@@ -6304,11 +6340,11 @@
             "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "2.0.3",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -6316,7 +6352,7 @@
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
             "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6343,8 +6379,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -6359,8 +6395,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -6374,7 +6410,7 @@
             "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -6383,7 +6419,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -6393,22 +6429,23 @@
             "dev": true
         },
         "sqlops": {
-            "version": "github:anthonydresser/sqlops-extension-sqlops#dac501bbaa03a25239c060c6371dfdcf06707599",
+            "version": "github:anthonydresser/sqlops-extension-sqlops#439a29228eb8f4cd0109ab538e84f0b548c5f054",
+            "from": "github:anthonydresser/sqlops-extension-sqlops",
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.3",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "sshpk": {
@@ -6416,14 +6453,14 @@
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6450,8 +6487,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6460,7 +6497,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6469,7 +6506,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6478,7 +6515,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6489,7 +6526,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6498,7 +6535,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6509,9 +6546,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -6527,7 +6564,7 @@
             "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-exhaust": {
@@ -6546,7 +6583,7 @@
             "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -6560,9 +6597,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -6570,7 +6607,7 @@
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -6583,7 +6620,7 @@
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -6591,7 +6628,7 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -6599,8 +6636,8 @@
             "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-bom-string": {
@@ -6620,8 +6657,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "tar": {
@@ -6629,9 +6666,9 @@
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "temp-dir": {
@@ -6646,12 +6683,12 @@
             "integrity": "sha1-jP9jD7fp2gXwR8dM5M5NaFRX1JI=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "is-stream": "1.1.0",
-                "make-dir": "1.2.0",
-                "pify": "3.0.0",
-                "temp-dir": "1.0.0",
-                "uuid": "3.2.1"
+                "graceful-fs": "^4.1.2",
+                "is-stream": "^1.1.0",
+                "make-dir": "^1.0.0",
+                "pify": "^3.0.0",
+                "temp-dir": "^1.0.0",
+                "uuid": "^3.0.1"
             }
         },
         "through": {
@@ -6664,8 +6701,8 @@
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -6673,8 +6710,8 @@
             "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -6688,8 +6725,8 @@
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.40",
-                "next-tick": "1.0.0"
+                "es5-ext": "~0.10.14",
+                "next-tick": "1"
             }
         },
         "tmp": {
@@ -6698,7 +6735,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -6707,8 +6744,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "is-negated-glob": "1.0.0"
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-object-path": {
@@ -6717,7 +6754,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -6726,10 +6763,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -6738,8 +6775,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "to-through": {
@@ -6748,7 +6785,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
@@ -6756,7 +6793,7 @@
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tslint": {
@@ -6765,13 +6802,13 @@
             "integrity": "sha1-2hZcqT2P3CwIa1EWXuG6y0jJjqU=",
             "dev": true,
             "requires": {
-                "colors": "1.2.1",
-                "diff": "2.2.3",
-                "findup-sync": "0.3.0",
-                "glob": "7.1.2",
-                "optimist": "0.6.1",
-                "resolve": "1.5.0",
-                "underscore.string": "3.3.4"
+                "colors": "^1.1.2",
+                "diff": "^2.2.1",
+                "findup-sync": "~0.3.0",
+                "glob": "^7.0.3",
+                "optimist": "~0.6.0",
+                "resolve": "^1.1.7",
+                "underscore.string": "^3.3.4"
             },
             "dependencies": {
                 "diff": {
@@ -6786,7 +6823,7 @@
                     "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
                     "dev": true,
                     "requires": {
-                        "glob": "5.0.15"
+                        "glob": "~5.0.0"
                     },
                     "dependencies": {
                         "glob": {
@@ -6795,11 +6832,11 @@
                             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                             "dev": true,
                             "requires": {
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.4",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         }
                     }
@@ -6815,7 +6852,8 @@
         "tunnel-agent": {
             "version": "0.4.3",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
         },
         "tweetnacl": {
             "version": "0.14.5",
@@ -6845,9 +6883,9 @@
             "integrity": "sha512-DtRNLb7x8yCTv/KHlwes+NI+aGb4Vl1iPC63Hhtcvk1DpxSAZzKWQv0RQFY0jX2Uqj0SDBNl8Na4e6MV6TNDgw==",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "lodash": "4.17.5",
-                "postinstall-build": "5.0.1"
+                "circular-json": "^0.3.1",
+                "lodash": "^4.17.4",
+                "postinstall-build": "^5.0.1"
             }
         },
         "typescript": {
@@ -6868,9 +6906,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6905,8 +6943,8 @@
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
             }
         },
         "undertaker": {
@@ -6915,15 +6953,15 @@
             "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "bach": "1.2.0",
-                "collection-map": "1.0.0",
-                "es6-weak-map": "2.0.2",
-                "last-run": "1.1.1",
-                "object.defaults": "1.1.0",
-                "object.reduce": "1.0.1",
-                "undertaker-registry": "1.0.1"
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
             }
         },
         "undertaker-registry": {
@@ -6938,10 +6976,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6950,7 +6988,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -6959,10 +6997,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -6972,8 +7010,8 @@
             "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "universalify": {
@@ -6987,8 +7025,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -6997,9 +7035,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7044,8 +7082,8 @@
             "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
             "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             }
         },
         "use": {
@@ -7054,7 +7092,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7081,7 +7119,7 @@
             "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "vali-date": {
@@ -7095,8 +7133,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "value-or-function": {
@@ -7110,9 +7148,9 @@
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -7127,12 +7165,12 @@
             "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
             "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
             "requires": {
-                "clone": "2.1.1",
-                "clone-buffer": "1.0.0",
-                "clone-stats": "1.0.0",
-                "cloneable-readable": "1.1.1",
-                "remove-trailing-separator": "1.1.0",
-                "replace-ext": "1.0.0"
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
             }
         },
         "vinyl-fs": {
@@ -7141,23 +7179,23 @@
             "integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
             "dev": true,
             "requires": {
-                "fs-mkdirp-stream": "1.0.0",
-                "glob-stream": "6.1.0",
-                "graceful-fs": "4.1.11",
-                "is-valid-glob": "1.0.0",
-                "lazystream": "1.0.0",
-                "lead": "1.0.0",
-                "object.assign": "4.1.0",
-                "pumpify": "1.4.0",
-                "readable-stream": "2.3.5",
-                "remove-bom-buffer": "3.0.0",
-                "remove-bom-stream": "1.2.0",
-                "resolve-options": "1.1.0",
-                "through2": "2.0.3",
-                "to-through": "2.0.0",
-                "value-or-function": "3.0.0",
-                "vinyl": "2.1.0",
-                "vinyl-sourcemap": "1.1.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             }
         },
         "vinyl-source-stream": {
@@ -7165,8 +7203,8 @@
             "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -7184,8 +7222,8 @@
                     "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -7196,13 +7234,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.1.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             }
         },
         "vsce": {
@@ -7211,23 +7249,23 @@
             "integrity": "sha512-LiQjHdoaXOHKdk/PRN5OWWeEm/4w7tnFLf8EM+pzvlz/8uk7uJiqtMjVYAYawnU7c8KbMSz9nE9M6nCTV4ZSQA==",
             "dev": true,
             "requires": {
-                "cheerio": "1.0.0-rc.2",
-                "commander": "2.11.0",
-                "denodeify": "1.2.1",
-                "glob": "7.1.2",
-                "lodash": "4.17.5",
-                "markdown-it": "8.4.1",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "osenv": "0.1.5",
-                "parse-semver": "1.1.1",
-                "read": "1.0.7",
-                "semver": "5.5.0",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^2.8.1",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "lodash": "^4.15.0",
+                "markdown-it": "^8.3.1",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
                 "tmp": "0.0.29",
-                "url-join": "1.1.0",
-                "vso-node-api": "6.1.2-preview",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "url-join": "^1.1.0",
+                "vso-node-api": "^6.1.2-preview",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
             }
         },
         "vscode": {
@@ -7236,20 +7274,20 @@
             "integrity": "sha512-WpHxNfZoxT/JjJbfNNTmXHV9up03yjo3I+jZcYvDvukvYgHtNsvAC98RLz18qmoLwJTncEKrLoxwd4A+VHMmlA==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.3",
-                "url-parse": "1.2.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src": "^0.4.3",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "browser-stdout": {
@@ -7297,7 +7335,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -7313,10 +7351,10 @@
             "integrity": "sha1-qrNUbfJFHs2JTgcbuZtd8Zxfp48=",
             "dev": true,
             "requires": {
-                "q": "1.5.1",
+                "q": "^1.0.1",
                 "tunnel": "0.0.4",
-                "typed-rest-client": "0.9.0",
-                "underscore": "1.8.3"
+                "typed-rest-client": "^0.9.0",
+                "underscore": "^1.8.3"
             }
         },
         "which": {
@@ -7325,7 +7363,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -7351,8 +7389,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -7383,9 +7421,9 @@
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "optional": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             }
         },
@@ -7395,7 +7433,7 @@
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7411,8 +7449,8 @@
             "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -7420,7 +7458,7 @@
             "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/samples/sqlservices/package-lock.json
+++ b/samples/sqlservices/package-lock.json
@@ -10,11 +10,11 @@
             "integrity": "sha1-z6I7xYQPkQTOMqZedNt+epdLvuE=",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "css": "2.2.1",
-                "normalize-path": "2.1.1",
-                "source-map": "0.5.7",
-                "through2": "2.0.3"
+                "acorn": "^5.0.3",
+                "css": "^2.2.1",
+                "normalize-path": "^2.1.1",
+                "source-map": "^0.5.6",
+                "through2": "^2.0.3"
             }
         },
         "@gulp-sourcemaps/map-sources": {
@@ -23,8 +23,8 @@
             "integrity": "sha1-iQrnxdjId/bThIYCFazp1+yUW9o=",
             "dev": true,
             "requires": {
-                "normalize-path": "2.1.1",
-                "through2": "2.0.3"
+                "normalize-path": "^2.0.1",
+                "through2": "^2.0.3"
             }
         },
         "@types/handlebars": {
@@ -51,10 +51,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "align-text": {
@@ -62,9 +62,9 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -72,7 +72,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -88,7 +88,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -142,8 +142,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             }
         },
         "append-buffer": {
@@ -152,7 +152,7 @@
             "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
             "dev": true,
             "requires": {
-                "buffer-equal": "1.0.0"
+                "buffer-equal": "^1.0.0"
             }
         },
         "archy": {
@@ -167,7 +167,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -182,7 +182,7 @@
             "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.0"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-flatten": {
@@ -197,7 +197,7 @@
             "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
             "dev": true,
             "requires": {
-                "make-iterator": "1.0.0"
+                "make-iterator": "^1.0.0"
             }
         },
         "arr-union": {
@@ -224,8 +224,8 @@
             "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
             "dev": true,
             "requires": {
-                "array-slice": "1.1.0",
-                "is-number": "4.0.0"
+                "array-slice": "^1.0.0",
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -242,7 +242,7 @@
             "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -265,9 +265,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "1.0.0",
-                "get-value": "2.0.6",
-                "kind-of": "5.1.0"
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -284,7 +284,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -334,10 +334,10 @@
             "integrity": "sha512-mxc+yISkb0vjsuvG3dJCIZXzRWjKndQ9Zo9zNDJ1K2wh9eP0E0oGmOWm+4cFOvW4dA0tGFImTW5tQJHCtn1kIQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0",
-                "process-nextick-args": "1.0.7",
-                "stream-exhaust": "1.0.2"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.2",
+                "process-nextick-args": "^1.0.7",
+                "stream-exhaust": "^1.0.1"
             }
         },
         "async-each": {
@@ -352,7 +352,7 @@
             "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
             "dev": true,
             "requires": {
-                "async-done": "1.2.4"
+                "async-done": "^1.2.2"
             }
         },
         "asynckit": {
@@ -385,15 +385,15 @@
             "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
             "dev": true,
             "requires": {
-                "arr-filter": "1.1.2",
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "array-each": "1.0.1",
-                "array-initial": "1.1.0",
-                "array-last": "1.3.0",
-                "async-done": "1.2.4",
-                "async-settle": "1.0.0",
-                "now-and-later": "2.0.0"
+                "arr-filter": "^1.1.1",
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "array-each": "^1.0.0",
+                "array-initial": "^1.0.0",
+                "array-last": "^1.1.1",
+                "async-done": "^1.2.2",
+                "async-settle": "^1.0.0",
+                "now-and-later": "^2.0.0"
             }
         },
         "balanced-match": {
@@ -408,13 +408,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -423,7 +423,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -435,7 +435,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -456,7 +456,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boolbase": {
@@ -471,7 +471,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -480,7 +480,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -490,18 +490,18 @@
             "integrity": "sha512-SO5lYHA3vO6gz66erVvedSCkp7AKWdv6VcQ2N4ysXfPxdAlxAMMAdwegGGcv1Bqwm7naF1hNdk5d6AAIEHV2nQ==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "kind-of": "6.0.2",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "kind-of": "^6.0.2",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -510,7 +510,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -519,7 +519,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -560,15 +560,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "camelcase": {
@@ -589,8 +589,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -599,11 +599,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
         },
         "cheerio": {
@@ -612,12 +612,12 @@
             "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-serializer": "0.1.0",
-                "entities": "1.1.1",
-                "htmlparser2": "3.9.2",
-                "lodash": "4.17.10",
-                "parse5": "3.0.3"
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.0",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
             }
         },
         "child-process-promise": {
@@ -626,9 +626,9 @@
             "integrity": "sha1-RzChHvYQ+tRQuPIjx50x172tgHQ=",
             "dev": true,
             "requires": {
-                "cross-spawn": "4.0.2",
-                "node-version": "1.1.3",
-                "promise-polyfill": "6.1.0"
+                "cross-spawn": "^4.0.2",
+                "node-version": "^1.0.0",
+                "promise-polyfill": "^6.0.1"
             }
         },
         "chokidar": {
@@ -637,18 +637,18 @@
             "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.1",
-                "fsevents": "1.1.3",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.0.4"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             }
         },
         "class-utils": {
@@ -657,10 +657,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -669,7 +669,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -678,7 +678,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -687,7 +687,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -698,7 +698,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -707,7 +707,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -718,9 +718,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -737,9 +737,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
             }
         },
         "clone": {
@@ -766,9 +766,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -797,9 +797,9 @@
             "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
             "dev": true,
             "requires": {
-                "arr-map": "2.0.2",
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "arr-map": "^2.0.2",
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "collection-visit": {
@@ -808,8 +808,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-support": {
@@ -830,7 +830,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -857,10 +857,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "convert-source-map": {
@@ -881,8 +881,8 @@
             "integrity": "sha1-Zl/DIEbKhKiYq6o8WUXn8kjMugA=",
             "dev": true,
             "requires": {
-                "each-props": "1.3.1",
-                "is-plain-object": "2.0.4"
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
             }
         },
         "core-util-is": {
@@ -897,8 +897,8 @@
             "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
-                "which": "1.3.0"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             }
         },
         "cryptiles": {
@@ -907,7 +907,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "css": {
@@ -916,10 +916,10 @@
             "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "source-map": "0.1.43",
-                "source-map-resolve": "0.3.1",
-                "urix": "0.1.0"
+                "inherits": "^2.0.1",
+                "source-map": "^0.1.38",
+                "source-map-resolve": "^0.3.0",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "atob": {
@@ -934,7 +934,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "source-map-resolve": {
@@ -943,10 +943,10 @@
                     "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
                     "dev": true,
                     "requires": {
-                        "atob": "1.1.3",
-                        "resolve-url": "0.2.1",
-                        "source-map-url": "0.3.0",
-                        "urix": "0.1.0"
+                        "atob": "~1.1.0",
+                        "resolve-url": "~0.2.1",
+                        "source-map-url": "~0.3.0",
+                        "urix": "~0.1.0"
                     }
                 },
                 "source-map-url": {
@@ -963,10 +963,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-what": {
@@ -981,7 +981,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.42"
+                "es5-ext": "^0.10.9"
             }
         },
         "dashdash": {
@@ -990,7 +990,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -1022,9 +1022,9 @@
             "integrity": "sha512-GZqvGIgKNlUnHUPQhepnUZFIMoi3dgZKQBzKDeL2g7oJF9SNAji/AAu36dusFUas0O+pae74lNeoIPHqXWDkLg==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "memoizee": "0.4.12",
-                "object-assign": "4.1.1"
+                "debug": "3.X",
+                "memoizee": "0.4.X",
+                "object-assign": "4.X"
             },
             "dependencies": {
                 "debug": {
@@ -1055,7 +1055,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "default-compare": {
@@ -1064,7 +1064,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "5.1.0"
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -1087,8 +1087,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -1097,8 +1097,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             }
         },
         "del": {
@@ -1107,12 +1107,12 @@
             "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
             "dev": true,
             "requires": {
-                "globby": "6.1.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "p-map": "1.2.0",
-                "pify": "3.0.0",
-                "rimraf": "2.6.2"
+                "globby": "^6.1.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "p-map": "^1.1.1",
+                "pify": "^3.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "pify": {
@@ -1159,8 +1159,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -1183,7 +1183,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domutils": {
@@ -1192,8 +1192,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "duplexer": {
@@ -1208,7 +1208,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -1223,10 +1223,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1243,10 +1243,10 @@
             "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "each-props": {
@@ -1255,8 +1255,8 @@
             "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
             "dev": true,
             "requires": {
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0"
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -1266,7 +1266,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -1275,7 +1275,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "entities": {
@@ -1290,7 +1290,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es5-ext": {
@@ -1299,9 +1299,9 @@
             "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1",
-                "next-tick": "1.0.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
             }
         },
         "es6-iterator": {
@@ -1310,9 +1310,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.42",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-symbol": {
@@ -1321,8 +1321,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.42"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-weak-map": {
@@ -1331,10 +1331,10 @@
             "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.42",
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.14",
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "escape-string-regexp": {
@@ -1349,8 +1349,8 @@
             "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.42"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "event-stream": {
@@ -1359,13 +1359,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -1374,13 +1374,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1389,7 +1389,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1398,7 +1398,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1407,7 +1407,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1416,7 +1416,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1427,7 +1427,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1436,7 +1436,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1447,9 +1447,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -1466,7 +1466,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             },
             "dependencies": {
                 "fill-range": {
@@ -1475,11 +1475,11 @@
                     "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
                     "dev": true,
                     "requires": {
-                        "is-number": "2.1.0",
-                        "isobject": "2.1.0",
-                        "randomatic": "1.1.7",
-                        "repeat-element": "1.1.2",
-                        "repeat-string": "1.6.1"
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^1.1.3",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "is-number": {
@@ -1488,7 +1488,7 @@
                     "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -1506,7 +1506,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -1517,7 +1517,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "extend": {
@@ -1532,8 +1532,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1542,7 +1542,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1553,14 +1553,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1569,7 +1569,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -1578,7 +1578,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1595,9 +1595,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -1618,7 +1618,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -1633,10 +1633,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1645,7 +1645,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1656,8 +1656,8 @@
             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
             "dev": true,
             "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -1666,10 +1666,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "is-glob": {
@@ -1678,7 +1678,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -1689,11 +1689,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -1714,8 +1714,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "for-in": {
@@ -1730,7 +1730,7 @@
             "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -1751,9 +1751,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "fragment-cache": {
@@ -1762,7 +1762,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "from": {
@@ -1776,9 +1776,9 @@
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -1787,8 +1787,8 @@
             "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "through2": "2.0.3"
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
             }
         },
         "fs.realpath": {
@@ -1804,8 +1804,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.3.0",
+                "node-pre-gyp": "^0.6.39"
             },
             "dependencies": {
                 "abbrev": {
@@ -1820,8 +1820,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "ansi-regex": {
@@ -1841,8 +1841,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "asn1": {
@@ -1886,7 +1886,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "tweetnacl": "0.14.5"
+                        "tweetnacl": "^0.14.3"
                     }
                 },
                 "block-stream": {
@@ -1894,7 +1894,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "boom": {
@@ -1902,7 +1902,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "brace-expansion": {
@@ -1910,7 +1910,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "0.4.2",
+                        "balanced-match": "^0.4.1",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -1941,7 +1941,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "delayed-stream": "1.0.0"
+                        "delayed-stream": "~1.0.0"
                     }
                 },
                 "concat-map": {
@@ -1964,7 +1964,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1"
+                        "boom": "2.x.x"
                     }
                 },
                 "dashdash": {
@@ -1973,7 +1973,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2022,7 +2022,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "extend": {
@@ -2048,9 +2048,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "fs.realpath": {
@@ -2063,10 +2063,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
+                        "graceful-fs": "^4.1.2",
+                        "inherits": "~2.0.0",
+                        "mkdirp": ">=0.5 0",
+                        "rimraf": "2"
                     }
                 },
                 "fstream-ignore": {
@@ -2075,9 +2075,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
+                        "fstream": "^1.0.0",
+                        "inherits": "2",
+                        "minimatch": "^3.0.0"
                     }
                 },
                 "gauge": {
@@ -2086,14 +2086,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "getpass": {
@@ -2102,7 +2102,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "1.0.0"
+                        "assert-plus": "^1.0.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2118,12 +2118,12 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -2143,8 +2143,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "has-unicode": {
@@ -2158,10 +2158,10 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
+                        "boom": "2.x.x",
+                        "cryptiles": "2.x.x",
+                        "hoek": "2.x.x",
+                        "sntp": "1.x.x"
                     }
                 },
                 "hoek": {
@@ -2175,9 +2175,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "inflight": {
@@ -2185,8 +2185,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -2205,7 +2205,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "is-typedarray": {
@@ -2231,7 +2231,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
+                        "jsbn": "~0.1.0"
                     }
                 },
                 "jsbn": {
@@ -2252,7 +2252,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsonify": "0.0.0"
+                        "jsonify": "~0.0.0"
                     }
                 },
                 "json-stringify-safe": {
@@ -2297,7 +2297,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mime-db": "1.27.0"
+                        "mime-db": "~1.27.0"
                     }
                 },
                 "minimatch": {
@@ -2305,7 +2305,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -2333,17 +2333,17 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
+                        "detect-libc": "^1.0.2",
                         "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
+                        "mkdirp": "^0.5.1",
+                        "nopt": "^4.0.1",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
                         "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^2.2.1",
+                        "tar-pack": "^3.4.0"
                     }
                 },
                 "nopt": {
@@ -2352,8 +2352,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npmlog": {
@@ -2362,10 +2362,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -2390,7 +2390,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -2411,8 +2411,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -2449,10 +2449,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "~0.4.0",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2468,13 +2468,13 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "request": {
@@ -2483,28 +2483,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "rimraf": {
@@ -2512,7 +2512,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -2543,7 +2543,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "2.x.x"
                     }
                 },
                 "sshpk": {
@@ -2552,15 +2552,15 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
+                        "asn1": "~0.2.3",
+                        "assert-plus": "^1.0.0",
+                        "bcrypt-pbkdf": "^1.0.0",
+                        "dashdash": "^1.12.0",
+                        "ecc-jsbn": "~0.1.1",
+                        "getpass": "^0.1.1",
+                        "jodid25519": "^1.0.0",
+                        "jsbn": "~0.1.0",
+                        "tweetnacl": "~0.14.0"
                     },
                     "dependencies": {
                         "assert-plus": {
@@ -2576,9 +2576,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -2586,7 +2586,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "stringstream": {
@@ -2600,7 +2600,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2614,9 +2614,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
+                        "block-stream": "*",
+                        "fstream": "^1.0.2",
+                        "inherits": "2"
                     }
                 },
                 "tar-pack": {
@@ -2625,14 +2625,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "debug": "^2.2.0",
+                        "fstream": "^1.0.10",
+                        "fstream-ignore": "^1.0.5",
+                        "once": "^1.3.3",
+                        "readable-stream": "^2.1.4",
+                        "rimraf": "^2.5.1",
+                        "tar": "^2.2.1",
+                        "uid-number": "^0.0.6"
                     }
                 },
                 "tough-cookie": {
@@ -2641,7 +2641,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -2650,7 +2650,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "tweetnacl": {
@@ -2691,7 +2691,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -2707,10 +2707,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "function-bind": {
@@ -2731,7 +2731,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -2752,7 +2752,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2769,12 +2769,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -2783,8 +2783,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -2793,7 +2793,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -2808,7 +2808,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2819,8 +2819,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -2829,7 +2829,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2840,16 +2840,16 @@
             "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "7.1.2",
-                "glob-parent": "3.1.0",
-                "is-negated-glob": "1.0.0",
-                "ordered-read-streams": "1.0.1",
-                "pumpify": "1.4.0",
-                "readable-stream": "2.3.5",
-                "remove-trailing-separator": "1.1.0",
-                "to-absolute-glob": "2.0.2",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "glob-watcher": {
@@ -2858,10 +2858,10 @@
             "integrity": "sha512-fK92r2COMC199WCyGUblrZKhjra3cyVMDiypDdqg1vsSDmexnbYivK1kNR4QItiNXLKmGlqan469ks67RtNa2g==",
             "dev": true,
             "requires": {
-                "async-done": "1.2.4",
-                "chokidar": "2.0.3",
-                "just-debounce": "1.0.0",
-                "object.defaults": "1.1.0"
+                "async-done": "^1.2.0",
+                "chokidar": "^2.0.0",
+                "just-debounce": "^1.0.0",
+                "object.defaults": "^1.1.0"
             }
         },
         "global-modules": {
@@ -2870,9 +2870,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-prefix": {
@@ -2881,11 +2881,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.0"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -2894,11 +2894,11 @@
             "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "glob": "7.1.2",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "glogg": {
@@ -2907,7 +2907,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -2927,10 +2927,10 @@
             "integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
             "dev": true,
             "requires": {
-                "glob-watcher": "5.0.1",
-                "gulp-cli": "2.0.1",
-                "undertaker": "1.2.0",
-                "vinyl-fs": "3.0.2"
+                "glob-watcher": "^5.0.0",
+                "gulp-cli": "^2.0.0",
+                "undertaker": "^1.0.0",
+                "vinyl-fs": "^3.0.0"
             },
             "dependencies": {
                 "gulp-cli": {
@@ -2939,24 +2939,24 @@
                     "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "archy": "1.0.0",
-                        "array-sort": "1.0.0",
-                        "color-support": "1.1.3",
-                        "concat-stream": "1.6.2",
-                        "copy-props": "2.0.1",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "interpret": "1.1.0",
-                        "isobject": "3.0.1",
-                        "liftoff": "2.5.0",
-                        "matchdep": "2.0.0",
-                        "mute-stdout": "1.0.0",
-                        "pretty-hrtime": "1.0.3",
-                        "replace-homedir": "1.0.0",
-                        "semver-greatest-satisfied-range": "1.1.0",
-                        "v8flags": "3.0.2",
-                        "yargs": "7.1.0"
+                        "ansi-colors": "^1.0.1",
+                        "archy": "^1.0.0",
+                        "array-sort": "^1.0.0",
+                        "color-support": "^1.1.3",
+                        "concat-stream": "^1.6.0",
+                        "copy-props": "^2.0.1",
+                        "fancy-log": "^1.3.2",
+                        "gulplog": "^1.0.0",
+                        "interpret": "^1.1.0",
+                        "isobject": "^3.0.1",
+                        "liftoff": "^2.5.0",
+                        "matchdep": "^2.0.0",
+                        "mute-stdout": "^1.0.0",
+                        "pretty-hrtime": "^1.0.0",
+                        "replace-homedir": "^1.0.0",
+                        "semver-greatest-satisfied-range": "^1.1.0",
+                        "v8flags": "^3.0.1",
+                        "yargs": "^7.1.0"
                     }
                 }
             }
@@ -2967,9 +2967,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-color": {
@@ -2984,9 +2984,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -2995,8 +2995,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "clone": {
@@ -3023,10 +3023,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3041,8 +3041,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -3051,8 +3051,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -3063,11 +3063,11 @@
             "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "~3.3.4",
+                "node.extend": "~1.1.2",
+                "request": "~2.79.0",
+                "through2": "~2.0.3",
+                "vinyl": "~2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -3078,30 +3078,30 @@
                 },
                 "request": {
                     "version": "2.79.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                    "resolved": "http://registry.npmjs.org/request/-/request-2.79.0.tgz",
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.7.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.18",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.2.1"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "vinyl": {
@@ -3110,13 +3110,13 @@
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^1.0.0",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "is-stream": "^1.1.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -3127,11 +3127,11 @@
             "integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.85.0",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "event-stream": "^3.3.4",
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             }
         },
         "gulp-sourcemaps": {
@@ -3140,17 +3140,17 @@
             "integrity": "sha1-y7IAhFCxvM5s0jv5gze+dRv24wo=",
             "dev": true,
             "requires": {
-                "@gulp-sourcemaps/identity-map": "1.0.1",
-                "@gulp-sourcemaps/map-sources": "1.0.0",
-                "acorn": "5.5.3",
-                "convert-source-map": "1.5.1",
-                "css": "2.2.1",
-                "debug-fabulous": "1.1.0",
-                "detect-newline": "2.1.0",
-                "graceful-fs": "4.1.11",
-                "source-map": "0.6.1",
-                "strip-bom-string": "1.0.0",
-                "through2": "2.0.3"
+                "@gulp-sourcemaps/identity-map": "1.X",
+                "@gulp-sourcemaps/map-sources": "1.X",
+                "acorn": "5.X",
+                "convert-source-map": "1.X",
+                "css": "2.X",
+                "debug-fabulous": "1.X",
+                "detect-newline": "2.X",
+                "graceful-fs": "4.X",
+                "source-map": "~0.6.0",
+                "strip-bom-string": "1.X",
+                "through2": "2.X"
             },
             "dependencies": {
                 "source-map": {
@@ -3167,10 +3167,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3179,7 +3179,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3194,9 +3194,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3217,7 +3217,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3226,7 +3226,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3235,7 +3235,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3244,11 +3244,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3257,14 +3257,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3273,10 +3273,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3285,8 +3285,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3297,11 +3297,11 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -3316,7 +3316,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3337,7 +3337,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "micromatch": {
@@ -3346,19 +3346,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3367,8 +3367,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -3389,7 +3389,7 @@
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl": {
@@ -3398,8 +3398,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -3409,23 +3409,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -3436,9 +3436,9 @@
             "integrity": "sha1-cq02j0JEXyqs+v0vd/oZFm7eeVg=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "map-stream": "0.1.0",
-                "through": "2.3.8"
+                "gulp-util": "~3.0.7",
+                "map-stream": "~0.1.0",
+                "through": "~2.3.8"
             }
         },
         "gulp-typescript": {
@@ -3447,10 +3447,10 @@
             "integrity": "sha512-bZosNvbUGzFA4bjjWoUPyjU5vfgJSzlYKkU0Jutbsrj+td8yvtqxethhqfzB9MwyamaUODIuidj5gIytZ523Bw==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "source-map": "0.5.7",
-                "through2": "2.0.3",
-                "vinyl-fs": "2.4.4"
+                "gulp-util": "~3.0.7",
+                "source-map": "~0.5.3",
+                "through2": "~2.0.1",
+                "vinyl-fs": "~2.4.3"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3459,7 +3459,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3474,9 +3474,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3497,7 +3497,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3506,7 +3506,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3515,7 +3515,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3524,11 +3524,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3537,14 +3537,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3553,10 +3553,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3565,8 +3565,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3577,11 +3577,11 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 },
                 "is-extglob": {
@@ -3596,7 +3596,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3617,7 +3617,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "micromatch": {
@@ -3626,19 +3626,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -3647,8 +3647,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "replace-ext": {
@@ -3669,7 +3669,7 @@
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl": {
@@ -3678,8 +3678,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 },
@@ -3689,23 +3689,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     }
                 }
             }
@@ -3716,11 +3716,11 @@
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -3729,24 +3729,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "clone": {
@@ -3779,8 +3779,8 @@
                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -3792,13 +3792,13 @@
             "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "event-stream": "^3.3.1",
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^2.0.0",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -3807,7 +3807,7 @@
                     "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0"
+                        "arr-flatten": "^1.0.1"
                     }
                 },
                 "array-unique": {
@@ -3822,9 +3822,9 @@
                     "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "1.8.2",
-                        "preserve": "0.2.0",
-                        "repeat-element": "1.1.2"
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
                     }
                 },
                 "clone": {
@@ -3845,7 +3845,7 @@
                     "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
                     "dev": true,
                     "requires": {
-                        "is-posix-bracket": "0.1.1"
+                        "is-posix-bracket": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3854,7 +3854,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -3863,7 +3863,7 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3872,11 +3872,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "glob-stream": {
@@ -3885,14 +3885,14 @@
                     "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
                     "dev": true,
                     "requires": {
-                        "extend": "3.0.1",
-                        "glob": "5.0.15",
-                        "glob-parent": "3.1.0",
-                        "micromatch": "2.3.11",
-                        "ordered-read-streams": "0.3.0",
-                        "through2": "0.6.5",
-                        "to-absolute-glob": "0.1.1",
-                        "unique-stream": "2.2.1"
+                        "extend": "^3.0.0",
+                        "glob": "^5.0.3",
+                        "glob-parent": "^3.0.0",
+                        "micromatch": "^2.3.7",
+                        "ordered-read-streams": "^0.3.0",
+                        "through2": "^0.6.0",
+                        "to-absolute-glob": "^0.1.1",
+                        "unique-stream": "^2.0.2"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3901,10 +3901,10 @@
                             "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
                                 "isarray": "0.0.1",
-                                "string_decoder": "0.10.31"
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "through2": {
@@ -3913,8 +3913,8 @@
                             "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "1.0.34",
-                                "xtend": "4.0.1"
+                                "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                                "xtend": ">=4.0.0 <4.1.0-0"
                             }
                         }
                     }
@@ -3925,11 +3925,11 @@
                     "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
                     "dev": true,
                     "requires": {
-                        "convert-source-map": "1.5.1",
-                        "graceful-fs": "4.1.11",
-                        "strip-bom": "2.0.0",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "convert-source-map": "^1.1.1",
+                        "graceful-fs": "^4.1.2",
+                        "strip-bom": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "vinyl": "^1.0.0"
                     },
                     "dependencies": {
                         "vinyl": {
@@ -3938,8 +3938,8 @@
                             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                             "dev": true,
                             "requires": {
-                                "clone": "1.0.4",
-                                "clone-stats": "0.0.1",
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
                                 "replace-ext": "0.0.1"
                             }
                         }
@@ -3957,7 +3957,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 },
                 "is-valid-glob": {
@@ -3978,7 +3978,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "micromatch": {
@@ -3987,19 +3987,19 @@
                     "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "2.0.0",
-                        "array-unique": "0.2.1",
-                        "braces": "1.8.5",
-                        "expand-brackets": "0.1.5",
-                        "extglob": "0.3.2",
-                        "filename-regex": "2.0.1",
-                        "is-extglob": "1.0.0",
-                        "is-glob": "2.0.1",
-                        "kind-of": "3.2.2",
-                        "normalize-path": "2.1.1",
-                        "object.omit": "2.0.1",
-                        "parse-glob": "3.0.4",
-                        "regex-cache": "0.4.4"
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
                     }
                 },
                 "ordered-read-streams": {
@@ -4008,8 +4008,8 @@
                     "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
                     "dev": true,
                     "requires": {
-                        "is-stream": "1.1.0",
-                        "readable-stream": "2.3.5"
+                        "is-stream": "^1.0.1",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "queue": {
@@ -4018,7 +4018,7 @@
                     "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "replace-ext": {
@@ -4039,7 +4039,7 @@
                     "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1"
+                        "extend-shallow": "^2.0.1"
                     }
                 },
                 "vinyl-fs": {
@@ -4048,23 +4048,23 @@
                     "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
                     "dev": true,
                     "requires": {
-                        "duplexify": "3.5.4",
-                        "glob-stream": "5.3.5",
-                        "graceful-fs": "4.1.11",
+                        "duplexify": "^3.2.0",
+                        "glob-stream": "^5.3.2",
+                        "graceful-fs": "^4.0.0",
                         "gulp-sourcemaps": "1.6.0",
-                        "is-valid-glob": "0.3.0",
-                        "lazystream": "1.0.0",
-                        "lodash.isequal": "4.5.0",
-                        "merge-stream": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "object-assign": "4.1.1",
-                        "readable-stream": "2.3.5",
-                        "strip-bom": "2.0.0",
-                        "strip-bom-stream": "1.0.0",
-                        "through2": "2.0.3",
-                        "through2-filter": "2.0.0",
-                        "vali-date": "1.0.0",
-                        "vinyl": "1.2.0"
+                        "is-valid-glob": "^0.3.0",
+                        "lazystream": "^1.0.0",
+                        "lodash.isequal": "^4.0.0",
+                        "merge-stream": "^1.0.0",
+                        "mkdirp": "^0.5.0",
+                        "object-assign": "^4.0.0",
+                        "readable-stream": "^2.0.4",
+                        "strip-bom": "^2.0.0",
+                        "strip-bom-stream": "^1.0.0",
+                        "through2": "^2.0.0",
+                        "through2-filter": "^2.0.0",
+                        "vali-date": "^1.0.0",
+                        "vinyl": "^1.0.0"
                     },
                     "dependencies": {
                         "vinyl": {
@@ -4073,8 +4073,8 @@
                             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                             "dev": true,
                             "requires": {
-                                "clone": "1.0.4",
-                                "clone-stats": "0.0.1",
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
                                 "replace-ext": "0.0.1"
                             }
                         }
@@ -4088,7 +4088,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "handlebars": {
@@ -4096,10 +4096,10 @@
             "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "source-map": {
@@ -4107,7 +4107,7 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -4124,10 +4124,10 @@
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.15.1",
-                "is-my-json-valid": "2.17.2",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "has-ansi": {
@@ -4136,7 +4136,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -4151,7 +4151,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -4166,9 +4166,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -4177,8 +4177,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4187,7 +4187,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4198,10 +4198,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -4222,7 +4222,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -4237,12 +4237,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.5.1",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.5"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-signature": {
@@ -4251,9 +4251,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -4262,8 +4262,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -4302,8 +4302,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -4312,7 +4312,7 @@
             "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             }
         },
         "is-arrayish": {
@@ -4327,7 +4327,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -4341,7 +4341,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -4350,7 +4350,7 @@
             "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
             }
         },
         "is-descriptor": {
@@ -4359,9 +4359,9 @@
             "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
             }
         },
         "is-dotfile": {
@@ -4376,7 +4376,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -4397,7 +4397,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -4406,7 +4406,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-my-ip-valid": {
@@ -4421,11 +4421,11 @@
             "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-negated-glob": {
@@ -4440,7 +4440,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4449,7 +4449,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4466,7 +4466,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -4489,7 +4489,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -4498,7 +4498,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-object": {
@@ -4507,7 +4507,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-posix-bracket": {
@@ -4540,7 +4540,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-stream": {
@@ -4561,7 +4561,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-utf8": {
@@ -4631,7 +4631,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -4645,7 +4645,7 @@
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -4698,8 +4698,8 @@
             "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
             "dev": true,
             "requires": {
-                "default-resolution": "2.0.0",
-                "es6-weak-map": "2.0.2"
+                "default-resolution": "^2.0.0",
+                "es6-weak-map": "^2.0.1"
             }
         },
         "lazy-cache": {
@@ -4714,7 +4714,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -4723,7 +4723,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "lead": {
@@ -4732,7 +4732,7 @@
             "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
             "dev": true,
             "requires": {
-                "flush-write-stream": "1.0.3"
+                "flush-write-stream": "^1.0.2"
             }
         },
         "liftoff": {
@@ -4741,14 +4741,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.6.0"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "linkify-it": {
@@ -4757,7 +4757,7 @@
             "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
             "dev": true,
             "requires": {
-                "uc.micro": "1.0.5"
+                "uc.micro": "^1.0.1"
             }
         },
         "load-json-file": {
@@ -4766,11 +4766,11 @@
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "lodash": {
@@ -4839,7 +4839,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -4866,9 +4866,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.restparam": {
@@ -4883,15 +4883,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -4900,8 +4900,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "longest": {
@@ -4915,8 +4915,8 @@
             "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "lru-queue": {
@@ -4925,7 +4925,7 @@
             "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.42"
+                "es5-ext": "~0.10.2"
             }
         },
         "make-iterator": {
@@ -4934,7 +4934,7 @@
             "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -4943,7 +4943,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4966,7 +4966,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-it": {
@@ -4975,11 +4975,11 @@
             "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "entities": "1.1.1",
-                "linkify-it": "2.0.3",
-                "mdurl": "1.0.1",
-                "uc.micro": "1.0.5"
+                "argparse": "^1.0.7",
+                "entities": "~1.1.1",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
             }
         },
         "matchdep": {
@@ -4988,9 +4988,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "2.0.0",
-                "micromatch": "3.1.10",
-                "resolve": "1.6.0",
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
                 "stack-trace": "0.0.10"
             }
         },
@@ -5006,14 +5006,14 @@
             "integrity": "sha512-sprBu6nwxBWBvBOh5v2jcsGqiGLlL2xr2dLub3vR8dnE8YB17omwtm/0NSHl8jjNbcsJd5GMWJAnTSVe/O0Wfg==",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.42",
-                "es6-weak-map": "2.0.2",
-                "event-emitter": "0.3.5",
-                "is-promise": "2.1.0",
-                "lru-queue": "0.1.0",
-                "next-tick": "1.0.0",
-                "timers-ext": "0.1.5"
+                "d": "1",
+                "es5-ext": "^0.10.30",
+                "es6-weak-map": "^2.0.2",
+                "event-emitter": "^0.3.5",
+                "is-promise": "^2.1",
+                "lru-queue": "0.1",
+                "next-tick": "1",
+                "timers-ext": "^0.1.2"
             }
         },
         "merge-stream": {
@@ -5022,7 +5022,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -5031,19 +5031,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.1",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "mime": {
@@ -5064,7 +5064,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "minimatch": {
@@ -5073,7 +5073,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -5088,8 +5088,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5098,7 +5098,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5159,7 +5159,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -5176,10 +5176,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "multipipe": {
@@ -5216,18 +5216,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "next-tick": {
@@ -5248,7 +5248,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-package-data": {
@@ -5257,10 +5257,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -5269,7 +5269,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "now-and-later": {
@@ -5278,7 +5278,7 @@
             "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.3.2"
             }
         },
         "nth-check": {
@@ -5287,7 +5287,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "number-is-nan": {
@@ -5314,9 +5314,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -5325,7 +5325,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -5334,7 +5334,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -5343,7 +5343,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -5352,9 +5352,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5371,7 +5371,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5388,7 +5388,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.assign": {
@@ -5397,10 +5397,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.11"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -5409,10 +5409,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "object.map": {
@@ -5421,8 +5421,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "object.omit": {
@@ -5431,8 +5431,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-own": {
@@ -5441,7 +5441,7 @@
                     "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -5452,7 +5452,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "object.reduce": {
@@ -5461,8 +5461,8 @@
             "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.0"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             }
         },
         "once": {
@@ -5471,7 +5471,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "optimist": {
@@ -5479,8 +5479,8 @@
             "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -5496,7 +5496,7 @@
             "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.1"
             }
         },
         "os-homedir": {
@@ -5511,7 +5511,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -5526,8 +5526,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-map": {
@@ -5542,9 +5542,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -5553,10 +5553,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -5571,7 +5571,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -5582,7 +5582,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -5597,7 +5597,7 @@
             "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.1.0"
             }
         },
         "parse5": {
@@ -5606,7 +5606,7 @@
             "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
             "dev": true,
             "requires": {
-                "@types/node": "7.0.58"
+                "@types/node": "*"
             }
         },
         "pascalcase": {
@@ -5627,7 +5627,7 @@
             "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
             "dev": true,
             "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
             }
         },
         "path-is-absolute": {
@@ -5654,7 +5654,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -5669,9 +5669,9 @@
             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
             }
         },
         "pause-stream": {
@@ -5680,7 +5680,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -5713,7 +5713,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "plugin-error": {
@@ -5722,11 +5722,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -5735,8 +5735,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -5757,7 +5757,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -5810,8 +5810,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -5820,9 +5820,9 @@
             "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.4",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.5.3",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -5849,7 +5849,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -5858,8 +5858,8 @@
             "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -5868,7 +5868,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -5879,7 +5879,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-pkg": {
@@ -5888,9 +5888,9 @@
             "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
             "dev": true,
             "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
             }
         },
         "read-pkg-up": {
@@ -5899,8 +5899,8 @@
             "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
             "dev": true,
             "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
             }
         },
         "readable-stream": {
@@ -5909,13 +5909,13 @@
             "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -5932,10 +5932,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.5",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -5944,7 +5944,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.6.0"
+                "resolve": "^1.1.6"
             }
         },
         "regex-cache": {
@@ -5953,7 +5953,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -5962,8 +5962,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "remove-bom-buffer": {
@@ -5972,8 +5972,8 @@
             "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
-                "is-utf8": "0.2.1"
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
             }
         },
         "remove-bom-stream": {
@@ -5982,9 +5982,9 @@
             "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
             "dev": true,
             "requires": {
-                "remove-bom-buffer": "3.0.0",
-                "safe-buffer": "5.1.1",
-                "through2": "2.0.3"
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
@@ -6016,9 +6016,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "is-absolute": "1.0.0",
-                "remove-trailing-separator": "1.1.0"
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
             }
         },
         "request": {
@@ -6027,28 +6027,28 @@
             "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "hawk": "~6.0.2",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "stringstream": "~0.0.5",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6069,7 +6069,7 @@
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "caseless": {
@@ -6084,7 +6084,7 @@
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "dev": true,
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -6093,7 +6093,7 @@
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "dev": true,
                             "requires": {
-                                "hoek": "4.2.1"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -6115,8 +6115,8 @@
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "hawk": {
@@ -6125,10 +6125,10 @@
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "dev": true,
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.1",
-                        "sntp": "2.1.0"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -6160,7 +6160,7 @@
                     "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "tunnel-agent": {
@@ -6198,7 +6198,7 @@
             "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -6207,8 +6207,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-options": {
@@ -6217,7 +6217,7 @@
             "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
             "dev": true,
             "requires": {
-                "value-or-function": "3.0.0"
+                "value-or-function": "^3.0.0"
             }
         },
         "resolve-url": {
@@ -6238,7 +6238,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -6247,7 +6247,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "safe-buffer": {
@@ -6262,7 +6262,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "semver": {
@@ -6277,7 +6277,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "1.5.0"
+                "sver-compat": "^1.5.0"
             }
         },
         "set-blocking": {
@@ -6298,10 +6298,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -6310,7 +6310,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -6321,14 +6321,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6337,7 +6337,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -6346,7 +6346,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6355,7 +6355,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6364,7 +6364,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6375,7 +6375,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6384,7 +6384,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6395,9 +6395,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -6414,9 +6414,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -6425,7 +6425,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 }
             }
@@ -6436,7 +6436,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -6445,7 +6445,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6456,7 +6456,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "source-map": {
@@ -6470,11 +6470,11 @@
             "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
             "dev": true,
             "requires": {
-                "atob": "2.1.0",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -6483,7 +6483,7 @@
             "integrity": "sha512-PETSPG6BjY1AHs2t64vS2aqAgu6dMIMXJULWFBGbh2Gr8nVLbCFDo6i/RMMvviIQ2h1Z8+5gQhVKSn2je9nmdg==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.0"
             },
             "dependencies": {
                 "source-map": {
@@ -6512,8 +6512,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -6528,8 +6528,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -6544,7 +6544,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -6553,7 +6553,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "sprintf-js": {
@@ -6564,22 +6564,23 @@
         },
         "sqlops": {
             "version": "github:anthonydresser/sqlops-extension-sqlops#dac501bbaa03a25239c060c6371dfdcf06707599",
+            "from": "github:anthonydresser/sqlops-extension-sqlops",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.4",
-                "url-parse": "1.3.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src": "^0.4.3",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "sshpk": {
@@ -6588,14 +6589,14 @@
             "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -6624,8 +6625,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -6634,7 +6635,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -6643,7 +6644,7 @@
                     "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6652,7 +6653,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6663,7 +6664,7 @@
                     "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6672,7 +6673,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6683,9 +6684,9 @@
                     "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "0.1.6",
-                        "is-data-descriptor": "0.1.4",
-                        "kind-of": "5.1.0"
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
                     }
                 },
                 "kind-of": {
@@ -6702,7 +6703,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-exhaust": {
@@ -6723,7 +6724,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -6738,9 +6739,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -6749,7 +6750,7 @@
             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -6764,7 +6765,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -6773,7 +6774,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -6782,8 +6783,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "strip-bom-string": {
@@ -6804,8 +6805,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "tar": {
@@ -6814,9 +6815,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -6831,8 +6832,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.5",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -6841,8 +6842,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "time-stamp": {
@@ -6857,8 +6858,8 @@
             "integrity": "sha512-tsEStd7kmACHENhsUPaxb8Jf8/+GZZxyNFQbZD07HQOyooOa6At1rQqjffgvg7n+dxscQa9cjjMdWhJtsP2sxg==",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.42",
-                "next-tick": "1.0.0"
+                "es5-ext": "~0.10.14",
+                "next-tick": "1"
             }
         },
         "tmp": {
@@ -6867,7 +6868,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-absolute-glob": {
@@ -6876,8 +6877,8 @@
             "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "is-negated-glob": "1.0.0"
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
             }
         },
         "to-object-path": {
@@ -6886,7 +6887,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -6895,7 +6896,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -6906,10 +6907,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -6918,8 +6919,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "to-through": {
@@ -6928,7 +6929,7 @@
             "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
@@ -6937,7 +6938,7 @@
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tslint": {
@@ -6946,13 +6947,13 @@
             "integrity": "sha1-2hZcqT2P3CwIa1EWXuG6y0jJjqU=",
             "dev": true,
             "requires": {
-                "colors": "1.2.1",
-                "diff": "2.2.3",
-                "findup-sync": "0.3.0",
-                "glob": "7.1.2",
-                "optimist": "0.6.1",
-                "resolve": "1.6.0",
-                "underscore.string": "3.3.4"
+                "colors": "^1.1.2",
+                "diff": "^2.2.1",
+                "findup-sync": "~0.3.0",
+                "glob": "^7.0.3",
+                "optimist": "~0.6.0",
+                "resolve": "^1.1.7",
+                "underscore.string": "^3.3.4"
             },
             "dependencies": {
                 "diff": {
@@ -6967,7 +6968,7 @@
                     "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
                     "dev": true,
                     "requires": {
-                        "glob": "5.0.15"
+                        "glob": "~5.0.0"
                     },
                     "dependencies": {
                         "glob": {
@@ -6976,11 +6977,11 @@
                             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                             "dev": true,
                             "requires": {
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.4",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         }
                     }
@@ -7040,9 +7041,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "optional": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7057,8 +7058,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -7074,9 +7075,9 @@
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -7106,8 +7107,8 @@
             "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
             }
         },
         "undertaker": {
@@ -7116,15 +7117,15 @@
             "integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "arr-map": "2.0.2",
-                "bach": "1.2.0",
-                "collection-map": "1.0.0",
-                "es6-weak-map": "2.0.2",
-                "last-run": "1.1.1",
-                "object.defaults": "1.1.0",
-                "object.reduce": "1.0.1",
-                "undertaker-registry": "1.0.1"
+                "arr-flatten": "^1.0.1",
+                "arr-map": "^2.0.0",
+                "bach": "^1.0.0",
+                "collection-map": "^1.0.0",
+                "es6-weak-map": "^2.0.1",
+                "last-run": "^1.1.0",
+                "object.defaults": "^1.0.0",
+                "object.reduce": "^1.0.0",
+                "undertaker-registry": "^1.0.0"
             }
         },
         "undertaker-registry": {
@@ -7139,10 +7140,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -7151,7 +7152,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -7160,10 +7161,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -7174,8 +7175,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "universalify": {
@@ -7189,8 +7190,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -7199,9 +7200,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -7247,8 +7248,8 @@
             "integrity": "sha512-zPvPA3T7P6M+0iNsgX+iAcAz4GshKrowtQBHHc/28tVsBc8jK7VRCNX+2GEcoE6zDB6XqXhcyiUWPVZY6C70Cg==",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "~1.0.0"
             }
         },
         "use": {
@@ -7257,7 +7258,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "util-deprecate": {
@@ -7278,7 +7279,7 @@
             "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "vali-date": {
@@ -7293,8 +7294,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "value-or-function": {
@@ -7309,9 +7310,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -7328,12 +7329,12 @@
             "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
             "dev": true,
             "requires": {
-                "clone": "2.1.2",
-                "clone-buffer": "1.0.0",
-                "clone-stats": "1.0.0",
-                "cloneable-readable": "1.1.2",
-                "remove-trailing-separator": "1.1.0",
-                "replace-ext": "1.0.0"
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
             }
         },
         "vinyl-fs": {
@@ -7342,23 +7343,23 @@
             "integrity": "sha512-AUSFda1OukBwuLPBTbyuO4IRWgfXmqC4UTW0f8xrCa8Hkv9oyIU+NSqBlgfOLZRoUt7cHdo75hKQghCywpIyIw==",
             "dev": true,
             "requires": {
-                "fs-mkdirp-stream": "1.0.0",
-                "glob-stream": "6.1.0",
-                "graceful-fs": "4.1.11",
-                "is-valid-glob": "1.0.0",
-                "lazystream": "1.0.0",
-                "lead": "1.0.0",
-                "object.assign": "4.1.0",
-                "pumpify": "1.4.0",
-                "readable-stream": "2.3.5",
-                "remove-bom-buffer": "3.0.0",
-                "remove-bom-stream": "1.2.0",
-                "resolve-options": "1.1.0",
-                "through2": "2.0.3",
-                "to-through": "2.0.0",
-                "value-or-function": "3.0.0",
-                "vinyl": "2.1.0",
-                "vinyl-sourcemap": "1.1.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             }
         },
         "vinyl-source-stream": {
@@ -7367,8 +7368,8 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -7389,8 +7390,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -7401,13 +7402,13 @@
             "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
             "dev": true,
             "requires": {
-                "append-buffer": "1.0.2",
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "normalize-path": "2.1.1",
-                "now-and-later": "2.0.0",
-                "remove-bom-buffer": "3.0.0",
-                "vinyl": "2.1.0"
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
             }
         },
         "vsce": {
@@ -7416,23 +7417,23 @@
             "integrity": "sha512-LiQjHdoaXOHKdk/PRN5OWWeEm/4w7tnFLf8EM+pzvlz/8uk7uJiqtMjVYAYawnU7c8KbMSz9nE9M6nCTV4ZSQA==",
             "dev": true,
             "requires": {
-                "cheerio": "1.0.0-rc.2",
-                "commander": "2.15.1",
-                "denodeify": "1.2.1",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "markdown-it": "8.4.1",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "osenv": "0.1.5",
-                "parse-semver": "1.1.1",
-                "read": "1.0.7",
-                "semver": "5.5.0",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^2.8.1",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "lodash": "^4.15.0",
+                "markdown-it": "^8.3.1",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
                 "tmp": "0.0.29",
-                "url-join": "1.1.0",
-                "vso-node-api": "6.5.0",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "url-join": "^1.1.0",
+                "vso-node-api": "^6.1.2-preview",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
             }
         },
         "vscode": {
@@ -7441,20 +7442,20 @@
             "integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src-vscode": "0.5.0",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.7",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.4",
-                "url-parse": "1.4.3",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.0",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -7475,11 +7476,11 @@
                     "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
                     "dev": true,
                     "requires": {
-                        "event-stream": "3.3.4",
-                        "streamifier": "0.1.1",
-                        "tar": "2.2.1",
-                        "through2": "2.0.3",
-                        "vinyl": "1.2.0"
+                        "event-stream": "~3.3.4",
+                        "streamifier": "~0.1.1",
+                        "tar": "^2.2.1",
+                        "through2": "~2.0.3",
+                        "vinyl": "^1.2.0"
                     }
                 },
                 "querystringify": {
@@ -7500,8 +7501,8 @@
                     "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
                     "dev": true,
                     "requires": {
-                        "querystringify": "2.0.0",
-                        "requires-port": "1.0.0"
+                        "querystringify": "^2.0.0",
+                        "requires-port": "^1.0.0"
                     }
                 },
                 "vinyl": {
@@ -7510,8 +7511,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -7529,7 +7530,7 @@
             "dev": true,
             "requires": {
                 "tunnel": "0.0.4",
-                "typed-rest-client": "0.12.0",
+                "typed-rest-client": "^0.12.0",
                 "underscore": "1.8.3"
             }
         },
@@ -7539,7 +7540,7 @@
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -7565,8 +7566,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -7599,19 +7600,19 @@
             "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "5.0.0"
+                "camelcase": "^3.0.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.2",
+                "which-module": "^1.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^5.0.0"
             }
         },
         "yargs-parser": {
@@ -7620,7 +7621,7 @@
             "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
             }
         },
         "yauzl": {
@@ -7629,8 +7630,8 @@
             "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -7639,7 +7640,7 @@
             "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1393,10 +1393,6 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
 
-deep-extend@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
-
 deep-is@~0.1.2, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -5493,16 +5489,7 @@ raw-body@2.3.2:
     iconv-lite "0.4.19"
     unpipe "1.0.0"
 
-rc@^1.1.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.2.tgz#d8ce9cb57e8d64d9c7badd9876c7c34cbe3c7077"
-  dependencies:
-    deep-extend "~0.4.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
-rc@^1.1.6:
+rc@1.2.8, rc@^1.1.2, rc@^1.1.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   dependencies:


### PR DESCRIPTION
Update a few dependencies, specifically:
- The version of `rc` that our dependencies use
- `service-downloader`
- `sqlops-extension-sqlops` (this appears to be coming from master anyway but this updates `package-lock.json`)