### PR TITLE
Fix broken 'Clear Token Cache' command

### DIFF
--- a/extensions/account-provider-azure/src/account-provider/azureAccountProviderService.ts
+++ b/extensions/account-provider-azure/src/account-provider/azureAccountProviderService.ts
@@ -20,7 +20,7 @@ let localize = nls.loadMessageBundle();
 
 export class AzureAccountProviderService implements vscode.Disposable {
 	// CONSTANTS ///////////////////////////////////////////////////////////////
-	private static CommandClearTokenCache = 'accounts.azure.clearTokenCache';
+	private static CommandClearTokenCache = 'accounts.clearTokenCache';
 	private static ConfigurationSection = 'accounts.azure';
 	private static CredentialNamespace = 'azureAccountProviderCredentials';
 


### PR DESCRIPTION
The Azure account provider "Clear token cache" command wasn't working because when the command got renamed from "extension.clearTokenCache" it got called "accounts.clearTokenCache" in some places and "accounts.azure.clearTokenCache" in others