### PR TITLE
use a more specific class to control the width

### DIFF
--- a/src/sql/parts/query/editor/media/queryActions.css
+++ b/src/sql/parts/query/editor/media/queryActions.css
@@ -1,5 +1,3 @@
-.monaco-select-box {
-	cursor: pointer;
+.databaseListDropdown {
 	min-width: 150px;
-	padding: 2px;
 }


### PR DESCRIPTION
#2660 
Didn't realize my change has a global effect. the fix is to set the min-width of the parent element with a class name that is not likely to impact others.
