### PR TITLE
Fix chart error that caused query editor to close

### DIFF
--- a/src/sql/parts/query/editor/charting/chartView.ts
+++ b/src/sql/parts/query/editor/charting/chartView.ts
@@ -315,7 +315,7 @@ export class ChartView implements IPanelView {
 				});
 				setFunc = (val: string) => {
 					if (!isUndefinedOrNull(val)) {
-						input.value = val;
+						numberInput.value = val;
 					}
 				};
 				this.optionDisposables.push(attachInputBoxStyler(numberInput, this._themeService));
@@ -330,7 +330,7 @@ export class ChartView implements IPanelView {
 		this._state = val;
 		if (this.state.options) {
 			for (let key in this.state.options) {
-				if (this.state.options.hasOwnProperty(key)) {
+				if (this.state.options.hasOwnProperty(key) && this.optionMap[key]) {
 					this.options[key] = this.state.options[key];
 					this.optionMap[key].set(this.state.options[key]);
 				}


### PR DESCRIPTION
There were 2 errors in the chart state restore logic that caused query editors to fail to restore successfully if the user had opened chart viewer and switched the chart type.

This is a fix for part of the error in #2635 